### PR TITLE
Speed up finding jumpdests

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -17,17 +17,6 @@ bool is_terminator(uint8_t c) noexcept
 }
 }  // namespace
 
-int code_analysis::find_jumpdest(int offset) const noexcept
-{
-    // TODO: Replace with lower_bound().
-    for (const auto& d : jumpdest_map)
-    {
-        if (d.first == offset)
-            return d.second;
-    }
-    return -1;
-}
-
 evmc_call_kind op2call_kind(uint8_t opcode) noexcept
 {
     switch (opcode)

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -65,7 +65,10 @@ code_analysis analyze(
             beginblock_instr.arg.p.number = static_cast<int>(analysis.blocks.size() - 1);
 
             if (jumpdest)  // Add the jumpdest to the map.
-                analysis.jumpdest_map.emplace_back(static_cast<int>(i), instr_index);
+            {
+                analysis.jumpdest_offsets.emplace_back(static_cast<int16_t>(i));
+                analysis.jumpdest_targets.emplace_back(static_cast<int16_t>(instr_index));
+            }
             else  // Increase instruction count because additional BEGINBLOCK was injected.
                 ++instr_index;
         }

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -152,15 +152,23 @@ struct code_analysis
     /// invalidated when the container grows.
     std::deque<bytes32> args_storage;
 
-    std::vector<std::pair<int, int>> jumpdest_map;
+    /// The offsets of JUMPDESTs in the original code.
+    /// These are values that JUMP/JUMPI receives as an argument.
+    /// The elements are sorted.
+    std::vector<int16_t> jumpdest_offsets;
+
+    /// The indexes of the instructions in the generated instruction table
+    /// matching the elements from jumdest_offsets.
+    /// This is value to which the next instruction pointer must be set in JUMP/JUMPI.
+    std::vector<int16_t> jumpdest_targets;
 };
 
 inline int find_jumpdest(const code_analysis& analysis, int offset) noexcept
 {
-    const auto& m = analysis.jumpdest_map;
-    const auto it = std::lower_bound(std::begin(m), std::end(m), offset,
-        [](std::pair<int, int> p, int v) noexcept { return p.first < v; });
-    return (it != std::end(m) && it->first == offset) ? it->second : -1;
+    const auto begin = std::begin(analysis.jumpdest_offsets);
+    const auto end = std::end(analysis.jumpdest_offsets);
+    const auto it = std::lower_bound(begin, end, offset);
+    return (it != end && *it == offset) ? analysis.jumpdest_targets[it - begin] : -1;
 }
 
 EVMC_EXPORT code_analysis analyze(

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -153,10 +153,18 @@ struct code_analysis
     std::deque<bytes32> args_storage;
 
     std::vector<std::pair<int, int>> jumpdest_map;
-
-    // TODO: Exported for unit tests. Rework unit tests?
-    EVMC_EXPORT int find_jumpdest(int offset) const noexcept;
 };
+
+inline int find_jumpdest(const code_analysis& analysis, int offset) noexcept
+{
+    // TODO: Replace with lower_bound().
+    for (const auto& d : analysis.jumpdest_map)
+    {
+        if (d.first == offset)
+            return d.second;
+    }
+    return -1;
+}
 
 EVMC_EXPORT code_analysis analyze(
     const exec_fn_table& fns, evmc_revision rev, const uint8_t* code, size_t code_size) noexcept;

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -157,13 +157,10 @@ struct code_analysis
 
 inline int find_jumpdest(const code_analysis& analysis, int offset) noexcept
 {
-    // TODO: Replace with lower_bound().
-    for (const auto& d : analysis.jumpdest_map)
-    {
-        if (d.first == offset)
-            return d.second;
-    }
-    return -1;
+    const auto& m = analysis.jumpdest_map;
+    const auto it = std::lower_bound(std::begin(m), std::end(m), offset,
+        [](std::pair<int, int> p, int v) noexcept { return p.first < v; });
+    return (it != std::end(m) && it->first == offset) ? it->second : -1;
 }
 
 EVMC_EXPORT code_analysis analyze(

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -481,7 +481,7 @@ void op_jump(execution_state& state, instr_argument) noexcept
     const auto dst = state.stack.pop();
     auto pc = -1;
     if (std::numeric_limits<int>::max() < dst ||
-        (pc = state.analysis->find_jumpdest(static_cast<int>(dst))) < 0)
+        (pc = find_jumpdest(*state.analysis, static_cast<int>(dst))) < 0)
         return state.exit(EVMC_BAD_JUMP_DESTINATION);
 
     state.next_instr = &state.analysis->instrs[static_cast<size_t>(pc)];

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -90,6 +90,7 @@ TEST(analysis, jump1)
     EXPECT_EQ(analysis.jumpdest_map[0], std::pair(6, 5));
     EXPECT_EQ(find_jumpdest(analysis, 6), 5);
     EXPECT_EQ(find_jumpdest(analysis, 0), -1);
+    EXPECT_EQ(find_jumpdest(analysis, 7), -1);
 }
 
 TEST(analysis, empty)

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -88,8 +88,8 @@ TEST(analysis, jump1)
     ASSERT_EQ(analysis.blocks.size(), 3);
     ASSERT_EQ(analysis.jumpdest_map.size(), 1);
     EXPECT_EQ(analysis.jumpdest_map[0], std::pair(6, 5));
-    EXPECT_EQ(analysis.find_jumpdest(6), 5);
-    EXPECT_EQ(analysis.find_jumpdest(0), -1);
+    EXPECT_EQ(find_jumpdest(analysis, 6), 5);
+    EXPECT_EQ(find_jumpdest(analysis, 0), -1);
 }
 
 TEST(analysis, empty)

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -86,8 +86,10 @@ TEST(analysis, jump1)
     const auto analysis = analyze(fake_fn_table, rev, &code[0], code.size());
 
     ASSERT_EQ(analysis.blocks.size(), 3);
-    ASSERT_EQ(analysis.jumpdest_map.size(), 1);
-    EXPECT_EQ(analysis.jumpdest_map[0], std::pair(6, 5));
+    ASSERT_EQ(analysis.jumpdest_offsets.size(), 1);
+    ASSERT_EQ(analysis.jumpdest_targets.size(), 1);
+    EXPECT_EQ(analysis.jumpdest_offsets[0], 6);
+    EXPECT_EQ(analysis.jumpdest_targets[0], 5);
     EXPECT_EQ(find_jumpdest(analysis, 6), 5);
     EXPECT_EQ(find_jumpdest(analysis, 0), -1);
     EXPECT_EQ(find_jumpdest(analysis, 7), -1);
@@ -109,8 +111,10 @@ TEST(analysis, only_jumpdest)
     auto analysis = evmone::analyze(fake_fn_table, rev, &code[0], code.size());
 
     ASSERT_EQ(analysis.blocks.size(), 1);
-    ASSERT_EQ(analysis.jumpdest_map.size(), 1);
-    EXPECT_EQ(analysis.jumpdest_map[0], std::pair(0, 0));
+    ASSERT_EQ(analysis.jumpdest_offsets.size(), 1);
+    ASSERT_EQ(analysis.jumpdest_targets.size(), 1);
+    EXPECT_EQ(analysis.jumpdest_offsets[0], 0);
+    EXPECT_EQ(analysis.jumpdest_targets[0], 0);
 }
 
 TEST(analysis, jumpi_at_the_end)

--- a/test/utils/dump.cpp
+++ b/test/utils/dump.cpp
@@ -30,14 +30,14 @@ void dump_analysis(const evmone::code_analysis& analysis)
         {
             block = &analysis.blocks[size_t(instr.arg.p.number)];
 
-            auto get_jumpdest_offset = [&analysis](size_t index) noexcept
+            const auto get_jumpdest_offset = [&analysis](size_t index) noexcept
             {
-                for (const auto& d : analysis.jumpdest_map)
+                for (size_t t = 0; t < analysis.jumpdest_targets.size(); ++t)
                 {
-                    if (d.second == static_cast<int>(index))
-                        return d.first;
+                    if (t == index)
+                        return analysis.jumpdest_offsets[t];
                 }
-                return -1;
+                return int16_t{-1};
             };
 
             std::cout << "┌ ";


### PR DESCRIPTION
This replaces the linear search if the jumpdest with binary search. It also applies data-driven approach where the jumpdest "map" is not vector of pairs, but two vectors of offsets and targets. We also shrank the size of elements from `int` to `int16_t`.

There is a small trade-off here. The analysis takes longer because requires 2x more vector resizes. And for contracts with small number of jumpdests (like blake2b_huff which only has 3 of them) the time increase in analysis might hide the gain in execution. But still I believe it's worth the 33% speed increase in blake2b_shifts which has a lot of jumpdests.

```
Comparing bin/evmone-bench-master to bin/evmone-bench
Benchmark                            Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------
sha1_shifts/analysis              +0.0501         +0.0501             5             5             5             5
sha1_shifts/empty                 -0.0379         -0.0379            50            48            50            48
sha1_shifts/1351                  -0.0488         -0.0488           938           893           938           893
sha1_shifts/2737                  -0.0496         -0.0497          1825          1734          1825          1734
sha1_shifts/5311                  -0.0486         -0.0486          3554          3381          3554          3381
sha1_shifts/65536                 -0.0494         -0.0495         43275         41135         43274         41132
stop/analysis                     +0.0131         +0.0131             0             0             0             0
stop                              +0.0007         +0.0007             1             1             1             1
blake2b_huff/analysis             +0.0354         +0.0355            52            54            52            54
blake2b_huff/empty                +0.0291         +0.0291            73            75            73            75
blake2b_huff/abc                  +0.0307         +0.0307            72            75            72            75
blake2b_huff/2805nulls            -0.0033         -0.0033           485           483           485           483
blake2b_huff/2805aa               +0.0025         +0.0025           482           483           482           483
blake2b_huff/5610nulls            -0.0065         -0.0065           896           890           896           890
blake2b_huff/8415nulls            -0.0075         -0.0075          1285          1276          1285          1276
blake2b_huff/65536nulls           -0.0094         -0.0094          9609          9519          9609          9519
sha1_divs/analysis                +0.0529         +0.0529             5             5             5             5
sha1_divs/empty                   -0.0164         -0.0164            98            96            98            96
sha1_divs/1351                    -0.0209         -0.0209          1913          1873          1913          1873
sha1_divs/2737                    -0.0207         -0.0207          3728          3651          3728          3651
sha1_divs/5311                    -0.0211         -0.0211          7272          7118          7272          7118
sha1_divs/65536                   -0.0196         -0.0196         88532         86797         88531         86798
weierstrudel/analysis             +0.0591         +0.0591            65            69            65            69
weierstrudel/0                    +0.0005         +0.0005           337           337           337           337
weierstrudel/1                    -0.0192         -0.0192           660           648           660           648
weierstrudel/2                    -0.0192         -0.0192           824           809           824           809
weierstrudel/3                    -0.0194         -0.0194           989           970           989           970
weierstrudel/8                    -0.0231         -0.0231          1806          1764          1806          1764
weierstrudel/9                    -0.0227         -0.0227          1971          1926          1971          1926
weierstrudel/14                   -0.0240         -0.0240          2790          2723          2790          2723
blake2b_shifts/analysis           +0.1496         +0.1496            26            30            26            30
blake2b_shifts/empty              +0.0000         +0.0000             0             0             0             0
blake2b_shifts/2805nulls          -0.3398         -0.3398          6568          4336          6568          4336
blake2b_shifts/5610nulls          -0.3313         -0.3313         12930          8646         12929          8646
blake2b_shifts/8415nulls          -0.3276         -0.3276         19254         12947         19254         12947
blake2b_shifts/65536nulls         -0.2887         -0.2887        143245        101887        143243        101885
```