### PR TITLE
Push arguments to stack in undefined_instructions test.

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -84,7 +84,8 @@ code_analysis analyze(
         auto& instr = jumpdest ? analysis.instrs.back() : analysis.instrs.emplace_back(fns[c]);
 
         auto metrics = instr_table[c];
-        block->gas_cost += metrics.gas_cost;
+        if (metrics.gas_cost > 0)  // can be -1 for undefined instruction
+            block->gas_cost += metrics.gas_cost;
         auto stack_req = metrics.num_stack_arguments - block->stack_diff;
         block->stack_diff += (metrics.num_stack_returned_items - metrics.num_stack_arguments);
         block->stack_req = std::max(block->stack_req, stack_req);

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -946,18 +946,22 @@ TEST_F(evm, shift_overflow)
 
 TEST_F(evm, undefined_instructions)
 {
+    auto latest_metrics = evmc_get_instruction_metrics_table(EVMC_MAX_REVISION);
+
     for (auto i = 0; i <= EVMC_MAX_REVISION; ++i)
     {
-        auto r = evmc_revision(i);
-        auto names = evmc_get_instruction_names_table(r);
+        rev = evmc_revision(i);
+        auto names = evmc_get_instruction_names_table(rev);
 
         for (uint8_t opcode = 0; opcode <= 0xfe; ++opcode)
         {
             if (names[opcode] != nullptr)
                 continue;
 
-            auto res = vm.execute(*this, r, {}, &opcode, sizeof(opcode));
-            EXPECT_EQ(res.status_code, EVMC_UNDEFINED_INSTRUCTION) << hex(opcode);
+            auto code = latest_metrics[opcode].num_stack_arguments * push(0) + evmc_opcode(opcode);
+
+            execute(30000000, code);
+            EXPECT_EQ(result.status_code, EVMC_UNDEFINED_INSTRUCTION) << hex(opcode);
         }
     }
 }

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -960,7 +960,7 @@ TEST_F(evm, undefined_instructions)
 
             auto code = latest_metrics[opcode].num_stack_arguments * push(0) + evmc_opcode(opcode);
 
-            execute(30000000, code);
+            execute(code);
             EXPECT_EQ(result.status_code, EVMC_UNDEFINED_INSTRUCTION) << hex(opcode);
         }
     }


### PR DESCRIPTION
aleth-interpreter first checks whether there's enough arguments for instruction (according to latest revision requirements) before checking whether this instruction is defined for current revision.

So this was failing for some instructions like bit shifts, that were defined in later revisions.