### PR TITLE
Fix integer overflow in analysis around gas cost of undefined instruction

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -84,7 +84,8 @@ code_analysis analyze(
         auto& instr = jumpdest ? analysis.instrs.back() : analysis.instrs.emplace_back(fns[c]);
 
         auto metrics = instr_table[c];
-        block->gas_cost += metrics.gas_cost;
+        if (metrics.gas_cost > 0)  // can be -1 for undefined instruction
+            block->gas_cost += metrics.gas_cost;
         auto stack_req = metrics.num_stack_arguments - block->stack_diff;
         block->stack_diff += (metrics.num_stack_returned_items - metrics.num_stack_arguments);
         block->stack_req = std::max(block->stack_req, stack_req);

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -962,6 +962,17 @@ TEST_F(evm, undefined_instructions)
     }
 }
 
+TEST_F(evm, undefined_instruction_analysis_overflow)
+{
+    rev = EVMC_PETERSBURG;
+
+    auto undefined_opcode = evmc_opcode(0x0c);
+    auto code = bytecode{undefined_opcode};
+
+    execute(code);
+    EXPECT_EQ(result.status_code, EVMC_UNDEFINED_INSTRUCTION);
+}
+
 TEST_F(evm, undefined_instruction_block_cost_negative)
 {
     // For undefined instructions EVMC instruction tables have cost -1.

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -962,6 +962,26 @@ TEST_F(evm, undefined_instructions)
     }
 }
 
+TEST_F(evm, undefined_instruction_block_cost_negative)
+{
+    // For undefined instructions EVMC instruction tables have cost -1.
+    // If naively counted block costs can become negative.
+
+    const auto max_gas = std::numeric_limits<int64_t>::max();
+
+    const auto code1 = bytecode{} + "0f";  // Block cost -1.
+    execute(max_gas, code1);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+
+    const auto code2 = bytecode{} + OP_JUMPDEST + "c6" + "4b" + OP_STOP;  // Block cost -1.
+    execute(max_gas, code2);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+
+    const auto code3 = bytecode{} + OP_ADDRESS + "2a" + "2b" + "2c" + "2d";  // Block cost -2.
+    execute(max_gas, code3);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
 TEST_F(evm, abort)
 {
     for (auto r = 0; r <= EVMC_MAX_REVISION; ++r)


### PR DESCRIPTION
Without the fix it's not only UBSAN warning, but also the test fails, returning `EVMC_OUT_OF_GAS` instead of `EVMC_UNDEFINED_INSTRUCTION`.

Overflow happens not at the place of fix but later during execution here
https://github.com/ethereum/evmone/blob/47a1d47ae96b19a247d3923311735cce118a347b/lib/evmone/instructions.cpp#L1164