### PR TITLE
utils: Decode bytecode into human-readable string

### DIFF
--- a/test/unittests/bytecode_test.cpp
+++ b/test/unittests/bytecode_test.cpp
@@ -48,3 +48,27 @@ TEST(bytecode, repeat)
 
     EXPECT_EQ(0 * OP_STOP, "");
 }
+
+TEST(bytecode, decode)
+{
+    const auto code = push(0x01e240) + OP_DUP1 + OP_GAS + "cc" + OP_REVERT;
+    EXPECT_EQ(decode(code, EVMC_FRONTIER),
+        "bytecode{} + OP_PUSH3 + \"01e240\" + OP_DUP1 + OP_GAS + \"cc\" + \"fd\"");
+    EXPECT_EQ(decode(code, EVMC_BYZANTIUM),
+        "bytecode{} + OP_PUSH3 + \"01e240\" + OP_DUP1 + OP_GAS + \"cc\" + OP_REVERT");
+}
+
+TEST(bytecode, decode_push_trimmed_data)
+{
+    const auto code1 = bytecode{} + OP_PUSH2 + "0000";
+    EXPECT_EQ(decode(code1, EVMC_FRONTIER), "bytecode{} + OP_PUSH2 + \"0000\"");
+
+    const auto code2 = bytecode{} + OP_PUSH2 + "00";
+    EXPECT_EQ(decode(code2, EVMC_FRONTIER), "bytecode{} + OP_PUSH2 + \"00\"");
+
+    const auto code3 = bytecode{} + OP_PUSH2;
+    EXPECT_EQ(decode(code3, EVMC_FRONTIER), "bytecode{} + OP_PUSH2");
+
+    const auto code4 = bytecode{} + OP_PUSH2 + "";
+    EXPECT_EQ(decode(code4, EVMC_FRONTIER), "bytecode{} + OP_PUSH2");
+}

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -164,3 +164,34 @@ inline bytecode sload(bytecode index)
 {
     return index + OP_SLOAD;
 }
+
+
+inline std::string decode(bytes_view bytecode, evmc_revision rev)
+{
+    auto s = std::string{"bytecode{}"};
+    const auto names = evmc_get_instruction_names_table(rev);
+    for (auto it = bytecode.begin(); it != bytecode.end(); ++it)
+    {
+        const auto opcode = *it;
+        if (const auto name = names[opcode]; name)
+        {
+            s += std::string{" + OP_"} + name;
+
+            if (opcode >= OP_PUSH1 && opcode <= OP_PUSH32)
+            {
+                auto push_data = std::string{};
+                auto push_data_size = opcode - OP_PUSH1 + 1;
+                while (push_data_size-- && ++it != bytecode.end())
+                    push_data += to_hex({&*it, 1});
+                if (!push_data.empty())
+                    s += " + \"" + push_data + '"';
+                if (it == bytecode.end())
+                    break;
+            }
+        }
+        else
+            s += " + \"" + to_hex({&opcode, 1}) + '"';
+    }
+
+    return s;
+}

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -179,14 +179,15 @@ inline std::string decode(bytes_view bytecode, evmc_revision rev)
 
             if (opcode >= OP_PUSH1 && opcode <= OP_PUSH32)
             {
-                auto push_data = std::string{};
-                auto push_data_size = opcode - OP_PUSH1 + 1;
-                while (push_data_size-- && ++it != bytecode.end())
-                    push_data += to_hex({&*it, 1});
-                if (!push_data.empty())
-                    s += " + \"" + push_data + '"';
-                if (it == bytecode.end())
-                    break;
+                const auto push_data_start = it + 1;
+                const auto push_data_size =
+                    std::min(static_cast<std::size_t>(opcode - OP_PUSH1 + 1),
+                        static_cast<std::size_t>(bytecode.end() - push_data_start));
+                if (push_data_size != 0)
+                {
+                    s += " + \"" + to_hex({&*push_data_start, push_data_size}) + '"';
+                    it += push_data_size;
+                }
             }
         }
         else


### PR DESCRIPTION
Adds a procedure to convert a bytecode into a human-readable bytecode expression which is also compilable  back to bytecode with bytecode helpers.

TODO:
- [x] Add basic unit tests.