### PR TITLE
Implement EIP-663 variant C

### DIFF
--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -1284,6 +1284,10 @@ constexpr exec_fn_table create_op_table_constantinople() noexcept
 constexpr exec_fn_table create_op_table_istanbul() noexcept
 {
     auto table = create_op_table_constantinople();
+    table[OP_DUPN] = op_dup;
+    table[OP_SWAPN] = op_swap;
+    table[OP_DUPSN] = op_dup;
+    table[OP_SWAPSN] = op_swap;
     return table;
 }
 }  // namespace


### PR DESCRIPTION
This implement the variant C of the [EIP-663](https://eips.ethereum.org/EIPS/eip-663) by adding 4 new instructions for EVM stack manipulation: `DUPN`, `SWAPN`, `DUPSN`, `SWAPSN`.

The function change is only done in the analysis phase when the instruction argument (stack item index) is decode. During execution the same procedure is used as for legacy `DUP` and `SWAP` instructions.

Closes #84.