### PR TITLE
bench: Add option to load external EVMC VM

### DIFF
--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(benchmark CONFIG REQUIRED)
 add_executable(evmone-bench bench.cpp)
 
 target_include_directories(evmone-bench PRIVATE ${evmone_private_include_dir})
-target_link_libraries(evmone-bench PRIVATE evmone testutils benchmark::benchmark)
+target_link_libraries(evmone-bench PRIVATE evmone testutils evmc::loader benchmark::benchmark)
 
 check_include_file_cxx(filesystem HAVE_FILESYSTEM)
 if(NOT HAVE_FILESYSTEM)


### PR DESCRIPTION
```bash
evmone-bench <evmc_module> <path_to_benchmarks_dir>
```