### PR TITLE
Test for EIP-663 with jumpdest

### DIFF
--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -1284,6 +1284,10 @@ constexpr exec_fn_table create_op_table_constantinople() noexcept
 constexpr exec_fn_table create_op_table_istanbul() noexcept
 {
     auto table = create_op_table_constantinople();
+    table[OP_DUPN] = op_dup;
+    table[OP_SWAPN] = op_swap;
+    table[OP_DUPSN] = op_dup;
+    table[OP_SWAPSN] = op_swap;
     return table;
 }
 }  // namespace

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -239,6 +239,19 @@ TEST_F(evm, swapsn_jumpdest)
     EXPECT_STATUS(EVMC_BAD_JUMP_DESTINATION);
 }
 
+TEST_F(evm, swapsn_push)
+{
+    const auto code = push(5) + OP_JUMP + OP_SWAPSN + push(OP_JUMPDEST) + push(0) + ret_top();
+
+    rev = EVMC_PETERSBURG;
+    execute(code);
+    EXPECT_STATUS(EVMC_BAD_JUMP_DESTINATION);
+
+    rev = EVMC_ISTANBUL;
+    execute(code);
+    EXPECT_STATUS(EVMC_SUCCESS);
+}
+
 TEST_F(evm, memory_and_not)
 {
     execute(42, "600060018019815381518252800190f3");

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -226,6 +226,19 @@ TEST_F(evm, swapn_full_stack)
     EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
 }
 
+TEST_F(evm, swapsn_jumpdest)
+{
+    const auto code = push(4) + OP_JUMP + OP_SWAPSN + OP_JUMPDEST + push(0) + ret_top();
+
+    rev = EVMC_PETERSBURG;
+    execute(code);
+    EXPECT_STATUS(EVMC_SUCCESS);
+
+    rev = EVMC_ISTANBUL;
+    execute(code);
+    EXPECT_STATUS(EVMC_BAD_JUMP_DESTINATION);
+}
+
 TEST_F(evm, memory_and_not)
 {
     execute(42, "600060018019815381518252800190f3");


### PR DESCRIPTION
I've added a test on top of [EIP-663 implementation](https://github.com/ethereum/evmone/pull/98) for the problem called out by @chriseth in https://ethereum-magicians.org/t/eip-663-unlimited-swap-and-dup-instructions/3346/10

Basically some JUMPDESTs that were considered valid before EIP-663, with it are considered a part of the multibyte opcode and not a JUMPDEST. So some old contracts might be broken.