### PR TITLE
Do not keep information about block stack change

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -54,6 +54,7 @@ code_analysis analyze(
 
     block_info* block = nullptr;
 
+    int block_stack_change = 0;
     int instr_index = 0;
 
     const auto code_end = code + code_size;
@@ -68,6 +69,7 @@ code_analysis analyze(
         {
             // Create new block.
             block = &analysis.blocks.emplace_back();
+            block_stack_change = 0;
 
             // Create BEGINBLOCK instruction which either replaces JUMPDEST or is injected
             // in case there is no JUMPDEST.
@@ -89,9 +91,9 @@ code_analysis analyze(
         const auto instr_stack_req = metrics.num_stack_arguments;
         const auto instr_stack_change = metrics.num_stack_returned_items - instr_stack_req;
 
-        block->stack_req = std::max(block->stack_req, instr_stack_req - block->stack_change);
-        block->stack_change += instr_stack_change;
-        block->stack_max = std::max(block->stack_max, block->stack_change);
+        block->stack_req = std::max(block->stack_req, instr_stack_req - block_stack_change);
+        block_stack_change += instr_stack_change;
+        block->stack_max = std::max(block->stack_max, block_stack_change);
 
         if (metrics.gas_cost > 0)  // can be -1 for undefined instruction
             block->gas_cost += metrics.gas_cost;

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -93,7 +93,7 @@ code_analysis analyze(
 
         block->stack_req = std::max(block->stack_req, instr_stack_req - block_stack_change);
         block_stack_change += instr_stack_change;
-        block->stack_max = std::max(block->stack_max, block_stack_change);
+        block->stack_max_growth = std::max(block->stack_max_growth, block_stack_change);
 
         if (metrics.gas_cost > 0)  // can be -1 for undefined instruction
             block->gas_cost += metrics.gas_cost;

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -162,10 +162,14 @@ struct instr_info
 
 struct block_info
 {
+    /// The total base gas cost of all instructions in the block.
     int64_t gas_cost = 0;
-    int stack_req = 0;     ///< The required stack height to execute the block.
-    int stack_max = 0;     ///< The relative maximum stack height in the block.
-    int stack_change = 0;  ///< The relative stack height change after the execution of the block.
+
+    /// The stack height required to execute the block.
+    int stack_req = 0;
+
+    /// The maximum stack height relative to the stack height at block start.
+    int stack_max = 0;
 };
 
 struct code_analysis

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -168,8 +168,8 @@ struct block_info
     /// The stack height required to execute the block.
     int stack_req = 0;
 
-    /// The maximum stack height relative to the stack height at block start.
-    int stack_max = 0;
+    /// The maximum stack height growth relative to the stack height at block start.
+    int stack_max_growth = 0;
 };
 
 struct code_analysis

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -1198,7 +1198,7 @@ void opx_beginblock(execution_state& state, instr_argument arg) noexcept
     if (static_cast<int>(state.stack.size()) < block.stack_req)
         return state.exit(EVMC_STACK_UNDERFLOW);
 
-    if (static_cast<int>(state.stack.size()) + block.stack_max > evm_stack::limit)
+    if (static_cast<int>(state.stack.size()) + block.stack_max_growth > evm_stack::limit)
         return state.exit(EVMC_STACK_OVERFLOW);
 
     state.current_block_cost = block.gas_cost;

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -42,7 +42,7 @@ TEST(analysis, example1)
     ASSERT_EQ(analysis.blocks.size(), 1);
     EXPECT_EQ(analysis.blocks[0].gas_cost, 14);
     EXPECT_EQ(analysis.blocks[0].stack_req, 0);
-    EXPECT_EQ(analysis.blocks[0].stack_max, 2);
+    EXPECT_EQ(analysis.blocks[0].stack_max_growth, 2);
 }
 
 TEST(analysis, stack_up_and_down)
@@ -61,7 +61,7 @@ TEST(analysis, stack_up_and_down)
     ASSERT_EQ(analysis.blocks.size(), 1);
     EXPECT_EQ(analysis.blocks[0].gas_cost, 7 * 3 + 10 * 2 + 3);
     EXPECT_EQ(analysis.blocks[0].stack_req, 3);
-    EXPECT_EQ(analysis.blocks[0].stack_max, 7);
+    EXPECT_EQ(analysis.blocks[0].stack_max_growth, 7);
 }
 
 TEST(analysis, push)

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -43,7 +43,6 @@ TEST(analysis, example1)
     EXPECT_EQ(analysis.blocks[0].gas_cost, 14);
     EXPECT_EQ(analysis.blocks[0].stack_req, 0);
     EXPECT_EQ(analysis.blocks[0].stack_max, 2);
-    EXPECT_EQ(analysis.blocks[0].stack_change, 0);
 }
 
 TEST(analysis, stack_up_and_down)
@@ -63,7 +62,6 @@ TEST(analysis, stack_up_and_down)
     EXPECT_EQ(analysis.blocks[0].gas_cost, 7 * 3 + 10 * 2 + 3);
     EXPECT_EQ(analysis.blocks[0].stack_req, 3);
     EXPECT_EQ(analysis.blocks[0].stack_max, 7);
-    EXPECT_EQ(analysis.blocks[0].stack_change, -2);
 }
 
 TEST(analysis, push)

--- a/test/utils/dump.cpp
+++ b/test/utils/dump.cpp
@@ -48,7 +48,7 @@ void dump_analysis(const evmone::code_analysis& analysis)
                 std::cout << "  ";
 
             std::cout << " " << std::setw(10) << block->gas_cost << " " << block->stack_req << " "
-                      << block->stack_max << " " << block->stack_change << "\n";
+                      << block->stack_max << "\n";
         }
 
         std::cout << "│ " << std::setw(9) << std::left << name << std::setw(4) << std::right

--- a/test/utils/dump.cpp
+++ b/test/utils/dump.cpp
@@ -48,7 +48,7 @@ void dump_analysis(const evmone::code_analysis& analysis)
                 std::cout << "  ";
 
             std::cout << " " << std::setw(10) << block->gas_cost << " " << block->stack_req << " "
-                      << block->stack_max << "\n";
+                      << block->stack_max_growth << "\n";
         }
 
         std::cout << "│ " << std::setw(9) << std::left << name << std::setw(4) << std::right


### PR DESCRIPTION
This information is only needed in analysis to compute other block stack requirements parameters.