### PR TITLE
Eliminate parameters of some instructions

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -140,6 +140,8 @@ code_analysis analyze(
         }
 
         case ANY_DUP:
+            // TODO: This is not needed, but we keep it
+            //       otherwise compiler will not use the jumptable for switch implementation.
             instr.arg.p.number = opcode - OP_DUP1;
             break;
 

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -175,6 +175,8 @@ code_analysis analyze(
         case OP_LOG2:
         case OP_LOG3:
         case OP_LOG4:
+            // TODO: This is not needed, but we keep it
+            //       otherwise compiler will not use the jumptable for switch implementation.
             instr.arg.p.number = opcode - OP_LOG0;
             break;
 

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -144,6 +144,8 @@ code_analysis analyze(
             break;
 
         case ANY_SWAP:
+            // TODO: This is not needed, but we keep it
+            //       otherwise compiler will not use the jumptable for switch implementation.
             instr.arg.p.number = opcode - OP_SWAP1 + 1;
             break;
 

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -682,9 +682,11 @@ void op_pop(execution_state& state, instr_argument) noexcept
     state.stack.pop();
 }
 
-void op_dup(execution_state& state, instr_argument arg) noexcept
+template <evmc_opcode DupOp>
+void op_dup(execution_state& state, instr_argument) noexcept
 {
-    state.stack.push(state.stack[arg.p.number]);
+    constexpr auto index = DupOp - OP_DUP1;
+    state.stack.push(state.stack[index]);
 }
 
 template <evmc_opcode SwapOp>
@@ -1266,8 +1268,23 @@ constexpr exec_fn_table create_op_table_frontier() noexcept
         table[op] = op_push_small;
     for (auto op = size_t{OP_PUSH9}; op <= OP_PUSH32; ++op)
         table[op] = op_push_full;
-    for (auto op = size_t{OP_DUP1}; op <= OP_DUP16; ++op)
-        table[op] = op_dup;
+
+    table[OP_DUP1] = op_dup<OP_DUP1>;
+    table[OP_DUP2] = op_dup<OP_DUP2>;
+    table[OP_DUP3] = op_dup<OP_DUP3>;
+    table[OP_DUP4] = op_dup<OP_DUP4>;
+    table[OP_DUP5] = op_dup<OP_DUP5>;
+    table[OP_DUP6] = op_dup<OP_DUP6>;
+    table[OP_DUP7] = op_dup<OP_DUP7>;
+    table[OP_DUP8] = op_dup<OP_DUP8>;
+    table[OP_DUP9] = op_dup<OP_DUP9>;
+    table[OP_DUP10] = op_dup<OP_DUP10>;
+    table[OP_DUP11] = op_dup<OP_DUP11>;
+    table[OP_DUP12] = op_dup<OP_DUP12>;
+    table[OP_DUP13] = op_dup<OP_DUP13>;
+    table[OP_DUP14] = op_dup<OP_DUP14>;
+    table[OP_DUP15] = op_dup<OP_DUP15>;
+    table[OP_DUP16] = op_dup<OP_DUP16>;
 
     table[OP_SWAP1] = op_swap<OP_SWAP1>;
     table[OP_SWAP2] = op_swap<OP_SWAP2>;

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -687,9 +687,11 @@ void op_dup(execution_state& state, instr_argument arg) noexcept
     state.stack.push(state.stack[arg.p.number]);
 }
 
-void op_swap(execution_state& state, instr_argument arg) noexcept
+template <evmc_opcode SwapOp>
+void op_swap(execution_state& state, instr_argument) noexcept
 {
-    std::swap(state.stack.top(), state.stack[arg.p.number]);
+    constexpr auto index = SwapOp - OP_SWAP1 + 1;
+    std::swap(state.stack.top(), state.stack[index]);
 }
 
 void op_log(execution_state& state, instr_argument arg) noexcept
@@ -1266,8 +1268,24 @@ constexpr exec_fn_table create_op_table_frontier() noexcept
         table[op] = op_push_full;
     for (auto op = size_t{OP_DUP1}; op <= OP_DUP16; ++op)
         table[op] = op_dup;
-    for (auto op = size_t{OP_SWAP1}; op <= OP_SWAP16; ++op)
-        table[op] = op_swap;
+
+    table[OP_SWAP1] = op_swap<OP_SWAP1>;
+    table[OP_SWAP2] = op_swap<OP_SWAP2>;
+    table[OP_SWAP3] = op_swap<OP_SWAP3>;
+    table[OP_SWAP4] = op_swap<OP_SWAP4>;
+    table[OP_SWAP5] = op_swap<OP_SWAP5>;
+    table[OP_SWAP6] = op_swap<OP_SWAP6>;
+    table[OP_SWAP7] = op_swap<OP_SWAP7>;
+    table[OP_SWAP8] = op_swap<OP_SWAP8>;
+    table[OP_SWAP9] = op_swap<OP_SWAP9>;
+    table[OP_SWAP10] = op_swap<OP_SWAP10>;
+    table[OP_SWAP11] = op_swap<OP_SWAP11>;
+    table[OP_SWAP12] = op_swap<OP_SWAP12>;
+    table[OP_SWAP13] = op_swap<OP_SWAP13>;
+    table[OP_SWAP14] = op_swap<OP_SWAP14>;
+    table[OP_SWAP15] = op_swap<OP_SWAP15>;
+    table[OP_SWAP16] = op_swap<OP_SWAP16>;
+
     for (auto op = size_t{OP_LOG0}; op <= OP_LOG4; ++op)
         table[op] = op_log;
     table[OP_CREATE] = op_create;


### PR DESCRIPTION
For DUPs, SWAPs and LOGs, we now use different methods and eliminate the need for additional function parameter. For DUPs and SWAPs methods generated by templates. This solution was slightly faster than extracting common code. For LOGs, we have a common code handling all cases.

```
Comparing bin/evmone-bench-master to bin/evmone-bench
Benchmark                            Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------
sha1_shifts/analysis              -0.0090         -0.0090             3             3             3             3
sha1_shifts/empty                 -0.0156         -0.0156            37            37            37            37
sha1_shifts/1351                  -0.0264         -0.0264           688           670           688           670
sha1_shifts/2737                  -0.0281         -0.0281          1335          1297          1335          1297
sha1_shifts/5311                  -0.0264         -0.0264          2593          2525          2593          2525
sha1_shifts/65536                 -0.0256         -0.0256         31575         30767         31575         30767
stop/analysis                     -0.0003         -0.0003             0             0             0             0
stop                              -0.0103         -0.0103             1             1             1             1
blake2b_huff/analysis             +0.0011         +0.0010            35            35            35            35
blake2b_huff/empty                -0.0099         -0.0099            51            51            51            51
blake2b_huff/abc                  -0.0093         -0.0093            51            51            51            51
blake2b_huff/2805nulls            -0.0407         -0.0407           363           348           363           348
blake2b_huff/2805aa               -0.0409         -0.0409           363           348           363           348
blake2b_huff/5610nulls            -0.0414         -0.0414           674           646           674           646
blake2b_huff/8415nulls            -0.0435         -0.0435           973           931           973           931
blake2b_huff/65536nulls           -0.0466         -0.0466          7306          6966          7306          6966
sha1_divs/analysis                -0.0032         -0.0032             4             4             4             4
sha1_divs/empty                   -0.0075         -0.0075            80            79            80            79
sha1_divs/1351                    -0.0111         -0.0111          1580          1562          1580          1562
sha1_divs/2737                    -0.0111         -0.0111          3078          3044          3078          3044
sha1_divs/5311                    -0.0108         -0.0108          6002          5938          6002          5938
sha1_divs/65536                   -0.0108         -0.0108         73004         72218         73004         72218
weierstrudel/analysis             +0.0023         +0.0023            43            43            43            43
weierstrudel/0                    +0.0191         +0.0191           269           274           269           274
weierstrudel/1                    +0.0033         +0.0033           530           532           530           532
weierstrudel/2                    +0.0034         +0.0030           666           668           666           668
weierstrudel/3                    +0.0027         +0.0027           803           805           803           805
weierstrudel/8                    -0.0007         -0.0007          1474          1473          1474          1473
weierstrudel/9                    -0.0013         -0.0017          1611          1609          1611          1609
weierstrudel/14                   -0.0024         -0.0024          2285          2280          2285          2280
blake2b_shifts/analysis           -0.0032         -0.0036            19            18            19            18
blake2b_shifts/empty              +0.0000         +0.0000             0             0             0             0
blake2b_shifts/2805nulls          +0.0147         +0.0147          3745          3800          3745          3800
blake2b_shifts/5610nulls          +0.0141         +0.0141          7656          7764          7656          7764
blake2b_shifts/8415nulls          +0.0148         +0.0144         11466         11636         11466         11631
blake2b_shifts/65536nulls         +0.0115         +0.0116         90805         91850         90797         91849
```