### PR TITLE
Always keep current instruction pointer in a register

### DIFF
--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -86,7 +86,6 @@ struct instr_info;
 
 struct execution_state
 {
-    const instr_info* next_instr{nullptr};
     evmc_status_code status = EVMC_SUCCESS;
     int64_t gas_left = 0;
 
@@ -113,10 +112,10 @@ struct execution_state
     evmc_revision rev = {};
 
     /// Terminates the execution with the given status code.
-    void exit(evmc_status_code status_code) noexcept
+    const instr_info* exit(evmc_status_code status_code) noexcept
     {
         status = status_code;
-        next_instr = nullptr;
+        return nullptr;
     }
 };
 
@@ -134,7 +133,7 @@ union instr_argument
 
 static_assert(sizeof(instr_argument) == sizeof(void*), "Incorrect size of instr_argument");
 
-using exec_fn = void (*)(execution_state&, instr_argument arg);
+using exec_fn = const instr_info* (*)(const instr_info*, execution_state&, instr_argument arg);
 
 /// The evmone intrinsic opcodes.
 ///

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -133,7 +133,7 @@ union instr_argument
 
 static_assert(sizeof(instr_argument) == sizeof(void*), "Incorrect size of instr_argument");
 
-using exec_fn = const instr_info* (*)(const instr_info*, execution_state&, instr_argument arg);
+using exec_fn = const instr_info* (*)(const instr_info*, execution_state&);
 
 /// The evmone intrinsic opcodes.
 ///

--- a/lib/evmone/execution.cpp
+++ b/lib/evmone/execution.cpp
@@ -31,7 +31,7 @@ evmc_result execute(evmc_instance*, evmc_context* ctx, evmc_revision rev, const 
 
     const instr_info* instr = &state->analysis->instrs[0];
     while (instr)
-        instr = instr->fn(instr, *state, instr->arg);
+        instr = instr->fn(instr, *state);
 
     evmc_result result{};
 

--- a/lib/evmone/execution.cpp
+++ b/lib/evmone/execution.cpp
@@ -22,22 +22,16 @@ evmc_result execute(evmc_instance*, evmc_context* ctx, evmc_revision rev, const 
 
     auto state = std::make_unique<execution_state>();
     state->analysis = &analysis;
-    state->next_instr = &state->analysis->instrs[0];
     state->msg = msg;
     state->code = code;
     state->code_size = code_size;
     state->host = evmc::HostContext{ctx};
     state->gas_left = msg->gas;
     state->rev = rev;
-    while (state->next_instr)
-    {
-        const auto& instr = *state->next_instr;
 
-        // Advance next_instr to allow jump opcodes to overwrite it.
-        ++state->next_instr;
-
-        instr.fn(*state, instr.arg);
-    }
+    const instr_info* instr = &state->analysis->instrs[0];
+    while (instr)
+        instr = instr->fn(instr, *state, instr->arg);
 
     evmc_result result{};
 

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -564,10 +564,9 @@ const instr_info* op_jumpi(
     return instr;
 }
 
-const instr_info* op_pc(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+const instr_info* op_pc(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
-    state.stack.push(arg.p.number);
+    state.stack.push(instr->arg.p.number);
     return ++instr;
 }
 
@@ -577,10 +576,9 @@ const instr_info* op_msize(const instr_info* instr, execution_state& state, inst
     return ++instr;
 }
 
-const instr_info* op_gas(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+const instr_info* op_gas(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
-    const auto correction = state.current_block_cost - arg.p.number;
+    const auto correction = state.current_block_cost - instr->arg.p.number;
     const auto gas = static_cast<uint64_t>(state.gas_left + correction);
     state.stack.push(gas);
     return ++instr;
@@ -726,16 +724,16 @@ const instr_info* op_gaslimit(
 }
 
 const instr_info* op_push_small(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
-    state.stack.push(arg.small_push_value);
+    state.stack.push(instr->arg.small_push_value);
     return ++instr;
 }
 
 const instr_info* op_push_full(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
-    state.stack.push(*arg.push_value);
+    state.stack.push(*instr->arg.push_value);
     return ++instr;
 }
 
@@ -827,9 +825,9 @@ const instr_info* op_revert(const instr_info*, execution_state& state, instr_arg
     return state.exit(EVMC_REVERT);
 }
 
-const instr_info* op_call(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+const instr_info* op_call(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
+    const auto arg = instr->arg;
     auto gas = state.stack[0];
     const auto dst = intx::be::trunc<evmc::address>(state.stack[1]);
     auto value = state.stack[2];
@@ -947,8 +945,9 @@ const instr_info* op_call(
 }
 
 const instr_info* op_delegatecall(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
+    const auto arg = instr->arg;
     auto gas = state.stack[0];
     const auto dst = intx::be::trunc<evmc::address>(state.stack[1]);
     auto input_offset = state.stack[2];
@@ -1016,8 +1015,9 @@ const instr_info* op_delegatecall(
 }
 
 const instr_info* op_staticcall(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
+    const auto arg = instr->arg;
     auto gas = state.stack[0];
     const auto dst = intx::be::trunc<evmc::address>(state.stack[1]);
     auto input_offset = state.stack[2];
@@ -1080,11 +1080,12 @@ const instr_info* op_staticcall(
 }
 
 const instr_info* op_create(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
 
+    const auto arg = instr->arg;
     auto endowment = state.stack[0];
     auto init_code_offset = state.stack[1];
     auto init_code_size = state.stack[2];
@@ -1139,11 +1140,12 @@ const instr_info* op_create(
 }
 
 const instr_info* op_create2(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
 
+    const auto arg = instr->arg;
     auto endowment = state.stack[0];
     auto init_code_offset = state.stack[1];
     auto init_code_size = state.stack[2];
@@ -1234,10 +1236,9 @@ const instr_info* op_selfdestruct(
 }
 
 const instr_info* opx_beginblock(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
-    assert(arg.p.number >= 0);
-    auto& block = state.analysis->blocks[static_cast<size_t>(arg.p.number)];
+    auto& block = state.analysis->blocks[static_cast<size_t>(instr->arg.p.number)];
 
     if ((state.gas_left -= block.gas_cost) < 0)
         return state.exit(EVMC_OUT_OF_GAS);

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -72,74 +72,85 @@ inline bool check_memory(
 }
 
 
-void op_stop(execution_state& state, instr_argument) noexcept
+const instr_info* op_stop(const instr_info*, execution_state& state, instr_argument) noexcept
 {
-    state.exit(EVMC_SUCCESS);
+    return state.exit(EVMC_SUCCESS);
 }
 
-void op_add(execution_state& state, instr_argument) noexcept
+const instr_info* op_add(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() += state.stack.pop();
+    return ++instr;
 }
 
-void op_mul(execution_state& state, instr_argument) noexcept
+const instr_info* op_mul(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() *= state.stack.pop();
+    return ++instr;
 }
 
-void op_sub(execution_state& state, instr_argument) noexcept
+const instr_info* op_sub(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack[1] = state.stack[0] - state.stack[1];
     state.stack.pop();
+    return ++instr;
 }
 
-void op_div(execution_state& state, instr_argument) noexcept
+const instr_info* op_div(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? state.stack[0] / v : 0;
     state.stack.pop();
+    return ++instr;
 }
 
-void op_sdiv(execution_state& state, instr_argument) noexcept
+const instr_info* op_sdiv(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? intx::sdivrem(state.stack[0], v).quot : 0;
     state.stack.pop();
+    return ++instr;
 }
 
-void op_mod(execution_state& state, instr_argument) noexcept
+const instr_info* op_mod(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? state.stack[0] % v : 0;
     state.stack.pop();
+    return ++instr;
 }
 
-void op_smod(execution_state& state, instr_argument) noexcept
+const instr_info* op_smod(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? intx::sdivrem(state.stack[0], v).rem : 0;
     state.stack.pop();
+    return ++instr;
 }
 
-void op_addmod(execution_state& state, instr_argument) noexcept
+const instr_info* op_addmod(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto x = state.stack.pop();
     const auto y = state.stack.pop();
     auto& m = state.stack.top();
 
     m = m != 0 ? intx::addmod(x, y, m) : 0;
+    return ++instr;
 }
 
-void op_mulmod(execution_state& state, instr_argument) noexcept
+const instr_info* op_mulmod(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto x = state.stack.pop();
     const auto y = state.stack.pop();
     auto& m = state.stack.top();
 
     m = m != 0 ? intx::mulmod(x, y, m) : 0;
+    return ++instr;
 }
 
-void op_exp(execution_state& state, instr_argument) noexcept
+const instr_info* op_exp(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto base = state.stack.pop();
     auto& exponent = state.stack.top();
@@ -152,9 +163,10 @@ void op_exp(execution_state& state, instr_argument) noexcept
         return state.exit(EVMC_OUT_OF_GAS);
 
     exponent = intx::exp(base, exponent);
+    return ++instr;
 }
 
-void op_signextend(execution_state& state, instr_argument) noexcept
+auto op_signextend(const instr_info* pc, execution_state& state, instr_argument) noexcept
 {
     const auto ext = state.stack.pop();
     auto& x = state.stack.top();
@@ -167,22 +179,25 @@ void op_signextend(execution_state& state, instr_argument) noexcept
         auto is_neg = (x & sign_mask) != 0;
         x = is_neg ? x | ~value_mask : x & value_mask;
     }
+    return ++pc;
 }
 
-void op_lt(execution_state& state, instr_argument) noexcept
+const instr_info* op_lt(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // OPT: Have single function implementing all comparisons.
     state.stack[1] = state.stack[0] < state.stack[1];
     state.stack.pop();
+    return ++instr;
 }
 
-void op_gt(execution_state& state, instr_argument) noexcept
+const instr_info* op_gt(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack[1] = state.stack[1] < state.stack[0];
     state.stack.pop();
+    return ++instr;
 }
 
-void op_slt(execution_state& state, instr_argument) noexcept
+const instr_info* op_slt(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto x = state.stack[0];
     auto y = state.stack[1];
@@ -190,9 +205,10 @@ void op_slt(execution_state& state, instr_argument) noexcept
     auto y_neg = static_cast<bool>(y >> 255);
     state.stack[1] = (x_neg ^ y_neg) ? x_neg : x < y;
     state.stack.pop();
+    return ++instr;
 }
 
-void op_sgt(execution_state& state, instr_argument) noexcept
+const instr_info* op_sgt(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto x = state.stack[0];
     auto y = state.stack[1];
@@ -200,40 +216,48 @@ void op_sgt(execution_state& state, instr_argument) noexcept
     auto y_neg = static_cast<bool>(y >> 255);
     state.stack[1] = (x_neg ^ y_neg) ? y_neg : y < x;
     state.stack.pop();
+    return ++instr;
 }
 
-void op_eq(execution_state& state, instr_argument) noexcept
+const instr_info* op_eq(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack[1] = state.stack[0] == state.stack[1];
     state.stack.pop();
+    return ++instr;
 }
 
-void op_iszero(execution_state& state, instr_argument) noexcept
+const instr_info* op_iszero(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() = state.stack.top() == 0;
+    return ++instr;
 }
 
-void op_and(execution_state& state, instr_argument) noexcept
+const instr_info* op_and(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() &= state.stack.pop();
+    return ++instr;
 }
 
-void op_or(execution_state& state, instr_argument) noexcept
+const instr_info* op_or(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() |= state.stack.pop();
+    return ++instr;
 }
 
-void op_xor(execution_state& state, instr_argument) noexcept
+const instr_info* op_xor(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() ^= state.stack.pop();
+    return ++instr;
 }
 
-void op_not(execution_state& state, instr_argument) noexcept
+const instr_info* op_not(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() = ~state.stack.top();
+    return ++instr;
 }
 
-void op_byte(execution_state& state, instr_argument) noexcept
+const instr_info* op_byte(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto n = state.stack.pop();
     auto& x = state.stack.top();
@@ -246,22 +270,26 @@ void op_byte(execution_state& state, instr_argument) noexcept
         auto y = x >> sh;
         x = y & 0xff;
     }
+    return ++instr;
 }
 
-void op_shl(execution_state& state, instr_argument) noexcept
+const instr_info* op_shl(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() <<= state.stack.pop();
+    return ++instr;
 }
 
-void op_shr(execution_state& state, instr_argument) noexcept
+const instr_info* op_shr(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.top() >>= state.stack.pop();
+    return ++instr;
 }
 
-void op_sar(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_sar(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     if ((state.stack[1] & (uint256{1} << 255)) == 0)
-        return op_shr(state, arg);
+        return op_shr(instr, state, arg);
 
     constexpr auto allones = ~uint256{};
 
@@ -274,15 +302,16 @@ void op_sar(execution_state& state, instr_argument arg) noexcept
     }
 
     state.stack.pop();
+    return ++instr;
 }
 
-void op_sha3(execution_state& state, instr_argument) noexcept
+const instr_info* op_sha3(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto index = state.stack.pop();
     auto& size = state.stack.top();
 
     if (!check_memory(state, index, size))
-        return;
+        return nullptr;
 
     const auto i = static_cast<size_t>(index);
     const auto s = static_cast<size_t>(size);
@@ -293,37 +322,49 @@ void op_sha3(execution_state& state, instr_argument) noexcept
 
     auto data = s != 0 ? &state.memory[i] : nullptr;
     size = intx::be::load<uint256>(ethash::keccak256(data, s));
+    return ++instr;
 }
 
-void op_address(execution_state& state, instr_argument) noexcept
+const instr_info* op_address(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // TODO: Might be generalized using pointers to class member.
     state.stack.push(intx::be::load<uint256>(state.msg->destination));
+    return ++instr;
 }
 
-void op_balance(execution_state& state, instr_argument) noexcept
+const instr_info* op_balance(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& x = state.stack.top();
     x = intx::be::load<uint256>(state.host.get_balance(intx::be::trunc<evmc::address>(x)));
+    return ++instr;
 }
 
-void op_origin(execution_state& state, instr_argument) noexcept
+const instr_info* op_origin(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_origin));
+    return ++instr;
 }
 
-void op_caller(execution_state& state, instr_argument) noexcept
+const instr_info* op_caller(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // TODO: Might be generalized using pointers to class member.
     state.stack.push(intx::be::load<uint256>(state.msg->sender));
+    return ++instr;
 }
 
-void op_callvalue(execution_state& state, instr_argument) noexcept
+const instr_info* op_callvalue(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.msg->value));
+    return ++instr;
 }
 
-void op_calldataload(execution_state& state, instr_argument) noexcept
+const instr_info* op_calldataload(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& index = state.stack.top();
 
@@ -340,21 +381,25 @@ void op_calldataload(execution_state& state, instr_argument) noexcept
 
         index = intx::be::load<uint256>(data);
     }
+    return ++instr;
 }
 
-void op_calldatasize(execution_state& state, instr_argument) noexcept
+const instr_info* op_calldatasize(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(state.msg->input_size);
+    return ++instr;
 }
 
-void op_calldatacopy(execution_state& state, instr_argument) noexcept
+const instr_info* op_calldatacopy(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto mem_index = state.stack.pop();
     const auto input_index = state.stack.pop();
     const auto size = state.stack.pop();
 
     if (!check_memory(state, mem_index, size))
-        return;
+        return nullptr;
 
     auto dst = static_cast<size_t>(mem_index);
     auto src = state.msg->input_size < input_index ? state.msg->input_size :
@@ -371,14 +416,18 @@ void op_calldatacopy(execution_state& state, instr_argument) noexcept
 
     if (s - copy_size > 0)
         std::memset(&state.memory[dst + copy_size], 0, s - copy_size);
+    return ++instr;
 }
 
-void op_codesize(execution_state& state, instr_argument) noexcept
+const instr_info* op_codesize(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(state.code_size);
+    return ++instr;
 }
 
-void op_codecopy(execution_state& state, instr_argument) noexcept
+const instr_info* op_codecopy(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // TODO: Similar to op_calldatacopy().
 
@@ -387,7 +436,7 @@ void op_codecopy(execution_state& state, instr_argument) noexcept
     const auto size = state.stack.pop();
 
     if (!check_memory(state, mem_index, size))
-        return;
+        return nullptr;
 
     auto dst = static_cast<size_t>(mem_index);
     auto src = state.code_size < input_index ? state.code_size : static_cast<size_t>(input_index);
@@ -404,48 +453,56 @@ void op_codecopy(execution_state& state, instr_argument) noexcept
 
     if (s - copy_size > 0)
         std::memset(&state.memory[dst + copy_size], 0, s - copy_size);
+    return ++instr;
 }
 
-void op_mload(execution_state& state, instr_argument) noexcept
+const instr_info* op_mload(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& index = state.stack.top();
 
     if (!check_memory(state, index, 32))
-        return;
+        return nullptr;
 
     index = intx::be::unsafe::load<uint256>(&state.memory[static_cast<size_t>(index)]);
+    return ++instr;
 }
 
-void op_mstore(execution_state& state, instr_argument) noexcept
+const instr_info* op_mstore(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto index = state.stack.pop();
     const auto value = state.stack.pop();
 
     if (!check_memory(state, index, 32))
-        return;
+        return nullptr;
 
     intx::be::unsafe::store(&state.memory[static_cast<size_t>(index)], value);
+    return ++instr;
 }
 
-void op_mstore8(execution_state& state, instr_argument) noexcept
+const instr_info* op_mstore8(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto index = state.stack.pop();
     const auto value = state.stack.pop();
 
     if (!check_memory(state, index, 1))
-        return;
+        return nullptr;
 
     state.memory[static_cast<size_t>(index)] = static_cast<uint8_t>(value);
+    return ++instr;
 }
 
-void op_sload(execution_state& state, instr_argument) noexcept
+const instr_info* op_sload(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& x = state.stack.top();
     x = intx::be::load<uint256>(
         state.host.get_storage(state.msg->destination, intx::be::store<evmc::bytes32>(x)));
+    return ++instr;
 }
 
-void op_sstore(execution_state& state, instr_argument) noexcept
+const instr_info* op_sstore(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // TODO: Implement static mode violation in analysis.
     if (state.msg->flags & EVMC_STATIC)
@@ -475,9 +532,10 @@ void op_sstore(execution_state& state, instr_argument) noexcept
     }
     if ((state.gas_left -= cost) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
+    return ++instr;
 }
 
-void op_jump(execution_state& state, instr_argument) noexcept
+const instr_info* op_jump(const instr_info*, execution_state& state, instr_argument) noexcept
 {
     const auto dst = state.stack.pop();
     auto pc = -1;
@@ -485,51 +543,66 @@ void op_jump(execution_state& state, instr_argument) noexcept
         (pc = find_jumpdest(*state.analysis, static_cast<int>(dst))) < 0)
         return state.exit(EVMC_BAD_JUMP_DESTINATION);
 
-    state.next_instr = &state.analysis->instrs[static_cast<size_t>(pc)];
+    return &state.analysis->instrs[static_cast<size_t>(pc)];
 }
 
-void op_jumpi(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_jumpi(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     if (state.stack[1] != 0)
-        op_jump(state, arg);
+        instr = op_jump(instr, state, arg);
     else
+    {
         state.stack.pop();
+        ++instr;
+    }
 
     // OPT: The pc must be the BEGINBLOCK (even in fallback case),
     //      so we can execute it straight away.
 
     state.stack.pop();
+    return instr;
 }
 
-void op_pc(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_pc(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     state.stack.push(arg.p.number);
+    return ++instr;
 }
 
-void op_msize(execution_state& state, instr_argument) noexcept
+const instr_info* op_msize(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(state.memory.size());
+    return ++instr;
 }
 
-void op_gas(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_gas(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     const auto correction = state.current_block_cost - arg.p.number;
     const auto gas = static_cast<uint64_t>(state.gas_left + correction);
     state.stack.push(gas);
+    return ++instr;
 }
 
-void op_gasprice(execution_state& state, instr_argument) noexcept
+const instr_info* op_gasprice(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_gas_price));
+    return ++instr;
 }
 
-void op_extcodesize(execution_state& state, instr_argument) noexcept
+const instr_info* op_extcodesize(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& x = state.stack.top();
     x = state.host.get_code_size(intx::be::trunc<evmc::address>(x));
+    return ++instr;
 }
 
-void op_extcodecopy(execution_state& state, instr_argument) noexcept
+const instr_info* op_extcodecopy(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto addr = intx::be::trunc<evmc::address>(state.stack.pop());
     const auto mem_index = state.stack.pop();
@@ -537,7 +610,7 @@ void op_extcodecopy(execution_state& state, instr_argument) noexcept
     const auto size = state.stack.pop();
 
     if (!check_memory(state, mem_index, size))
-        return;
+        return nullptr;
 
     auto dst = static_cast<size_t>(mem_index);
     auto src = max_buffer_size < input_index ? max_buffer_size : static_cast<size_t>(input_index);
@@ -551,21 +624,25 @@ void op_extcodecopy(execution_state& state, instr_argument) noexcept
     auto num_bytes_copied = state.host.copy_code(addr, src, data, s);
     if (s - num_bytes_copied > 0)
         std::memset(&state.memory[dst + num_bytes_copied], 0, s - num_bytes_copied);
+    return ++instr;
 }
 
-void op_returndatasize(execution_state& state, instr_argument) noexcept
+const instr_info* op_returndatasize(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(state.return_data.size());
+    return ++instr;
 }
 
-void op_returndatacopy(execution_state& state, instr_argument) noexcept
+const instr_info* op_returndatacopy(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto mem_index = state.stack.pop();
     const auto input_index = state.stack.pop();
     const auto size = state.stack.pop();
 
     if (!check_memory(state, mem_index, size))
-        return;
+        return nullptr;
 
     auto dst = static_cast<size_t>(mem_index);
     auto s = static_cast<size_t>(size);
@@ -583,15 +660,19 @@ void op_returndatacopy(execution_state& state, instr_argument) noexcept
 
     if (s > 0)
         std::memcpy(&state.memory[dst], &state.return_data[src], s);
+    return ++instr;
 }
 
-void op_extcodehash(execution_state& state, instr_argument) noexcept
+const instr_info* op_extcodehash(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& x = state.stack.top();
     x = intx::be::load<uint256>(state.host.get_code_hash(intx::be::trunc<evmc::address>(x)));
+    return ++instr;
 }
 
-void op_blockhash(execution_state& state, instr_argument) noexcept
+const instr_info* op_blockhash(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     auto& number = state.stack.top();
 
@@ -601,68 +682,87 @@ void op_blockhash(execution_state& state, instr_argument) noexcept
     const auto header =
         (number < upper_bound && n >= lower_bound) ? state.host.get_block_hash(n) : evmc::bytes32{};
     number = intx::be::load<uint256>(header);
+    return ++instr;
 }
 
-void op_coinbase(execution_state& state, instr_argument) noexcept
+const instr_info* op_coinbase(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_coinbase));
+    return ++instr;
 }
 
-void op_timestamp(execution_state& state, instr_argument) noexcept
+const instr_info* op_timestamp(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // TODO: Add tests for negative timestamp?
     const auto timestamp = static_cast<uint64_t>(state.host.get_tx_context().block_timestamp);
     state.stack.push(timestamp);
+    return ++instr;
 }
 
-void op_number(execution_state& state, instr_argument) noexcept
+const instr_info* op_number(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     // TODO: Add tests for negative block number?
     const auto block_number = static_cast<uint64_t>(state.host.get_tx_context().block_number);
     state.stack.push(block_number);
+    return ++instr;
 }
 
-void op_difficulty(execution_state& state, instr_argument) noexcept
+const instr_info* op_difficulty(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_difficulty));
+    return ++instr;
 }
 
-void op_gaslimit(execution_state& state, instr_argument) noexcept
+const instr_info* op_gaslimit(
+    const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     const auto block_gas_limit = static_cast<uint64_t>(state.host.get_tx_context().block_gas_limit);
     state.stack.push(block_gas_limit);
+    return ++instr;
 }
 
-void op_push_small(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_push_small(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     state.stack.push(arg.small_push_value);
+    return ++instr;
 }
 
-void op_push_full(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_push_full(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     state.stack.push(*arg.push_value);
+    return ++instr;
 }
 
-void op_pop(execution_state& state, instr_argument) noexcept
+const instr_info* op_pop(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     state.stack.pop();
+    return ++instr;
 }
 
 template <evmc_opcode DupOp>
-void op_dup(execution_state& state, instr_argument) noexcept
+const instr_info* op_dup(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     constexpr auto index = DupOp - OP_DUP1;
     state.stack.push(state.stack[index]);
+    return ++instr;
 }
 
 template <evmc_opcode SwapOp>
-void op_swap(execution_state& state, instr_argument) noexcept
+const instr_info* op_swap(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     constexpr auto index = SwapOp - OP_SWAP1 + 1;
     std::swap(state.stack.top(), state.stack[index]);
+    return ++instr;
 }
 
-void op_log(execution_state& state, size_t num_topics) noexcept
+const instr_info* op_log(
+    const instr_info* instr, execution_state& state, size_t num_topics) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -671,7 +771,7 @@ void op_log(execution_state& state, size_t num_topics) noexcept
     const auto size = state.stack.pop();
 
     if (!check_memory(state, offset, size))
-        return;
+        return nullptr;
 
     const auto o = static_cast<size_t>(offset);
     const auto s = static_cast<size_t>(size);
@@ -686,47 +786,49 @@ void op_log(execution_state& state, size_t num_topics) noexcept
 
     const auto data = s != 0 ? &state.memory[o] : nullptr;
     state.host.emit_log(state.msg->destination, data, s, topics.data(), num_topics);
+    return ++instr;
 }
 
 template <evmc_opcode LogOp>
-void op_log(execution_state& state, instr_argument) noexcept
+const instr_info* op_log(const instr_info* instr, execution_state& state, instr_argument) noexcept
 {
     constexpr auto num_topics = LogOp - OP_LOG0;
-    op_log(state, num_topics);
+    return op_log(instr, state, num_topics);
 }
 
-void op_invalid(execution_state& state, instr_argument) noexcept
+const instr_info* op_invalid(const instr_info*, execution_state& state, instr_argument) noexcept
 {
-    state.exit(EVMC_INVALID_INSTRUCTION);
+    return state.exit(EVMC_INVALID_INSTRUCTION);
 }
 
-void op_return(execution_state& state, instr_argument) noexcept
-{
-    auto offset = state.stack[0];
-    auto size = state.stack[1];
-
-    if (!check_memory(state, offset, size))
-        return;
-
-    state.output_offset = static_cast<size_t>(offset);
-    state.output_size = static_cast<size_t>(size);
-    state.exit(EVMC_SUCCESS);
-}
-
-void op_revert(execution_state& state, instr_argument) noexcept
+const instr_info* op_return(const instr_info*, execution_state& state, instr_argument) noexcept
 {
     auto offset = state.stack[0];
     auto size = state.stack[1];
 
     if (!check_memory(state, offset, size))
-        return;
+        return nullptr;
 
     state.output_offset = static_cast<size_t>(offset);
     state.output_size = static_cast<size_t>(size);
-    state.exit(EVMC_REVERT);
+    return state.exit(EVMC_SUCCESS);
 }
 
-void op_call(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_revert(const instr_info*, execution_state& state, instr_argument) noexcept
+{
+    auto offset = state.stack[0];
+    auto size = state.stack[1];
+
+    if (!check_memory(state, offset, size))
+        return nullptr;
+
+    state.output_offset = static_cast<size_t>(offset);
+    state.output_size = static_cast<size_t>(size);
+    return state.exit(EVMC_REVERT);
+}
+
+const instr_info* op_call(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     auto gas = state.stack[0];
     const auto dst = intx::be::trunc<evmc::address>(state.stack[1]);
@@ -745,10 +847,10 @@ void op_call(execution_state& state, instr_argument arg) noexcept
     state.stack[0] = 0;
 
     if (!check_memory(state, input_offset, input_size))
-        return;
+        return nullptr;
 
     if (!check_memory(state, output_offset, output_size))
-        return;
+        return nullptr;
 
 
     auto msg = evmc_message{};
@@ -795,7 +897,7 @@ void op_call(execution_state& state, instr_argument arg) noexcept
             state.gas_left += 2300;  // Return unused stipend.
         if (state.gas_left < 0)
             return state.exit(EVMC_OUT_OF_GAS);
-        return;
+        return ++instr;
     }
 
     msg.destination = dst;
@@ -819,7 +921,7 @@ void op_call(execution_state& state, instr_argument arg) noexcept
             state.gas_left += 2300;  // Return unused stipend.
             if (state.gas_left < 0)
                 return state.exit(EVMC_OUT_OF_GAS);
-            return;
+            return ++instr;
         }
 
         msg.gas += 2300;  // Add stipend.
@@ -841,9 +943,11 @@ void op_call(execution_state& state, instr_argument arg) noexcept
 
     if ((state.gas_left -= gas_used) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
+    return ++instr;
 }
 
-void op_delegatecall(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_delegatecall(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     auto gas = state.stack[0];
     const auto dst = intx::be::trunc<evmc::address>(state.stack[1]);
@@ -860,10 +964,10 @@ void op_delegatecall(execution_state& state, instr_argument arg) noexcept
     state.stack[0] = 0;
 
     if (!check_memory(state, input_offset, input_size))
-        return;
+        return nullptr;
 
     if (!check_memory(state, output_offset, output_size))
-        return;
+        return nullptr;
 
     auto msg = evmc_message{};
     msg.kind = EVMC_DELEGATECALL;
@@ -882,7 +986,7 @@ void op_delegatecall(execution_state& state, instr_argument arg) noexcept
         return state.exit(EVMC_OUT_OF_GAS);
 
     if (state.msg->depth >= 1024)
-        return;
+        return ++instr;
 
     msg.depth = state.msg->depth + 1;
     msg.flags = state.msg->flags;
@@ -908,9 +1012,11 @@ void op_delegatecall(execution_state& state, instr_argument arg) noexcept
 
     if ((state.gas_left -= gas_used) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
+    return ++instr;
 }
 
-void op_staticcall(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_staticcall(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     auto gas = state.stack[0];
     const auto dst = intx::be::trunc<evmc::address>(state.stack[1]);
@@ -927,13 +1033,13 @@ void op_staticcall(execution_state& state, instr_argument arg) noexcept
     state.stack[0] = 0;
 
     if (!check_memory(state, input_offset, input_size))
-        return;
+        return nullptr;
 
     if (!check_memory(state, output_offset, output_size))
-        return;
+        return nullptr;
 
     if (state.msg->depth >= 1024)
-        return;
+        return ++instr;
 
     auto msg = evmc_message{};
     msg.kind = EVMC_CALL;
@@ -970,9 +1076,11 @@ void op_staticcall(execution_state& state, instr_argument arg) noexcept
 
     if ((state.gas_left -= gas_used) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
+    return ++instr;
 }
 
-void op_create(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_create(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -986,19 +1094,19 @@ void op_create(execution_state& state, instr_argument arg) noexcept
     state.stack[0] = 0;
 
     if (!check_memory(state, init_code_offset, init_code_size))
-        return;
+        return nullptr;
 
     state.return_data.clear();
 
     if (state.msg->depth >= 1024)
-        return;
+        return nullptr;
 
     if (endowment != 0)
     {
         const auto balance =
             intx::be::load<uint256>(state.host.get_balance(state.msg->destination));
         if (balance < endowment)
-            return;
+            return ++instr;
     }
 
     auto msg = evmc_message{};
@@ -1027,9 +1135,11 @@ void op_create(execution_state& state, instr_argument arg) noexcept
 
     if ((state.gas_left -= msg.gas - result.gas_left) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
+    return ++instr;
 }
 
-void op_create2(execution_state& state, instr_argument arg) noexcept
+const instr_info* op_create2(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -1045,7 +1155,7 @@ void op_create2(execution_state& state, instr_argument arg) noexcept
     state.stack[0] = 0;
 
     if (!check_memory(state, init_code_offset, init_code_size))
-        return;
+        return nullptr;
 
     auto salt_cost = num_words(static_cast<size_t>(init_code_size)) * 6;
     state.gas_left -= salt_cost;
@@ -1055,14 +1165,14 @@ void op_create2(execution_state& state, instr_argument arg) noexcept
     state.return_data.clear();
 
     if (state.msg->depth >= 1024)
-        return;
+        return ++instr;
 
     if (endowment != 0)
     {
         const auto balance =
             intx::be::load<uint256>(state.host.get_balance(state.msg->destination));
         if (balance < endowment)
-            return;
+            return ++instr;
     }
 
     auto msg = evmc_message{};
@@ -1089,14 +1199,16 @@ void op_create2(execution_state& state, instr_argument arg) noexcept
 
     if ((state.gas_left -= msg.gas - result.gas_left) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
+    return ++instr;
 }
 
-void op_undefined(execution_state& state, instr_argument) noexcept
+const instr_info* op_undefined(const instr_info*, execution_state& state, instr_argument) noexcept
 {
     return state.exit(EVMC_UNDEFINED_INSTRUCTION);
 }
 
-void op_selfdestruct(execution_state& state, instr_argument) noexcept
+const instr_info* op_selfdestruct(
+    const instr_info*, execution_state& state, instr_argument) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -1118,10 +1230,11 @@ void op_selfdestruct(execution_state& state, instr_argument) noexcept
     }
 
     state.host.selfdestruct(state.msg->destination, addr);
-    state.exit(EVMC_SUCCESS);
+    return state.exit(EVMC_SUCCESS);
 }
 
-void opx_beginblock(execution_state& state, instr_argument arg) noexcept
+const instr_info* opx_beginblock(
+    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
 {
     assert(arg.p.number >= 0);
     auto& block = state.analysis->blocks[static_cast<size_t>(arg.p.number)];
@@ -1136,6 +1249,7 @@ void opx_beginblock(execution_state& state, instr_argument arg) noexcept
         return state.exit(EVMC_STACK_OVERFLOW);
 
     state.current_block_cost = block.gas_cost;
+    return ++instr;
 }
 
 constexpr exec_fn_table create_op_table_frontier() noexcept

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -72,31 +72,31 @@ inline bool check_memory(
 }
 
 
-const instr_info* op_stop(const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_stop(const instr_info*, execution_state& state) noexcept
 {
     return state.exit(EVMC_SUCCESS);
 }
 
-const instr_info* op_add(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_add(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() += state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_mul(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_mul(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() *= state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_sub(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_sub(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack[1] = state.stack[0] - state.stack[1];
     state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_div(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_div(const instr_info* instr, execution_state& state) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? state.stack[0] / v : 0;
@@ -104,7 +104,7 @@ const instr_info* op_div(const instr_info* instr, execution_state& state, instr_
     return ++instr;
 }
 
-const instr_info* op_sdiv(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_sdiv(const instr_info* instr, execution_state& state) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? intx::sdivrem(state.stack[0], v).quot : 0;
@@ -112,7 +112,7 @@ const instr_info* op_sdiv(const instr_info* instr, execution_state& state, instr
     return ++instr;
 }
 
-const instr_info* op_mod(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_mod(const instr_info* instr, execution_state& state) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? state.stack[0] % v : 0;
@@ -120,7 +120,7 @@ const instr_info* op_mod(const instr_info* instr, execution_state& state, instr_
     return ++instr;
 }
 
-const instr_info* op_smod(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_smod(const instr_info* instr, execution_state& state) noexcept
 {
     auto& v = state.stack[1];
     v = v != 0 ? intx::sdivrem(state.stack[0], v).rem : 0;
@@ -128,8 +128,7 @@ const instr_info* op_smod(const instr_info* instr, execution_state& state, instr
     return ++instr;
 }
 
-const instr_info* op_addmod(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_addmod(const instr_info* instr, execution_state& state) noexcept
 {
     const auto x = state.stack.pop();
     const auto y = state.stack.pop();
@@ -139,8 +138,7 @@ const instr_info* op_addmod(
     return ++instr;
 }
 
-const instr_info* op_mulmod(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_mulmod(const instr_info* instr, execution_state& state) noexcept
 {
     const auto x = state.stack.pop();
     const auto y = state.stack.pop();
@@ -150,7 +148,7 @@ const instr_info* op_mulmod(
     return ++instr;
 }
 
-const instr_info* op_exp(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_exp(const instr_info* instr, execution_state& state) noexcept
 {
     const auto base = state.stack.pop();
     auto& exponent = state.stack.top();
@@ -166,7 +164,7 @@ const instr_info* op_exp(const instr_info* instr, execution_state& state, instr_
     return ++instr;
 }
 
-auto op_signextend(const instr_info* pc, execution_state& state, instr_argument) noexcept
+auto op_signextend(const instr_info* pc, execution_state& state) noexcept
 {
     const auto ext = state.stack.pop();
     auto& x = state.stack.top();
@@ -182,7 +180,7 @@ auto op_signextend(const instr_info* pc, execution_state& state, instr_argument)
     return ++pc;
 }
 
-const instr_info* op_lt(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_lt(const instr_info* instr, execution_state& state) noexcept
 {
     // OPT: Have single function implementing all comparisons.
     state.stack[1] = state.stack[0] < state.stack[1];
@@ -190,14 +188,14 @@ const instr_info* op_lt(const instr_info* instr, execution_state& state, instr_a
     return ++instr;
 }
 
-const instr_info* op_gt(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_gt(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack[1] = state.stack[1] < state.stack[0];
     state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_slt(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_slt(const instr_info* instr, execution_state& state) noexcept
 {
     auto x = state.stack[0];
     auto y = state.stack[1];
@@ -208,7 +206,7 @@ const instr_info* op_slt(const instr_info* instr, execution_state& state, instr_
     return ++instr;
 }
 
-const instr_info* op_sgt(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_sgt(const instr_info* instr, execution_state& state) noexcept
 {
     auto x = state.stack[0];
     auto y = state.stack[1];
@@ -219,45 +217,44 @@ const instr_info* op_sgt(const instr_info* instr, execution_state& state, instr_
     return ++instr;
 }
 
-const instr_info* op_eq(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_eq(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack[1] = state.stack[0] == state.stack[1];
     state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_iszero(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_iszero(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() = state.stack.top() == 0;
     return ++instr;
 }
 
-const instr_info* op_and(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_and(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() &= state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_or(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_or(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() |= state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_xor(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_xor(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() ^= state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_not(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_not(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() = ~state.stack.top();
     return ++instr;
 }
 
-const instr_info* op_byte(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_byte(const instr_info* instr, execution_state& state) noexcept
 {
     const auto n = state.stack.pop();
     auto& x = state.stack.top();
@@ -273,23 +270,22 @@ const instr_info* op_byte(const instr_info* instr, execution_state& state, instr
     return ++instr;
 }
 
-const instr_info* op_shl(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_shl(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() <<= state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_shr(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_shr(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.top() >>= state.stack.pop();
     return ++instr;
 }
 
-const instr_info* op_sar(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+const instr_info* op_sar(const instr_info* instr, execution_state& state) noexcept
 {
     if ((state.stack[1] & (uint256{1} << 255)) == 0)
-        return op_shr(instr, state, arg);
+        return op_shr(instr, state);
 
     constexpr auto allones = ~uint256{};
 
@@ -305,7 +301,7 @@ const instr_info* op_sar(
     return ++instr;
 }
 
-const instr_info* op_sha3(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_sha3(const instr_info* instr, execution_state& state) noexcept
 {
     const auto index = state.stack.pop();
     auto& size = state.stack.top();
@@ -325,46 +321,40 @@ const instr_info* op_sha3(const instr_info* instr, execution_state& state, instr
     return ++instr;
 }
 
-const instr_info* op_address(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_address(const instr_info* instr, execution_state& state) noexcept
 {
     // TODO: Might be generalized using pointers to class member.
     state.stack.push(intx::be::load<uint256>(state.msg->destination));
     return ++instr;
 }
 
-const instr_info* op_balance(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_balance(const instr_info* instr, execution_state& state) noexcept
 {
     auto& x = state.stack.top();
     x = intx::be::load<uint256>(state.host.get_balance(intx::be::trunc<evmc::address>(x)));
     return ++instr;
 }
 
-const instr_info* op_origin(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_origin(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_origin));
     return ++instr;
 }
 
-const instr_info* op_caller(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_caller(const instr_info* instr, execution_state& state) noexcept
 {
     // TODO: Might be generalized using pointers to class member.
     state.stack.push(intx::be::load<uint256>(state.msg->sender));
     return ++instr;
 }
 
-const instr_info* op_callvalue(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_callvalue(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.msg->value));
     return ++instr;
 }
 
-const instr_info* op_calldataload(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_calldataload(const instr_info* instr, execution_state& state) noexcept
 {
     auto& index = state.stack.top();
 
@@ -384,15 +374,13 @@ const instr_info* op_calldataload(
     return ++instr;
 }
 
-const instr_info* op_calldatasize(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_calldatasize(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(state.msg->input_size);
     return ++instr;
 }
 
-const instr_info* op_calldatacopy(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_calldatacopy(const instr_info* instr, execution_state& state) noexcept
 {
     const auto mem_index = state.stack.pop();
     const auto input_index = state.stack.pop();
@@ -419,15 +407,13 @@ const instr_info* op_calldatacopy(
     return ++instr;
 }
 
-const instr_info* op_codesize(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_codesize(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(state.code_size);
     return ++instr;
 }
 
-const instr_info* op_codecopy(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_codecopy(const instr_info* instr, execution_state& state) noexcept
 {
     // TODO: Similar to op_calldatacopy().
 
@@ -456,7 +442,7 @@ const instr_info* op_codecopy(
     return ++instr;
 }
 
-const instr_info* op_mload(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_mload(const instr_info* instr, execution_state& state) noexcept
 {
     auto& index = state.stack.top();
 
@@ -467,8 +453,7 @@ const instr_info* op_mload(const instr_info* instr, execution_state& state, inst
     return ++instr;
 }
 
-const instr_info* op_mstore(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_mstore(const instr_info* instr, execution_state& state) noexcept
 {
     const auto index = state.stack.pop();
     const auto value = state.stack.pop();
@@ -480,8 +465,7 @@ const instr_info* op_mstore(
     return ++instr;
 }
 
-const instr_info* op_mstore8(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_mstore8(const instr_info* instr, execution_state& state) noexcept
 {
     const auto index = state.stack.pop();
     const auto value = state.stack.pop();
@@ -493,7 +477,7 @@ const instr_info* op_mstore8(
     return ++instr;
 }
 
-const instr_info* op_sload(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_sload(const instr_info* instr, execution_state& state) noexcept
 {
     auto& x = state.stack.top();
     x = intx::be::load<uint256>(
@@ -501,8 +485,7 @@ const instr_info* op_sload(const instr_info* instr, execution_state& state, inst
     return ++instr;
 }
 
-const instr_info* op_sstore(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_sstore(const instr_info* instr, execution_state& state) noexcept
 {
     // TODO: Implement static mode violation in analysis.
     if (state.msg->flags & EVMC_STATIC)
@@ -535,7 +518,7 @@ const instr_info* op_sstore(
     return ++instr;
 }
 
-const instr_info* op_jump(const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_jump(const instr_info*, execution_state& state) noexcept
 {
     const auto dst = state.stack.pop();
     auto pc = -1;
@@ -546,11 +529,10 @@ const instr_info* op_jump(const instr_info*, execution_state& state, instr_argum
     return &state.analysis->instrs[static_cast<size_t>(pc)];
 }
 
-const instr_info* op_jumpi(
-    const instr_info* instr, execution_state& state, instr_argument arg) noexcept
+const instr_info* op_jumpi(const instr_info* instr, execution_state& state) noexcept
 {
     if (state.stack[1] != 0)
-        instr = op_jump(instr, state, arg);
+        instr = op_jump(instr, state);
     else
     {
         state.stack.pop();
@@ -564,19 +546,19 @@ const instr_info* op_jumpi(
     return instr;
 }
 
-const instr_info* op_pc(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_pc(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(instr->arg.p.number);
     return ++instr;
 }
 
-const instr_info* op_msize(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_msize(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(state.memory.size());
     return ++instr;
 }
 
-const instr_info* op_gas(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_gas(const instr_info* instr, execution_state& state) noexcept
 {
     const auto correction = state.current_block_cost - instr->arg.p.number;
     const auto gas = static_cast<uint64_t>(state.gas_left + correction);
@@ -584,23 +566,20 @@ const instr_info* op_gas(const instr_info* instr, execution_state& state, instr_
     return ++instr;
 }
 
-const instr_info* op_gasprice(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_gasprice(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_gas_price));
     return ++instr;
 }
 
-const instr_info* op_extcodesize(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_extcodesize(const instr_info* instr, execution_state& state) noexcept
 {
     auto& x = state.stack.top();
     x = state.host.get_code_size(intx::be::trunc<evmc::address>(x));
     return ++instr;
 }
 
-const instr_info* op_extcodecopy(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_extcodecopy(const instr_info* instr, execution_state& state) noexcept
 {
     const auto addr = intx::be::trunc<evmc::address>(state.stack.pop());
     const auto mem_index = state.stack.pop();
@@ -625,15 +604,13 @@ const instr_info* op_extcodecopy(
     return ++instr;
 }
 
-const instr_info* op_returndatasize(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_returndatasize(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(state.return_data.size());
     return ++instr;
 }
 
-const instr_info* op_returndatacopy(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_returndatacopy(const instr_info* instr, execution_state& state) noexcept
 {
     const auto mem_index = state.stack.pop();
     const auto input_index = state.stack.pop();
@@ -661,16 +638,14 @@ const instr_info* op_returndatacopy(
     return ++instr;
 }
 
-const instr_info* op_extcodehash(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_extcodehash(const instr_info* instr, execution_state& state) noexcept
 {
     auto& x = state.stack.top();
     x = intx::be::load<uint256>(state.host.get_code_hash(intx::be::trunc<evmc::address>(x)));
     return ++instr;
 }
 
-const instr_info* op_blockhash(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_blockhash(const instr_info* instr, execution_state& state) noexcept
 {
     auto& number = state.stack.top();
 
@@ -683,15 +658,13 @@ const instr_info* op_blockhash(
     return ++instr;
 }
 
-const instr_info* op_coinbase(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_coinbase(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_coinbase));
     return ++instr;
 }
 
-const instr_info* op_timestamp(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_timestamp(const instr_info* instr, execution_state& state) noexcept
 {
     // TODO: Add tests for negative timestamp?
     const auto timestamp = static_cast<uint64_t>(state.host.get_tx_context().block_timestamp);
@@ -699,8 +672,7 @@ const instr_info* op_timestamp(
     return ++instr;
 }
 
-const instr_info* op_number(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_number(const instr_info* instr, execution_state& state) noexcept
 {
     // TODO: Add tests for negative block number?
     const auto block_number = static_cast<uint64_t>(state.host.get_tx_context().block_number);
@@ -708,43 +680,39 @@ const instr_info* op_number(
     return ++instr;
 }
 
-const instr_info* op_difficulty(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_difficulty(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_difficulty));
     return ++instr;
 }
 
-const instr_info* op_gaslimit(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_gaslimit(const instr_info* instr, execution_state& state) noexcept
 {
     const auto block_gas_limit = static_cast<uint64_t>(state.host.get_tx_context().block_gas_limit);
     state.stack.push(block_gas_limit);
     return ++instr;
 }
 
-const instr_info* op_push_small(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_push_small(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(instr->arg.small_push_value);
     return ++instr;
 }
 
-const instr_info* op_push_full(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_push_full(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.push(*instr->arg.push_value);
     return ++instr;
 }
 
-const instr_info* op_pop(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_pop(const instr_info* instr, execution_state& state) noexcept
 {
     state.stack.pop();
     return ++instr;
 }
 
 template <evmc_opcode DupOp>
-const instr_info* op_dup(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_dup(const instr_info* instr, execution_state& state) noexcept
 {
     constexpr auto index = DupOp - OP_DUP1;
     state.stack.push(state.stack[index]);
@@ -752,7 +720,7 @@ const instr_info* op_dup(const instr_info* instr, execution_state& state, instr_
 }
 
 template <evmc_opcode SwapOp>
-const instr_info* op_swap(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_swap(const instr_info* instr, execution_state& state) noexcept
 {
     constexpr auto index = SwapOp - OP_SWAP1 + 1;
     std::swap(state.stack.top(), state.stack[index]);
@@ -788,18 +756,18 @@ const instr_info* op_log(
 }
 
 template <evmc_opcode LogOp>
-const instr_info* op_log(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_log(const instr_info* instr, execution_state& state) noexcept
 {
     constexpr auto num_topics = LogOp - OP_LOG0;
     return op_log(instr, state, num_topics);
 }
 
-const instr_info* op_invalid(const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_invalid(const instr_info*, execution_state& state) noexcept
 {
     return state.exit(EVMC_INVALID_INSTRUCTION);
 }
 
-const instr_info* op_return(const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_return(const instr_info*, execution_state& state) noexcept
 {
     auto offset = state.stack[0];
     auto size = state.stack[1];
@@ -812,7 +780,7 @@ const instr_info* op_return(const instr_info*, execution_state& state, instr_arg
     return state.exit(EVMC_SUCCESS);
 }
 
-const instr_info* op_revert(const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_revert(const instr_info*, execution_state& state) noexcept
 {
     auto offset = state.stack[0];
     auto size = state.stack[1];
@@ -825,7 +793,7 @@ const instr_info* op_revert(const instr_info*, execution_state& state, instr_arg
     return state.exit(EVMC_REVERT);
 }
 
-const instr_info* op_call(const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_call(const instr_info* instr, execution_state& state) noexcept
 {
     const auto arg = instr->arg;
     auto gas = state.stack[0];
@@ -944,8 +912,7 @@ const instr_info* op_call(const instr_info* instr, execution_state& state, instr
     return ++instr;
 }
 
-const instr_info* op_delegatecall(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_delegatecall(const instr_info* instr, execution_state& state) noexcept
 {
     const auto arg = instr->arg;
     auto gas = state.stack[0];
@@ -1014,8 +981,7 @@ const instr_info* op_delegatecall(
     return ++instr;
 }
 
-const instr_info* op_staticcall(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_staticcall(const instr_info* instr, execution_state& state) noexcept
 {
     const auto arg = instr->arg;
     auto gas = state.stack[0];
@@ -1079,8 +1045,7 @@ const instr_info* op_staticcall(
     return ++instr;
 }
 
-const instr_info* op_create(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_create(const instr_info* instr, execution_state& state) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -1139,8 +1104,7 @@ const instr_info* op_create(
     return ++instr;
 }
 
-const instr_info* op_create2(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* op_create2(const instr_info* instr, execution_state& state) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -1204,13 +1168,12 @@ const instr_info* op_create2(
     return ++instr;
 }
 
-const instr_info* op_undefined(const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_undefined(const instr_info*, execution_state& state) noexcept
 {
     return state.exit(EVMC_UNDEFINED_INSTRUCTION);
 }
 
-const instr_info* op_selfdestruct(
-    const instr_info*, execution_state& state, instr_argument) noexcept
+const instr_info* op_selfdestruct(const instr_info*, execution_state& state) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return state.exit(EVMC_STATIC_MODE_VIOLATION);
@@ -1235,8 +1198,7 @@ const instr_info* op_selfdestruct(
     return state.exit(EVMC_SUCCESS);
 }
 
-const instr_info* opx_beginblock(
-    const instr_info* instr, execution_state& state, instr_argument) noexcept
+const instr_info* opx_beginblock(const instr_info* instr, execution_state& state) noexcept
 {
     auto& block = state.analysis->blocks[static_cast<size_t>(instr->arg.p.number)];
 


### PR DESCRIPTION
This changes the signature of functions implementing instructions and the main loop. The pointer to current instructions has been removed from the state object, is now passed as an argument (rdi register) and next instruction pointer is returned from the instruction function (rax register).

```
Comparing bin/evmone-bench-master to bin/evmone-bench
Benchmark                            Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------
sha1_shifts/analysis              -0.0018         -0.0018             4             4             4             4
sha1_shifts/empty                 -0.0626         -0.0626            37            35            37            35
sha1_shifts/1351                  -0.0679         -0.0679           675           629           675           629
sha1_shifts/2737                  -0.0682         -0.0682          1312          1222          1312          1222
sha1_shifts/5311                  -0.0695         -0.0695          2559          2381          2559          2381
sha1_shifts/65536                 -0.0671         -0.0671         31088         29003         31088         29003
stop/analysis                     -0.0027         -0.0027             0             0             0             0
stop                              +0.0031         +0.0031             1             1             1             1
blake2b_huff/analysis             -0.0012         -0.0012            38            38            38            38
blake2b_huff/empty                -0.0194         -0.0194            55            54            55            54
blake2b_huff/abc                  -0.0185         -0.0185            55            54            55            54
blake2b_huff/2805nulls            -0.0653         -0.0653           386           361           386           361
blake2b_huff/2805aa               -0.0529         -0.0529           382           362           382           362
blake2b_huff/5610nulls            -0.0564         -0.0564           709           669           709           669
blake2b_huff/8415nulls            -0.0608         -0.0608          1024           961          1024           961
blake2b_huff/65536nulls           -0.0671         -0.0671          7711          7193          7711          7193
sha1_divs/analysis                +0.0040         +0.0040             4             4             4             4
sha1_divs/empty                   -0.0294         -0.0294            66            64            66            64
sha1_divs/1351                    -0.0290         -0.0290          1246          1210          1246          1210
sha1_divs/2737                    -0.0276         -0.0276          2424          2357          2424          2357
sha1_divs/5311                    -0.0315         -0.0315          4737          4588          4737          4588
sha1_divs/65536                   -0.0268         -0.0268         57453         55913         57453         55913
weierstrudel/analysis             -0.0051         -0.0051            46            46            46            46
weierstrudel/0                    -0.0330         -0.0330           295           286           295           286
weierstrudel/1                    -0.0317         -0.0317           561           543           561           543
weierstrudel/2                    -0.0345         -0.0345           706           681           706           681
weierstrudel/3                    -0.0320         -0.0320           849           821           849           821
weierstrudel/8                    -0.0341         -0.0340          1552          1499          1552          1499
weierstrudel/9                    -0.0428         -0.0427          1710          1637          1710          1637
weierstrudel/14                   -0.0341         -0.0341          2401          2319          2401          2319
blake2b_shifts/analysis           -0.0027         -0.0027            20            20            20            20
blake2b_shifts/empty              +0.0000         +0.0000             0             0             0             0
blake2b_shifts/2805nulls          -0.0665         -0.0665          3877          3619          3877          3619
blake2b_shifts/5610nulls          -0.0700         -0.0700          7980          7421          7980          7421
blake2b_shifts/8415nulls          -0.0656         -0.0657         11899         11118         11899         11118
blake2b_shifts/65536nulls         -0.0651         -0.0651         94082         87960         94083         87958
```