### PR TITLE
Update test fixture to properly handle empty code

### DIFF
--- a/test/unittests/evm_fixture.hpp
+++ b/test/unittests/evm_fixture.hpp
@@ -74,7 +74,7 @@ protected:
     /// Wrapper for evmone::execute. The result will be in the .result field.
     void execute(const evmc_message& m, bytes_view code) noexcept
     {
-        result = vm.execute(host, rev, m, &code[0], code.size());
+        result = vm.execute(host, rev, m, code.data(), code.size());
         gas_used = m.gas - result.gas_left;
     }
 };


### PR DESCRIPTION
Fix #146 

We can't dereference the bytes_view data pointer in execute() since the pointer might not be valid (for example, when empty code is supplied). Instead, we should just retrieve the pointer and pass it to the VM's "execute" implementation.