### PR TITLE
Coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ if(CABLE_COMPILER_GNULIKE)
 
     # Prepend to CXX flags to allow overriding.
     set(CMAKE_CXX_FLAGS "-fvisibility=hidden ${CMAKE_CXX_FLAGS}")
+
+    if(CABLE_COMPILER_CLANG)
+        set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")
+    endif()
+
 elseif(MSVC)
     add_compile_options(/wd4324)  # Disabled warning about alignment caused by alignas.
     add_compile_options(/wd5030)  # Allow using unknown attributes.

--- a/circle.yml
+++ b/circle.yml
@@ -175,6 +175,37 @@ jobs:
       - build
       - test
 
+  clang-latest-coverage:
+    executor: linux
+    environment:
+      CC: clang-8
+      CXX: clang++-8
+      BUILD_TYPE: Coverage
+      TESTS_FILTER: unittests
+    steps:
+      - build
+      - run:
+          name: "Run unit tests"
+          working_directory: ~/build
+          command: |
+            bin/evmone-unittests
+      - run:
+          name: "Coverage report"
+          working_directory: ~/build
+          command: |
+            mkdir ~/coverage
+            llvm-profdata-8 merge *.profraw -o evmone.profdata
+            llvm-cov-8 show lib/libevmone.so bin/evmone-unittests -Xdemangler llvm-cxxfilt-8 -instr-profile=evmone.profdata -ignore-filename-regex=include/evmc -region-coverage-lt=100 -format=html > ~/coverage/missing.html
+            llvm-cov-8 show lib/libevmone.so bin/evmone-unittests -Xdemangler llvm-cxxfilt-8 -instr-profile=evmone.profdata -ignore-filename-regex=include/evmc -format=html > ~/coverage/full.html
+
+            llvm-cov-8 report lib/libevmone.so bin/evmone-unittests -Xdemangler llvm-cxxfilt-8 -instr-profile=evmone.profdata -ignore-filename-regex=include/evmc > ~/coverage/report.txt
+            llvm-cov-8 report lib/libevmone.so bin/evmone-unittests -Xdemangler llvm-cxxfilt-8 -instr-profile=evmone.profdata -ignore-filename-regex=include/evmc -use-color
+      - store_artifacts:
+          path: ~/coverage
+          destination: coverage
+
+
+
   macos-asan:
     executor: macos
     environment:
@@ -215,4 +246,5 @@ workflows:
       - gcc-min
       - gcc-latest-coverage
       - clang-latest-ubsan
+      - clang-latest-coverage
       - macos-asan

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -32,6 +32,8 @@ inline constexpr uint64_t load64be(const unsigned char* data) noexcept
 
 code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) noexcept
 {
+    static constexpr auto stack_req_max = std::numeric_limits<int16_t>::max();
+
     const auto& op_tbl = get_op_table(rev);
     const auto opx_beginblock_fn = op_tbl[OPX_BEGINBLOCK].fn;
 
@@ -147,9 +149,9 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
         if (is_terminator || (code_pos != code_end && *code_pos == OP_JUMPDEST))
         {
             // Save current block.
-            const auto stack_req = block.stack_req <= std::numeric_limits<int16_t>::max() ?
+            const auto stack_req = block.stack_req <= stack_req_max ?
                                        static_cast<int16_t>(block.stack_req) :
-                                       std::numeric_limits<int16_t>::max();
+                                       stack_req_max;
             const auto stack_max_growth = static_cast<int16_t>(block.stack_max_growth);
             analysis.instrs[block.begin_block_index].arg.block = {
                 block.gas_cost, stack_req, stack_max_growth};
@@ -162,9 +164,8 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
     }
 
     // Save current block.
-    const auto stack_req = block.stack_req <= std::numeric_limits<int16_t>::max() ?
-                               static_cast<int16_t>(block.stack_req) :
-                               std::numeric_limits<int16_t>::max();
+    const auto stack_req =
+        block.stack_req <= stack_req_max ? static_cast<int16_t>(block.stack_req) : stack_req_max;
     const auto stack_max_growth = static_cast<int16_t>(block.stack_max_growth);
     analysis.instrs[block.begin_block_index].arg.block = {
         block.gas_cost, stack_req, stack_max_growth};

--- a/test/unittests/evm_other_test.cpp
+++ b/test/unittests/evm_other_test.cpp
@@ -29,6 +29,9 @@ TEST_F(evm_other, evmone_block_stack_req_overflow)
     const auto code = push(1) + 10 * OP_DUP1 + 5463 * OP_CALL;
     execute(code);
     EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
+
+    execute(code + ret_top());  // A variant with terminator.
+    EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
 }
 
 TEST_F(evm_other, loop_full_of_jumpdests)


### PR DESCRIPTION
This adds support for getting Clang based code coverage. Reports are published as CircleCI artifacts: https://circleci.com/gh/ethereum/evmone/4404#artifacts/containers/0