### PR TITLE
Make small push value parsing endianness independent

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -23,13 +23,6 @@ struct block_analysis
     explicit block_analysis(size_t index) noexcept : begin_block_index{index} {}
 };
 
-inline constexpr uint64_t load64be(const unsigned char* data) noexcept
-{
-    return uint64_t{data[7]} | (uint64_t{data[6]} << 8) | (uint64_t{data[5]} << 16) |
-           (uint64_t{data[4]} << 24) | (uint64_t{data[3]} << 32) | (uint64_t{data[2]} << 40) |
-           (uint64_t{data[1]} << 48) | (uint64_t{data[0]} << 56);
-}
-
 code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) noexcept
 {
     static constexpr auto stack_req_max = std::numeric_limits<int16_t>::max();
@@ -94,13 +87,14 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
             const auto push_size = static_cast<size_t>(opcode - OP_PUSH1) + 1;
             const auto push_end = code_pos + push_size;
 
-            uint8_t value_bytes[8]{};
-            auto insert_pos = &value_bytes[sizeof(value_bytes) - push_size];
-
-            // TODO: Consier the same endianness-specific loop as in ANY_LARGE_PUSH case.
+            uint64_t value = 0;
+            auto insert_bit_pos = (push_size - 1) * 8;
             while (code_pos < push_end && code_pos < code_end)
-                *insert_pos++ = *code_pos++;
-            instr.arg.small_push_value = load64be(value_bytes);
+            {
+                value |= uint64_t{*code_pos++} << insert_bit_pos;
+                insert_bit_pos -= 8;
+            }
+            instr.arg.small_push_value = value;
             break;
         }
 

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -85,11 +85,11 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
         case ANY_SMALL_PUSH:
         {
             const auto push_size = static_cast<size_t>(opcode - OP_PUSH1) + 1;
-            const auto push_end = code_pos + push_size;
+            const auto push_end = std::min(code_pos + push_size, code_end);
 
             uint64_t value = 0;
             auto insert_bit_pos = (push_size - 1) * 8;
-            while (code_pos < push_end && code_pos < code_end)
+            while (code_pos < push_end)
             {
                 value |= uint64_t{*code_pos++} << insert_bit_pos;
                 insert_bit_pos -= 8;

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -91,7 +91,7 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
 
         case ANY_SMALL_PUSH:
         {
-            const auto push_size = size_t(opcode - OP_PUSH1 + 1);
+            const auto push_size = static_cast<size_t>(opcode - OP_PUSH1) + 1;
             const auto push_end = code_pos + push_size;
 
             uint8_t value_bytes[8]{};
@@ -106,7 +106,7 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
 
         case ANY_LARGE_PUSH:
         {
-            const auto push_size = size_t(opcode - OP_PUSH1 + 1);
+            const auto push_size = static_cast<size_t>(opcode - OP_PUSH1) + 1;
             const auto push_end = code_pos + push_size;
 
             auto& push_value = analysis.push_values.emplace_back();


### PR DESCRIPTION
This also makes it faster.

Skylake Mobile:
```
Comparing bin/evmone-bench-master to bin/evmone-bench
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
blake2b_huff/analysis                           -0.1002         -0.1002            28            25            28            25
blake2b_shifts/analysis                         -0.2091         -0.2090            15            12            15            12
sha1_divs/analysis                              -0.0715         -0.0714             3             3             3             3
sha1_shifts/analysis                            -0.1620         -0.1620             3             2             3             2
weierstrudel/analysis                           -0.1195         -0.1195            34            30            34            30
micro/loop_with_many_jumpdests/analysis         +0.0189         +0.0190           113           115           113           115
```

Haswell:
```
Comparing bin/evmone-bench-master to bin/evmone-bench
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
blake2b_huff/analysis                           -0.1524         -0.1523            30            25            30            25
blake2b_shifts/analysis                         -0.2739         -0.2739            16            12            16            12
sha1_divs/analysis                              -0.1160         -0.1160             3             3             3             3
sha1_shifts/analysis                            -0.1585         -0.1586             3             2             3             2
weierstrudel/analysis                           -0.1736         -0.1735            35            29            35            29
micro/loop_with_many_jumpdests/analysis         -0.0195         -0.0195           110           108           110           108
```