### PR TITLE
fuzzer: Correct the LICENSE

### DIFF
--- a/test/fuzzer/CMakeLists.txt
+++ b/test/fuzzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# evmone: Fast Ethereum Virtual Machine implementation
+# evmone-fuzzer: LibFuzzer based testing tool for EVMC-compatible EVM implementations.
 # Copyright 2019 The evmone Authors.
 # Licensed under the Apache License, Version 2.0.
 include(ExternalProject)

--- a/test/fuzzer/README.md
+++ b/test/fuzzer/README.md
@@ -1,0 +1,21 @@
+# evmone-fuzzer
+
+> [LibFuzzer] powered testing tool for [EVMC]-compatible EVM implementations.
+
+## License
+
+The evmone-fuzzer source code is licensed under the [Apache License, Version 2.0].
+
+### Exceptions
+
+Depending on build system options selected, 
+the [aleth-interpreter][Aleth] is statically _linked to_ the evmone-fuzzer executable.
+The [Aleth] project is licensed under [GNU General Public License, Version 3] therefore 
+the final evmone-fuzzer binary is also licensed under [GNU General Public License, Version 3].
+
+[Aleth]: https://github.com/ethereum/aleth
+[Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0.txt
+[EVMC]: https://github.com/ethereum/evmc
+[evmone]: https://github.com/ethereum/evmone
+[GNU General Public License, Version 3]: LICENSE
+[LibFuzzer]: https://llvm.org/docs/LibFuzzer.html

--- a/test/fuzzer/fuzzer.cpp
+++ b/test/fuzzer/fuzzer.cpp
@@ -1,14 +1,11 @@
-// evmone: Fast Ethereum Virtual Machine implementation
-// Copyright 2019 Pawel Bylica.
+// evmone-fuzzer: LibFuzzer based testing tool for EVMC-compatible EVM implementations.
+// Copyright 2019 The evmone Authors.
 // Licensed under the Apache License, Version 2.0.
 
 #include <evmone/evmone.h>
-
-#include <evmc/instructions.h>
 #include <test/utils/bytecode.hpp>
 #include <test/utils/host_mock.hpp>
 #include <test/utils/utils.hpp>
-#include <algorithm>
 #include <cstring>
 #include <iostream>
 


### PR DESCRIPTION
Change the license of evmone-fuzzer from Apache 2.0 to GPL 3.0.
This is required because evmone-fuzzer "links to" aleth-interpreter (GPL 3.0).