### PR TITLE
tests: Extend the stack_underflow unit test

### DIFF
--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -42,7 +42,10 @@ TEST_F(evm, push_implicit_data)
 
 TEST_F(evm, stack_underflow)
 {
-    execute(13, push("01") + OP_POP + push("01") + OP_POP + OP_POP);
+    execute(13, push(1) + OP_POP + push(1) + OP_POP + OP_POP);
+    EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
+
+    execute(OP_NOT);
     EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
 }
 


### PR DESCRIPTION
This originally was to simplify some of the stack requirements preprocessing, but the change was incorrect. A unit test was added to show I was wrong. 