### PR TITLE
Add 32-bit gcc support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -159,6 +159,18 @@ jobs:
           command: |
             codecov --required --gcov-exec "$GCOV" --gcov-root ~/build
 
+  gcc-32bit:
+    executor: linux
+    environment:
+      CMAKE_OPTIONS: -DTOOLCHAIN=cxx17-32bit
+    steps:
+      - run:
+          name: "Install GCC 32-bit"
+          command: |
+            sudo apt -q update && sudo apt -qy install g++-multilib
+      - build
+      - test
+
   clang-latest-ubsan:
     executor: linux
     environment:
@@ -247,3 +259,4 @@ workflows:
       - clang-latest-ubsan
       - clang-latest-coverage
       - macos-asan
+      - gcc-32bit


### PR DESCRIPTION
Related to #192 
I added 32-bit build to circle.yml as given in [https://github.com/ethereum/evmc/blob/master/circle.yml#L149-L158](https://github.com/ethereum/evmc/blob/master/circle.yml#L149-L158), with some differences. I built it using `cmake .. -DEVMONE_TESTING=ON` command, followed by `cmake --build . -- -j` and then ran `bin/evmone-unittests` to test it.
No error/warnings were seen during the execution of these three commands. Have I tested it correctly? 