### PR TITLE
Fix jumpdest offset overflow

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -61,9 +61,9 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
         {
             // The JUMPDEST is always the first instruction in the block.
             // We don't have to insert anything to the instruction table.
-            analysis.jumpdest_offsets.emplace_back(static_cast<int16_t>(code_pos - code - 1));
+            analysis.jumpdest_offsets.emplace_back(static_cast<int32_t>(code_pos - code - 1));
             analysis.jumpdest_targets.emplace_back(
-                static_cast<int16_t>(analysis.instrs.size() - 1));
+                static_cast<int32_t>(analysis.instrs.size() - 1));
         }
         else
             analysis.instrs.emplace_back(opcode_info.fn);

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -199,12 +199,12 @@ struct code_analysis
     /// The offsets of JUMPDESTs in the original code.
     /// These are values that JUMP/JUMPI receives as an argument.
     /// The elements are sorted.
-    std::vector<int16_t> jumpdest_offsets;
+    std::vector<int32_t> jumpdest_offsets;
 
     /// The indexes of the instructions in the generated instruction table
     /// matching the elements from jumdest_offsets.
     /// This is value to which the next instruction pointer must be set in JUMP/JUMPI.
-    std::vector<int16_t> jumpdest_targets;
+    std::vector<int32_t> jumpdest_targets;
 };
 
 inline int find_jumpdest(const code_analysis& analysis, int offset) noexcept

--- a/test/unittests/evm_other_test.cpp
+++ b/test/unittests/evm_other_test.cpp
@@ -8,6 +8,7 @@
 /// - evmone's internal tests.
 
 #include "evm_fixture.hpp"
+
 #include <evmone/limits.hpp>
 
 using evm_other = evm;
@@ -55,4 +56,16 @@ TEST_F(evm_other, loop_full_of_jumpdests)
 
     execute(code);
     EXPECT_GAS_USED(EVMC_SUCCESS, 7987882);
+}
+
+TEST_F(evm_other, jumpdest_with_high_offset)
+{
+    for (auto offset : {3u, 16383u, 16384u, 32767u, 32768u, 65535u, 65536u})
+    {
+        auto code = push(offset) + OP_JUMP;
+        code.resize(offset, OP_INVALID);
+        code.push_back(OP_JUMPDEST);
+        execute(code);
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS) << "JUMPDEST at " << offset;
+    }
 }

--- a/test/utils/dump.cpp
+++ b/test/utils/dump.cpp
@@ -37,7 +37,7 @@ void dump(const evmone::code_analysis& analysis)
                     if (static_cast<size_t>(analysis.jumpdest_targets[t]) == index)
                         return analysis.jumpdest_offsets[t];
                 }
-                return int16_t{-1};
+                return int32_t{-1};
             };
 
             std::cout << "┌ ";


### PR DESCRIPTION
This mostly affects the performance of the analysis, but I think this change must land. Is much better if we are not restricted by the code size in general (i.e. evmone works for any code size).

This do not fix all the issues. There are other case not related to the jumpdest where overflow can happen. That is to be fixed in other PRs.

```
Comparing bin/evmone-bench-master to bin/evmone-bench
Benchmark                                          Time             CPU      Time Old      Time New       CPU Old       CPU New
-------------------------------------------------------------------------------------------------------------------------------
blake2b_huff/analysis                           +0.0051         +0.0051            26            26            26            26
blake2b_huff/empty                              +0.0063         +0.0062            39            40            39            40
blake2b_huff/2805nulls                          +0.0120         +0.0120           286           290           286           290
blake2b_huff/5610nulls                          +0.0127         +0.0127           533           540           533           540
blake2b_huff/8415nulls                          +0.0210         +0.0210           768           784           768           784
blake2b_huff/65536nulls                         +0.0212         +0.0212          5764          5886          5764          5886
blake2b_shifts/analysis                         +0.0439         +0.0439            12            12            12            12
blake2b_shifts/2805nulls                        +0.0110         +0.0110          2994          3027          2994          3027
blake2b_shifts/5610nulls                        +0.0102         +0.0102          5984          6045          5984          6045
blake2b_shifts/8415nulls                        +0.0089         +0.0089          8962          9041          8962          9041
blake2b_shifts/65536nulls                       +0.0092         +0.0093         69950         70597         69949         70598
sha1_divs/analysis                              +0.0582         +0.0582             3             3             3             3
sha1_divs/empty                                 +0.0139         +0.0139            55            55            55            55
sha1_divs/1351                                  +0.0079         +0.0079          1047          1055          1047          1055
sha1_divs/2737                                  +0.0074         +0.0075          2037          2052          2037          2052
sha1_divs/5311                                  -0.0223         -0.0223          4086          3994          4086          3994
sha1_divs/65536                                 +0.0053         +0.0053         48306         48560         48307         48561
sha1_shifts/analysis                            +0.0508         +0.0508             3             3             3             3
sha1_shifts/empty                               +0.0003         +0.0003            31            31            31            31
sha1_shifts/1351                                -0.0096         -0.0097           583           578           583           578
sha1_shifts/2737                                -0.0102         -0.0102          1132          1120          1132          1120
sha1_shifts/5311                                -0.0080         -0.0080          2206          2188          2206          2188
sha1_shifts/65536                               -0.0107         -0.0107         26842         26554         26842         26555
weierstrudel/analysis                           +0.0811         +0.0811            30            32            30            32
weierstrudel/0                                  +0.0149         +0.0149           248           251           248           251
weierstrudel/1                                  +0.0082         +0.0082           474           478           474           478
weierstrudel/3                                  +0.0078         +0.0078           721           727           721           727
weierstrudel/9                                  +0.0050         +0.0050          1451          1458          1451          1458
weierstrudel/14                                 +0.0044         +0.0044          2060          2069          2060          2069
micro/loop_with_many_jumpdests/analysis         +0.0706         +0.0706           115           124           115           124
micro/loop_with_many_jumpdests                  +0.0051         +0.0051         13044         13110         13044         13111
```