### PR TITLE
Fix block gas cost overflow

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -8,6 +8,14 @@
 
 namespace evmone
 {
+/// Clamps x to the max value of To type.
+template <typename To, typename T>
+inline constexpr To clamp(T x) noexcept
+{
+    constexpr auto max = std::numeric_limits<To>::max();
+    return x <= max ? static_cast<To>(x) : max;
+}
+
 struct block_analysis
 {
     int64_t gas_cost = 0;
@@ -25,19 +33,9 @@ struct block_analysis
     /// Close the current block by producing compressed information about the block.
     [[nodiscard]] block_info close() const noexcept
     {
-        using gas_cost_type = decltype(block_info{}.gas_cost);
-        static constexpr auto gas_cost_max = std::numeric_limits<gas_cost_type>::max();
-        static constexpr auto stack_param_max = std::numeric_limits<int16_t>::max();
-
-
-        const auto final_gas_cost =
-            gas_cost <= gas_cost_max ? static_cast<gas_cost_type>(gas_cost) : gas_cost_max;
-        const auto final_stack_req =
-            stack_req <= stack_param_max ? static_cast<int16_t>(stack_req) : stack_param_max;
-        const auto final_stack_max_growth = stack_max_growth <= stack_param_max ?
-                                                static_cast<int16_t>(stack_max_growth) :
-                                                stack_param_max;
-        return {final_gas_cost, final_stack_req, final_stack_max_growth};
+        return {clamp<decltype(block_info{}.gas_cost)>(gas_cost),
+            clamp<decltype(block_info{}.stack_req)>(stack_req),
+            clamp<decltype(block_info{}.stack_max_growth)>(stack_max_growth)};
     }
 };
 

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -10,7 +10,7 @@ namespace evmone
 {
 struct block_analysis
 {
-    int gas_cost = 0;
+    int64_t gas_cost = 0;
 
     int stack_req = 0;
     int stack_max_growth = 0;
@@ -25,14 +25,19 @@ struct block_analysis
     /// Close the current block by producing compressed information about the block.
     [[nodiscard]] block_info close() const noexcept
     {
+        using gas_cost_type = decltype(block_info{}.gas_cost);
+        static constexpr auto gas_cost_max = std::numeric_limits<gas_cost_type>::max();
         static constexpr auto stack_param_max = std::numeric_limits<int16_t>::max();
 
+
+        const auto final_gas_cost =
+            gas_cost <= gas_cost_max ? static_cast<gas_cost_type>(gas_cost) : gas_cost_max;
         const auto final_stack_req =
             stack_req <= stack_param_max ? static_cast<int16_t>(stack_req) : stack_param_max;
         const auto final_stack_max_growth = stack_max_growth <= stack_param_max ?
                                                 static_cast<int16_t>(stack_max_growth) :
                                                 stack_param_max;
-        return {gas_cost, final_stack_req, final_stack_max_growth};
+        return {final_gas_cost, final_stack_req, final_stack_max_growth};
     }
 };
 

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -147,7 +147,7 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
             break;
 
         case OP_PC:
-            instr.arg.number = static_cast<int>(code_pos - code - 1);
+            instr.arg.number = code_pos - code - 1;
             break;
         }
 

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -146,7 +146,7 @@ struct execution_state
 
 union instruction_argument
 {
-    int number;
+    int64_t number;
     const intx::uint256* push_value;
     uint64_t small_push_value;
     block_info block{};

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -89,7 +89,7 @@ struct block_info
 {
     /// The total base gas cost of all instructions in the block.
     /// This cannot overflow, see the static_assert() below.
-    int32_t gas_cost = 0;
+    uint32_t gas_cost = 0;
 
     static_assert(
         max_code_size * max_instruction_base_cost < std::numeric_limits<decltype(gas_cost)>::max(),
@@ -122,9 +122,8 @@ struct execution_state
 
     /// The gas cost of the current block.
     ///
-    /// This is only needed to correctly calculate remaining gas for GAS instruction.
-    /// TODO: Maybe this should be precomputed in analysis.
-    int32_t current_block_cost = 0;
+    /// This is only needed to correctly calculate the "current gas left" value.
+    uint32_t current_block_cost = 0;
 
     struct code_analysis* analysis = nullptr;
     bytes return_data;

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -30,7 +30,7 @@ TEST(analysis, example1)
     EXPECT_EQ(analysis.instrs[7].fn, op_tbl[OP_STOP].fn);
 
     const auto& block = analysis.instrs[0].arg.block;
-    EXPECT_EQ(block.gas_cost, 14);
+    EXPECT_EQ(block.gas_cost, 14u);
     EXPECT_EQ(block.stack_req, 0);
     EXPECT_EQ(block.stack_max_growth, 2);
 }
@@ -48,7 +48,7 @@ TEST(analysis, stack_up_and_down)
     EXPECT_EQ(analysis.instrs[18].fn, op_tbl[OP_PUSH1].fn);
 
     const auto& block = analysis.instrs[0].arg.block;
-    EXPECT_EQ(block.gas_cost, 7 * 3 + 10 * 2 + 3);
+    EXPECT_EQ(block.gas_cost, uint32_t{7 * 3 + 10 * 2 + 3});
     EXPECT_EQ(block.stack_req, 3);
     EXPECT_EQ(block.stack_max_growth, 7);
 }


### PR DESCRIPTION
This avoids overflow when calculating a block gas cost using saturation to `UINT_MAX`. To reach the limit you now need a block of 400k instructions and 4G of gas.