### PR TITLE
utils: Cleanups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,7 @@ BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: false
 ColumnLimit:     100
 ConstructorInitializerIndentWidth: 2
+IncludeBlocks: Preserve
 IncludeCategories:
   - Regex:           '^".*'
     Priority:        1

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -89,8 +89,7 @@ struct benchmark_case
                 auto output = bytes_view{r.output_data, r.output_size};
                 if (output != expected_output)
                 {
-                    auto error =
-                        "got: " + to_hex(output) + "  expected: " + to_hex(expected_output);
+                    auto error = "got: " + hex(output) + "  expected: " + hex(expected_output);
                     state.SkipWithError(error.c_str());
                     return;
                 }

--- a/test/fuzzer/fuzzer.cpp
+++ b/test/fuzzer/fuzzer.cpp
@@ -15,17 +15,17 @@ constexpr auto latest_rev = EVMC_ISTANBUL;
 
 inline std::ostream& operator<<(std::ostream& os, const evmc_address& addr)
 {
-    return os << to_hex({addr.bytes, sizeof(addr.bytes)});
+    return os << hex({addr.bytes, sizeof(addr.bytes)});
 }
 
 inline std::ostream& operator<<(std::ostream& os, const evmc_bytes32& v)
 {
-    return os << to_hex({v.bytes, sizeof(v.bytes)});
+    return os << hex({v.bytes, sizeof(v.bytes)});
 }
 
 inline std::ostream& operator<<(std::ostream& os, const bytes_view& v)
 {
-    return os << to_hex(v);
+    return os << hex(v);
 }
 
 [[clang::always_inline]] inline void assert_true(
@@ -294,7 +294,7 @@ fuzz_input populate_input(const uint8_t* data, size_t data_size) noexcept
 
 inline auto hex(const evmc_address& addr) noexcept
 {
-    return to_hex({addr.bytes, sizeof(addr)});
+    return hex({addr.bytes, sizeof(addr)});
 }
 
 inline evmc_status_code check_and_normalize(evmc_status_code status) noexcept
@@ -318,9 +318,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t data_size) noe
     {
         std::cout << "rev: " << int{in.rev} << "\n";
         std::cout << "depth: " << int{in.msg.depth} << "\n";
-        std::cout << "code: " << to_hex(code) << "\n";
+        std::cout << "code: " << hex(code) << "\n";
         std::cout << "decoded: " << decode(code, in.rev) << "\n";
-        std::cout << "input: " << to_hex({in.msg.input_data, in.msg.input_size}) << "\n";
+        std::cout << "input: " << hex({in.msg.input_data, in.msg.input_size}) << "\n";
         std::cout << "account: " << hex(in.msg.destination) << "\n";
         std::cout << "caller: " << hex(in.msg.sender) << "\n";
         std::cout << "value: " << in.msg.value << "\n";

--- a/test/unittests/bytecode_test.cpp
+++ b/test/unittests/bytecode_test.cpp
@@ -8,7 +8,7 @@
 TEST(bytecode, push)
 {
     auto code = push("0102") + OP_POP + push("010203040506070809") + "50";
-    EXPECT_EQ(to_hex(code), "610102506801020304050607080950");
+    EXPECT_EQ(hex(code), "610102506801020304050607080950");
 
     EXPECT_THROW(push(""), std::invalid_argument);
     auto data = bytes(33, '\x00');

--- a/test/unittests/evm_calls_test.cpp
+++ b/test/unittests/evm_calls_test.cpp
@@ -496,7 +496,7 @@ TEST_F(evm_calls, staticcall_input)
     const auto& call_msg = host.recorded_calls.back();
     EXPECT_EQ(call_msg.gas, 0xee);
     EXPECT_EQ(call_msg.input_size, 3);
-    EXPECT_EQ(to_hex(bytes_view(call_msg.input_data, call_msg.input_size)), "010203");
+    EXPECT_EQ(hex(bytes_view(call_msg.input_data, call_msg.input_size)), "010203");
 }
 
 TEST_F(evm_calls, call_with_value_low_gas)

--- a/test/unittests/evm_fixture.hpp
+++ b/test/unittests/evm_fixture.hpp
@@ -22,10 +22,10 @@
     EXPECT_EQ(result.status_code, STATUS_CODE); \
     EXPECT_EQ(gas_used, GAS_USED)
 
-#define EXPECT_OUTPUT_INT(X)                                    \
-    ASSERT_EQ(result.output_size, sizeof(intx::uint256));       \
-    EXPECT_EQ(to_hex({result.output_data, result.output_size}), \
-        to_hex({intx::be::store<evmc_bytes32>(intx::uint256{X}).bytes, sizeof(evmc_bytes32)}))
+#define EXPECT_OUTPUT_INT(X)                                 \
+    ASSERT_EQ(result.output_size, sizeof(intx::uint256));    \
+    EXPECT_EQ(hex({result.output_data, result.output_size}), \
+        hex({intx::be::store<evmc_bytes32>(intx::uint256{X}).bytes, sizeof(evmc_bytes32)}))
 
 /// The "evm" test fixture with generic unit tests for EVMC-compatible VM implementations.
 class evm : public testing::Test

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -600,7 +600,7 @@ TEST_F(evm, sha3_empty)
     execute(code);
     ASSERT_EQ(result.output_size, 32);
     auto keccak256_empty = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
-    EXPECT_EQ(to_hex({result.output_data, result.output_size}), keccak256_empty);
+    EXPECT_EQ(hex({result.output_data, result.output_size}), keccak256_empty);
 }
 
 TEST_F(evm, revert)
@@ -857,7 +857,7 @@ TEST_F(evm, reverse_16_stack_items)
 
     EXPECT_STATUS(EVMC_SUCCESS);
     ASSERT_EQ(result.output_size, n);
-    EXPECT_EQ(to_hex({result.output_data, result.output_size}), "0102030405060708090a0b0c0d0e0f10");
+    EXPECT_EQ(hex({result.output_data, result.output_size}), "0102030405060708090a0b0c0d0e0f10");
 }
 
 struct memory_access_opcode

--- a/test/unittests/utils_test.cpp
+++ b/test/unittests/utils_test.cpp
@@ -5,10 +5,10 @@
 #include <gtest/gtest.h>
 #include <test/utils/utils.hpp>
 
-TEST(utils, to_hex)
+TEST(utils, hex)
 {
     auto data = bytes{0x0, 0x1, 0xa, 0xf, 0x1f, 0xa0, 0xff, 0xf0};
-    EXPECT_EQ(to_hex(data), "00010a0f1fa0fff0");
+    EXPECT_EQ(hex(data), "00010a0f1fa0fff0");
 }
 
 TEST(utils, from_hex_empty)
@@ -41,18 +41,18 @@ TEST(utils, hex_byte)
 
 TEST(utils, from_hexx)
 {
-    EXPECT_EQ(to_hex(from_hexx("")), "");
+    EXPECT_EQ(hex(from_hexx("")), "");
 
-    EXPECT_EQ(to_hex(from_hexx("(0xca)")), "");
-    EXPECT_EQ(to_hex(from_hexx("(1xca)")), "ca");
-    EXPECT_EQ(to_hex(from_hexx("(5xca)")), "cacacacaca");
+    EXPECT_EQ(hex(from_hexx("(0xca)")), "");
+    EXPECT_EQ(hex(from_hexx("(1xca)")), "ca");
+    EXPECT_EQ(hex(from_hexx("(5xca)")), "cacacacaca");
 
-    EXPECT_EQ(to_hex(from_hexx("01(0x3a)02")), "0102");
-    EXPECT_EQ(to_hex(from_hexx("01(1x3a)02")), "013a02");
-    EXPECT_EQ(to_hex(from_hexx("01(2x3a)02")), "013a3a02");
+    EXPECT_EQ(hex(from_hexx("01(0x3a)02")), "0102");
+    EXPECT_EQ(hex(from_hexx("01(1x3a)02")), "013a02");
+    EXPECT_EQ(hex(from_hexx("01(2x3a)02")), "013a3a02");
 
-    EXPECT_EQ(to_hex(from_hexx("01(2x333)02(2x4444)03")), "01333333024444444403");
-    EXPECT_EQ(to_hex(from_hexx("01(4x333)02(4x4)03")), "0133333333333302444403");
+    EXPECT_EQ(hex(from_hexx("01(2x333)02(2x4444)03")), "01333333024444444403");
+    EXPECT_EQ(hex(from_hexx("01(4x333)02(4x4)03")), "0133333333333302444403");
 
-    EXPECT_EQ(to_hex(from_hexx("00")), "00");
+    EXPECT_EQ(hex(from_hexx("00")), "00");
 }

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -44,7 +44,7 @@ inline bool operator==(const bytecode& a, const bytecode& b) noexcept
 
 inline std::ostream& operator<<(std::ostream& os, const bytecode& c)
 {
-    return os << to_hex(c);
+    return os << hex(c);
 }
 
 inline bytecode operator*(int n, bytecode c)
@@ -300,7 +300,7 @@ inline std::string decode(bytes_view bytecode, evmc_revision rev)
                         static_cast<std::size_t>(bytecode.end() - push_data_start));
                 if (push_data_size != 0)
                 {
-                    s += " + \"" + to_hex({&*push_data_start, push_data_size}) + '"';
+                    s += " + \"" + hex({&*push_data_start, push_data_size}) + '"';
                     it += push_data_size;
                 }
             }

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -3,6 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 #pragma once
 
+#include <evmc/instructions.h>
 #include <test/utils/utils.hpp>
 #include <algorithm>
 

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -3,10 +3,8 @@
 // Licensed under the Apache License, Version 2.0.
 
 #include <test/utils/utils.hpp>
-
-#include <iomanip>
-#include <iostream>
 #include <regex>
+#include <stdexcept>
 
 bytes from_hex(std::string_view hex)
 {

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -12,10 +12,11 @@ bytes from_hex(std::string_view hex)
         throw std::length_error{"the length of the input is odd"};
 
     bytes bs;
+    bs.reserve(hex.length() / 2);
     int b = 0;
     for (size_t i = 0; i < hex.size(); ++i)
     {
-        auto h = hex[i];
+        const auto h = hex[i];
         int v;
         if (h >= '0' && h <= '9')
             v = h - '0';

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -35,7 +35,7 @@ bytes from_hex(std::string_view hex)
     return bs;
 }
 
-std::string to_hex(bytes_view bs)
+std::string hex(bytes_view bs)
 {
     std::string str;
     str.reserve(bs.size() * 2);

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -17,7 +17,7 @@ inline std::string hex(uint8_t b) noexcept
 }
 
 bytes from_hex(std::string_view hex);
-std::string to_hex(bytes_view bytes);
+std::string hex(bytes_view bs);
 
 /// Decodes the hexx encoded string.
 ///

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -3,9 +3,7 @@
 // Licensed under the Apache License, Version 2.0.
 #pragma once
 
-#include <evmc/instructions.h>
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 
 using bytes = std::basic_string<uint8_t>;

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -16,7 +16,14 @@ inline std::string hex(uint8_t b) noexcept
     return {hex_chars[b >> 4], hex_chars[b & 0xf]};
 }
 
+/// Decodes hex encoded string to bytes.
+///
+/// Exceptions:
+/// - std::length_error when the input has invalid length (must be even).
+/// - std::out_of_range when invalid hex digit encountered.
 bytes from_hex(std::string_view hex);
+
+/// Encodes bytes as hex string.
 std::string hex(bytes_view bs);
 
 /// Decodes the hexx encoded string.


### PR DESCRIPTION
- Clean ups #includes in utils
- Preallocates bytes buffer.
- Renames `to_hex()` to `hex()` (last commit, so can be reviewed separately).