### PR TITLE
ci: Drop -DNATIVE=ON for Windows builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 
+## [0.4.1] — unreleased
+
+### Fixed
+
+- The release binaries for Windows are now built without AVX instruction set
+  enabled. That was never intended and is consistent with binaries for other 
+  operating systems.
+  [#230](https://github.com/ethereum/evmone/pull/230)
+
 ## [0.4.0] — 2019-12-09
 
 ### Fixed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 
 before_build:
   - call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=amd64
-  - cmake -S . -B build -DEVMONE_TESTING=ON -DNATIVE=ON -Wno-dev -G "%GENERATOR%" -DCMAKE_INSTALL_PREFIX=C:\install
+  - cmake -S . -B build -DEVMONE_TESTING=ON -Wno-dev -G "%GENERATOR%" -DCMAKE_INSTALL_PREFIX=C:\install
 
 build_script:
   - cmake --build build --target package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,10 @@ build_script:
   - mkdir package
   - mv build/evmone-* package
 
+artifacts:
+  - path: package/*
+    name: package
+
 test_script:
   - cd build && ctest -j4 --output-on-failure --schedule-random
 


### PR DESCRIPTION
NATIVE=ON for MSVC enables AVX instruction set. This make Windows release binaries unusable on CPUs not having AVX.