### PR TITLE
Shortcut for 2^e

### DIFF
--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -160,8 +160,10 @@ const instruction* op_exp(const instruction* instr, execution_state& state) noex
         auto exp_bytes = as_bytes(exponent);
         uint8_t bit_to_set = exp_bytes[0];
         exp_bytes[0] = 0;
-        exp_bytes[bit_to_set>>3] = uint8_t(uint8_t(1) << (bit_to_set&7));
-    } else {
+        exp_bytes[bit_to_set >> 3] = uint8_t(uint8_t(1) << (bit_to_set & 7));
+    }
+    else
+    {
         exponent = intx::exp(base, exponent);
     }
     return ++instr;

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -155,7 +155,15 @@ const instruction* op_exp(const instruction* instr, execution_state& state) noex
     if ((state.gas_left -= additional_cost) < 0)
         return state.exit(EVMC_OUT_OF_GAS);
 
-    exponent = intx::exp(base, exponent);
+    if (base == 2 && exponent < 256)
+    {
+        auto exp_bytes = as_bytes(exponent);
+        uint8_t bit_to_set = exp_bytes[0];
+        exp_bytes[0] = 0;
+        exp_bytes[bit_to_set>>3] = uint8_t(uint8_t(1) << (bit_to_set&7));
+    } else {
+        exponent = intx::exp(base, exponent);
+    }
     return ++instr;
 }
 


### PR DESCRIPTION
There are a lot of contracts on the Ethereum mainnet that were compiled with Solidity prior to the shifting operations were available. For those, exponentiation 2^160 is used to emulate 1<<160. Measurements performed on turbo-geth confirm this. Since we are planning to integrate evmone into turbo-geth, and we have already implemented this shortcut (ledgerwatch/turbo-geth#505), it would be good to maintain that in evmone.

For https://github.com/ethereum/evmone/issues/231