### PR TITLE
CREATE(2) should only populate return data on failure

### DIFF
--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -340,9 +340,16 @@ const instruction* op_create(const instruction* instr, execution_state& state) n
     msg.value = intx::be::store<evmc::uint256be>(endowment);
 
     auto result = state.host.call(msg);
-    state.return_data.assign(result.output_data, result.output_size);
+
     if (result.status_code == EVMC_SUCCESS)
+    {
         state.stack[0] = intx::be::load<uint256>(result.create_address);
+        state.return_data.clear();
+    }
+    else
+    {
+        state.return_data.assign(result.output_data, result.output_size);
+    }
 
     if ((state.gas_left -= msg.gas - result.gas_left) < 0)
         return state.exit(EVMC_OUT_OF_GAS);


### PR DESCRIPTION
According to [EIP-211](https://eips.ethereum.org/EIPS/eip-211#specification), CREATE and CREATE2 should only populate return data on failure. See also the [implementation in Go Ethereum](https://github.com/ethereum/go-ethereum/blob/master/core/vm/instructions.go#L632).