### PR TITLE
Drop Visual Studio 2017 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,34 +46,35 @@ geth --vm.evm=./libevmone.so
 ### Building from source
 To build the evmone EVMC module (shared library), test, and benchmark:
 
-1. Clone the repo and create a ```build``` directory:
-```
-git clone --recursive https://github.com/ethereum/evmone
-cd evmone
-mkdir build
-cd build
-```
+1. Fetch the source code:
+   ```
+   git clone --recursive https://github.com/ethereum/evmone
+   cd evmone
+   ```
 
-2. Build dependencies and (on Windows) generate a Visual Studio solution, then build the source:
-#### Linux / OSX
-```
-cmake .. -DEVMONE_TESTING=ON
-cmake --build . -- -j
-```
+2. Configure the project build and dependencies:
+   ##### Linux / OSX
+   ```
+   cmake -S . -B build -DEVMONE_TESTING=ON
+   ```
 
-#### Windows
-*Note: >= Visual Studio 2017 is required since EVMOne makes heavy use of C++17*
-* **Visual Studio 2017**: ```cmake .. -DEVMONE_TESTING=ON -G "Visual Studio 15 2017 Win64"```
-* **Visual Studio 2019**: ```cmake .. -DEVMONE_TESTING=ON -G "Visual Studio 16 2019" -A x64```
-```
-cmake --build .
-```
+   ##### Windows
+   *Note: >= Visual Studio 2019 is required since evmone makes heavy use of C++17*
+   ```
+   cmake -S . -B build -DEVMONE_TESTING=ON -G "Visual Studio 16 2019" -A x64
+   ```
+   
+3. Build:
+   ```
+   cmake --build build --parallel
+   ```
+
 
 3. Run the unit tests or benchmarking tool:
-```
-bin/evmone-unittests
-bin/evmone-bench
-```
+   ```
+   build/bin/evmone-unittests
+   build/bin/evmone-bench test/benchmarks
+   ```
 ### Tools
 
 #### evm-test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: "{build}"
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 branches:
   only:
@@ -14,7 +14,7 @@ environment:
   GITHUB_TOKEN:
     secure: OE3TGKRyt/hvk5Gt3DLXvs3Y+F1NLDQAL/bHplDffR+hY2aFg6HrapThKjYo/XX2
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Ninja"
 
 cache:
@@ -25,7 +25,7 @@ install:
   - git submodule update --init --recursive
 
 before_build:
-  - call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\vsdevcmd" -arch=amd64
+  - call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools\VsDevCmd" -arch=amd64
   - cmake -S . -B build -DEVMONE_TESTING=ON -Wno-dev -G "%GENERATOR%" -DCMAKE_INSTALL_PREFIX=C:\install
 
 build_script:


### PR DESCRIPTION
The Visual Studio 2017 crashes when compiling #268.