### PR TITLE
Basic opcode tracing

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(evmone
     analysis.hpp
     baseline.cpp
     baseline.hpp
-    evmone.cpp
     execution.cpp
     execution.hpp
     instruction_traits.hpp
@@ -22,6 +21,7 @@ add_library(evmone
     instructions_calls.cpp
     limits.hpp
     opcodes_helpers.h
+    vm.cpp
 )
 target_link_libraries(evmone PUBLIC evmc::evmc intx::intx PRIVATE evmc::instructions ethash::keccak)
 target_include_directories(evmone PUBLIC
@@ -42,6 +42,6 @@ if(NOT SANITIZE)
     target_link_options(evmone PRIVATE $<$<PLATFORM_ID:Linux>:LINKER:--no-undefined>)
 endif()
 
-set_source_files_properties(evmone.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
+set_source_files_properties(vm.cpp PROPERTIES COMPILE_DEFINITIONS PROJECT_VERSION="${PROJECT_VERSION}")
 
 add_standalone_library(evmone)

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -5,6 +5,7 @@
 #include "baseline.hpp"
 #include "execution_state.hpp"
 #include "instructions.hpp"
+#include "vm.hpp"
 #include <evmc/instructions.h>
 #include <memory>
 
@@ -96,15 +97,16 @@ inline evmc_status_code check_requirements(const char* const* instruction_names,
 }
 }  // namespace
 
-evmc_result execute(evmc_vm* /*vm*/, const evmc_host_interface* host, evmc_host_context* ctx,
+evmc_result execute(evmc_vm* c_vm, const evmc_host_interface* host, evmc_host_context* ctx,
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept
 {
+    auto vm = static_cast<VM*>(c_vm);
     const auto jumpdest_map = analyze(code, code_size);
     auto state = std::make_unique<ExecutionState>(*msg, rev, *host, ctx, code, code_size);
-    return execute(*state, jumpdest_map);
+    return execute(*vm, *state, jumpdest_map);
 }
 
-evmc_result execute(ExecutionState& state, const CodeAnalysis& analysis) noexcept
+evmc_result execute(const VM& /*vm*/, ExecutionState& state, const CodeAnalysis& analysis) noexcept
 {
     const auto rev = state.rev;
     const auto code = state.code.data();

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -109,9 +109,9 @@ evmc_result execute(evmc_vm* c_vm, const evmc_host_interface* host, evmc_host_co
 
 evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& analysis) noexcept
 {
-        const auto& tracer = vm.tracer;
+    auto* tracer = vm.get_tracer();
     if (tracer)
-        tracer->onBeginExecution();
+        tracer->notify_execution_start();
 
     const auto rev = state.rev;
     const auto code = state.code.data();
@@ -127,7 +127,7 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
         const auto op = *pc;
 
         if (INTX_UNLIKELY(tracer))
-            tracer->onOpcode(static_cast<evmc_opcode>(op));
+            tracer->notify_instruction_start(static_cast<evmc_opcode>(op));
 
         const auto status = check_requirements(instruction_names, instruction_metrics, state, op);
         if (status != EVMC_SUCCESS)
@@ -769,7 +769,7 @@ exit:
         (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
 
     if (tracer)
-        tracer->onEndExecution();
+        tracer->notify_execution_end();
 
     return evmc::make_result(state.status, gas_left,
         state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -7,7 +7,6 @@
 #include "instructions.hpp"
 #include "vm.hpp"
 #include <evmc/instructions.h>
-#include <evmone/evmone.h>
 #include <memory>
 
 namespace evmone::baseline
@@ -110,7 +109,7 @@ evmc_result execute(evmc_vm* c_vm, const evmc_host_interface* host, evmc_host_co
 evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& analysis) noexcept
 {
     auto* tracer = vm.get_tracer();
-    if (tracer)
+    if (INTX_UNLIKELY(tracer != nullptr))
         tracer->notify_execution_start();
 
     const auto rev = state.rev;
@@ -126,7 +125,7 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
     {
         const auto op = *pc;
 
-        if (INTX_UNLIKELY(tracer))
+        if (INTX_UNLIKELY(tracer != nullptr))
             tracer->notify_instruction_start(static_cast<evmc_opcode>(op));
 
         const auto status = check_requirements(instruction_names, instruction_metrics, state, op);
@@ -768,7 +767,7 @@ exit:
     const auto gas_left =
         (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
 
-    if (tracer)
+    if (INTX_UNLIKELY(tracer != nullptr))
         tracer->notify_execution_end();
 
     return evmc::make_result(state.status, gas_left,

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -8,7 +8,11 @@
 #include <evmc/utils.h>
 #include <vector>
 
-namespace evmone::baseline
+namespace evmone
+{
+class VM;
+
+namespace baseline
 {
 struct CodeAnalysis
 {
@@ -25,5 +29,7 @@ evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_cont
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept;
 
 /// Executes in Baseline interpreter on the given external and initialized state.
-evmc_result execute(ExecutionState& state, const CodeAnalysis& analysis) noexcept;
-}  // namespace evmone::baseline
+evmc_result execute(const VM&, ExecutionState& state, const CodeAnalysis& analysis) noexcept;
+
+}  // namespace baseline
+}  // namespace evmone

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -8,55 +8,39 @@
 
 namespace evmone
 {
-class VMTracer;
-
-class TracerListNode
+class VMTracer
 {
+    friend class VM;  // Has access the the m_next_tracer to traverse the list forward.
     std::unique_ptr<VMTracer> m_next_tracer;
 
-protected:
-    [[nodiscard]] VMTracer* get_next_tracer() const noexcept { return m_next_tracer.get(); }
-
-    inline void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept;
-};
-
-class VMTracer : public TracerListNode
-{
 public:
     virtual ~VMTracer() = default;
 
-    void notify_execution_start() noexcept
+    void notify_execution_start() noexcept  // NOLINT(misc-no-recursion)
     {
         onBeginExecution();
-        if (auto* tracer = get_next_tracer())
-            tracer->notify_execution_start();
+        if (m_next_tracer)
+            m_next_tracer->notify_execution_start();
     }
 
-    void notify_execution_end() noexcept
+    void notify_execution_end() noexcept  // NOLINT(misc-no-recursion)
     {
         onEndExecution();
-        if (auto* tracer = get_next_tracer())
-            tracer->notify_execution_end();
+        if (m_next_tracer)
+            m_next_tracer->notify_execution_end();
     }
 
-    void notify_instruction_start(evmc_opcode opcode) noexcept
+    void notify_instruction_start(evmc_opcode opcode) noexcept  // NOLINT(misc-no-recursion)
     {
         onOpcode(opcode);
-        if (auto* tracer = get_next_tracer())
-            tracer->notify_instruction_start(opcode);
+        if (m_next_tracer)
+            m_next_tracer->notify_instruction_start(opcode);
     }
 
-protected:
+private:
     virtual void onBeginExecution() noexcept = 0;
     virtual void onOpcode(evmc_opcode opcode) noexcept = 0;
     virtual void onEndExecution() noexcept = 0;
 };
 
-void TracerListNode::add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
-{
-    if (m_next_tracer)
-        m_next_tracer->add_tracer(std::move(tracer));
-    else
-        m_next_tracer = std::move(tracer);
-}
 }  // namespace evmone

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -1,0 +1,62 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/instructions.h>
+#include <memory>
+
+namespace evmone
+{
+class VMTracer;
+
+class TracerListNode
+{
+    std::unique_ptr<VMTracer> m_next_tracer;
+
+protected:
+    [[nodiscard]] VMTracer* get_next_tracer() const noexcept { return m_next_tracer.get(); }
+
+    inline void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept;
+};
+
+class VMTracer : public TracerListNode
+{
+public:
+    virtual ~VMTracer() = default;
+
+    void notify_execution_start() noexcept
+    {
+        onBeginExecution();
+        if (auto* tracer = get_next_tracer())
+            tracer->notify_execution_start();
+    }
+
+    void notify_execution_end() noexcept
+    {
+        onEndExecution();
+        if (auto* tracer = get_next_tracer())
+            tracer->notify_execution_end();
+    }
+
+    void notify_instruction_start(evmc_opcode opcode) noexcept
+    {
+        onOpcode(opcode);
+        if (auto* tracer = get_next_tracer())
+            tracer->notify_instruction_start(opcode);
+    }
+
+protected:
+    virtual void onBeginExecution() noexcept = 0;
+    virtual void onOpcode(evmc_opcode opcode) noexcept = 0;
+    virtual void onEndExecution() noexcept = 0;
+};
+
+void TracerListNode::add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
+{
+    if (m_next_tracer)
+        m_next_tracer->add_tracer(std::move(tracer));
+    else
+        m_next_tracer = std::move(tracer);
+}
+}  // namespace evmone

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// @file
-/// EVMC instance and entry point of evmone is defined here.
+/// EVMC instance (class VM) and entry point of evmone is defined here.
 
+#include "vm.hpp"
 #include "baseline.hpp"
 #include "execution.hpp"
 #include <evmone/evmone.h>
@@ -15,8 +16,8 @@ namespace
 {
 void destroy(evmc_vm* vm) noexcept
 {
-    // TODO: Mark function with [[gnu:nonnull]] or add CHECK().
-    delete vm;
+    assert(vm != nullptr);
+    delete static_cast<VM*>(vm);
 }
 
 constexpr evmc_capabilities_flagset get_capabilities(evmc_vm* /*vm*/) noexcept
@@ -42,13 +43,12 @@ evmc_set_option_result set_option(evmc_vm* vm, char const* name, char const* val
     }
     return EVMC_SET_OPTION_INVALID_NAME;
 }
-}  // namespace
-}  // namespace evmone
 
-extern "C" {
-EVMC_EXPORT evmc_vm* evmc_create_evmone() noexcept
-{
-    return new evmc_vm{
+}  // namespace
+
+
+inline constexpr VM::VM() noexcept
+  : evmc_vm{
         EVMC_ABI_VERSION,
         "evmone",
         PROJECT_VERSION,
@@ -56,6 +56,14 @@ EVMC_EXPORT evmc_vm* evmc_create_evmone() noexcept
         evmone::execute,
         evmone::get_capabilities,
         evmone::set_option,
-    };
+    }
+{}
+
+}  // namespace evmone
+
+extern "C" {
+EVMC_EXPORT evmc_vm* evmc_create_evmone() noexcept
+{
+    return new evmone::VM{};
 }
 }

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -1,10 +1,9 @@
 // evmone: Fast Ethereum Virtual Machine implementation
-// Copyright 2018-2020 The evmone Authors.
+// Copyright 2018 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
 /// @file
 /// EVMC instance and entry point of evmone is defined here.
-/// The file name matches the evmone.h public header.
 
 #include "baseline.hpp"
 #include "execution.hpp"

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -20,7 +20,7 @@ namespace evmone
 {
 namespace
 {
-struct BasicTracer : VMTracer
+class BasicTracer : public VMTracer
 {
     void onBeginExecution() noexcept final {}
 
@@ -29,7 +29,7 @@ struct BasicTracer : VMTracer
     void onEndExecution() noexcept final {}
 };
 
-struct HistogramTracer : VMTracer
+class HistogramTracer : public VMTracer
 {
     std::map<evmc_opcode, int> opcode_counter;
 

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -14,15 +14,31 @@
 #include <evmc/instructions.h>
 #include <cstdio>
 #include <cstring>
+#include <map>
 
 namespace evmone
 {
 namespace
 {
-void basic_trace(evmc_opcode opcode) noexcept
+struct BasicTracer : VMTracer
 {
-    std::puts(instr::traits[opcode].name);
-}
+    std::map<evmc_opcode, int> opcode_counter;
+
+    void onBeginExecution() noexcept final { opcode_counter.clear(); }
+
+    void onOpcode(evmc_opcode opcode) noexcept final
+    {
+        std::puts(instr::traits[opcode].name);
+        ++opcode_counter[opcode];
+    }
+
+    void onEndExecution() noexcept final
+    {
+        std::puts("\nTotal:");
+        for (const auto [opcode, count] : opcode_counter)
+            printf("%s,%d\n", instr::traits[opcode].name, count);
+    }
+};
 
 void destroy(evmc_vm* vm) noexcept
 {
@@ -35,25 +51,28 @@ constexpr evmc_capabilities_flagset get_capabilities(evmc_vm* /*vm*/) noexcept
     return EVMC_CAPABILITY_EVM1;
 }
 
-evmc_set_option_result set_option(evmc_vm* vm, char const* name, char const* value) noexcept
+evmc_set_option_result set_option(evmc_vm* c_vm, char const* name, char const* value) noexcept
 {
+    assert(c_vm != nullptr);
+    auto& vm = *static_cast<VM*>(c_vm);
+
     if (name[0] == 'O' && name[1] == '\0')
     {
         if (value[0] == '0' && value[1] == '\0')  // O=0
         {
-            vm->execute = evmone::baseline::execute;
+            vm.execute = evmone::baseline::execute;
             return EVMC_SET_OPTION_SUCCESS;
         }
         else if (value[0] == '2' && value[1] == '\0')  // O=2
         {
-            vm->execute = evmone::execute;
+            vm.execute = evmone::execute;
             return EVMC_SET_OPTION_SUCCESS;
         }
         return EVMC_SET_OPTION_INVALID_VALUE;
     }
     else if (std::strcmp(name, "trace") == 0)
     {
-        static_cast<VM*>(vm)->tracing_fn = basic_trace;
+        vm.tracer = std::make_unique<BasicTracer>();
         return EVMC_SET_OPTION_SUCCESS;
     }
     return EVMC_SET_OPTION_INVALID_NAME;

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -33,15 +33,9 @@ struct HistogramTracer : VMTracer
 {
     std::map<evmc_opcode, int> opcode_counter;
 
-    void onBeginExecution() noexcept final
-    {
-        opcode_counter.clear();
-    }
+    void onBeginExecution() noexcept final { opcode_counter.clear(); }
 
-    void onOpcode(evmc_opcode opcode) noexcept final
-    {
-        ++opcode_counter[opcode];
-    }
+    void onOpcode(evmc_opcode opcode) noexcept final { ++opcode_counter[opcode]; }
 
     void onEndExecution() noexcept final
     {

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -73,9 +73,14 @@ struct HistogramTracer : VMTracer
 
     void onEndExecution() noexcept final
     {
-        std::puts("\nTotal:");
+        std::puts("\nHistogram:");
+        int all = 0;
         for (const auto [opcode, count] : opcode_counter)
+        {
             printf("%s,%d\n", instr::traits[opcode].name, count);
+            all += count;
+        }
+        printf("all,%d\n", all);
         if (next_tracer)
             next_tracer->onEndExecution();
     }

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -22,14 +22,53 @@ namespace
 {
 struct BasicTracer : VMTracer
 {
-    std::map<evmc_opcode, int> opcode_counter;
+    std::unique_ptr<VMTracer> next_tracer;
 
-    void onBeginExecution() noexcept final { opcode_counter.clear(); }
+    BasicTracer(std::unique_ptr<VMTracer> _next_tracer = nullptr)
+      : next_tracer{std::move(_next_tracer)}
+    {}
+
+    void onBeginExecution() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onBeginExecution();
+    }
 
     void onOpcode(evmc_opcode opcode) noexcept final
     {
         std::puts(instr::traits[opcode].name);
+        if (next_tracer)
+            next_tracer->onOpcode(opcode);
+    }
+
+    void onEndExecution() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onEndExecution();
+    }
+};
+
+struct HistogramTracer : VMTracer
+{
+    std::unique_ptr<VMTracer> next_tracer;
+    std::map<evmc_opcode, int> opcode_counter;
+
+    HistogramTracer(std::unique_ptr<VMTracer> _next_tracer = nullptr)
+      : next_tracer{std::move(_next_tracer)}
+    {}
+
+    void onBeginExecution() noexcept final
+    {
+        opcode_counter.clear();
+        if (next_tracer)
+            next_tracer->onBeginExecution();
+    }
+
+    void onOpcode(evmc_opcode opcode) noexcept final
+    {
         ++opcode_counter[opcode];
+        if (next_tracer)
+            next_tracer->onOpcode(opcode);
     }
 
     void onEndExecution() noexcept final
@@ -37,6 +76,8 @@ struct BasicTracer : VMTracer
         std::puts("\nTotal:");
         for (const auto [opcode, count] : opcode_counter)
             printf("%s,%d\n", instr::traits[opcode].name, count);
+        if (next_tracer)
+            next_tracer->onEndExecution();
     }
 };
 
@@ -72,7 +113,12 @@ evmc_set_option_result set_option(evmc_vm* c_vm, char const* name, char const* v
     }
     else if (std::strcmp(name, "trace") == 0)
     {
-        vm.tracer = std::make_unique<BasicTracer>();
+        vm.tracer = std::make_unique<BasicTracer>(std::move(vm.tracer));
+        return EVMC_SET_OPTION_SUCCESS;
+    }
+    else if (std::strcmp(name, "histogram") == 0)
+    {
+        vm.tracer = std::make_unique<HistogramTracer>(std::move(vm.tracer));
         return EVMC_SET_OPTION_SUCCESS;
     }
     return EVMC_SET_OPTION_INVALID_NAME;

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -10,10 +10,20 @@
 #include "execution.hpp"
 #include <evmone/evmone.h>
 
+#include "instruction_traits.hpp"
+#include <evmc/instructions.h>
+#include <cstdio>
+#include <cstring>
+
 namespace evmone
 {
 namespace
 {
+void basic_trace(evmc_opcode opcode) noexcept
+{
+    std::puts(instr::traits[opcode].name);
+}
+
 void destroy(evmc_vm* vm) noexcept
 {
     assert(vm != nullptr);
@@ -40,6 +50,11 @@ evmc_set_option_result set_option(evmc_vm* vm, char const* name, char const* val
             return EVMC_SET_OPTION_SUCCESS;
         }
         return EVMC_SET_OPTION_INVALID_VALUE;
+    }
+    else if (std::strcmp(name, "trace") == 0)
+    {
+        static_cast<VM*>(vm)->tracing_fn = basic_trace;
+        return EVMC_SET_OPTION_SUCCESS;
     }
     return EVMC_SET_OPTION_INVALID_NAME;
 }

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -1,0 +1,16 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.h>
+
+namespace evmone
+{
+/// The evmone EVMC instance.
+class VM : public evmc_vm
+{
+public:
+    inline constexpr VM() noexcept;
+};
+}  // namespace evmone

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <evmc/evmc.h>
+#include <evmc/instructions.h>
 
 namespace evmone
 {
@@ -11,6 +12,10 @@ namespace evmone
 class VM : public evmc_vm
 {
 public:
+    using TracingFn = void (*)(evmc_opcode opcode) noexcept;
+
+    TracingFn tracing_fn = nullptr;
+
     inline constexpr VM() noexcept;
 };
 }  // namespace evmone

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -9,10 +9,43 @@
 
 namespace evmone
 {
-struct VMTracer
+class VMTracer
 {
-    virtual ~VMTracer() {}
+    std::unique_ptr<VMTracer> m_next_tracer;
 
+public:
+    virtual ~VMTracer() = default;
+
+    void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
+    {
+        if (m_next_tracer)
+            m_next_tracer->add_tracer(std::move(tracer));
+        else
+            m_next_tracer = std::move(tracer);
+    }
+
+    void notify_execution_start() noexcept
+    {
+        onBeginExecution();
+        if (m_next_tracer)
+            m_next_tracer->notify_execution_start();
+    }
+
+    void notify_execution_end() noexcept
+    {
+        onEndExecution();
+        if (m_next_tracer)
+            m_next_tracer->notify_execution_end();
+    }
+
+    void notify_instruction_start(evmc_opcode opcode) noexcept
+    {
+        onOpcode(opcode);
+        if (m_next_tracer)
+            m_next_tracer->notify_instruction_start(opcode);
+    }
+
+protected:
     virtual void onBeginExecution() noexcept = 0;
     virtual void onOpcode(evmc_opcode opcode) noexcept = 0;
     virtual void onEndExecution() noexcept = 0;
@@ -21,9 +54,19 @@ struct VMTracer
 /// The evmone EVMC instance.
 class VM : public evmc_vm
 {
-public:
-    std::unique_ptr<VMTracer> tracer;
+    std::unique_ptr<VMTracer> m_tracer;
 
+public:
     inline constexpr VM() noexcept;
+
+    [[nodiscard]] VMTracer* get_tracer() const noexcept { return m_tracer.get(); }
+
+    void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
+    {
+        if (m_tracer)
+            m_tracer->add_tracer(std::move(tracer));
+        else
+            m_tracer = std::move(tracer);
+    }
 };
 }  // namespace evmone

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -5,16 +5,24 @@
 
 #include <evmc/evmc.h>
 #include <evmc/instructions.h>
+#include <memory>
 
 namespace evmone
 {
+struct VMTracer
+{
+    virtual ~VMTracer() {}
+
+    virtual void onBeginExecution() noexcept = 0;
+    virtual void onOpcode(evmc_opcode opcode) noexcept = 0;
+    virtual void onEndExecution() noexcept = 0;
+};
+
 /// The evmone EVMC instance.
 class VM : public evmc_vm
 {
 public:
-    using TracingFn = void (*)(evmc_opcode opcode) noexcept;
-
-    TracingFn tracing_fn = nullptr;
+    std::unique_ptr<VMTracer> tracer;
 
     inline constexpr VM() noexcept;
 };

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -9,16 +9,22 @@
 namespace evmone
 {
 /// The evmone EVMC instance.
-class VM : public evmc_vm, TracerListNode
+class VM : public evmc_vm
 {
+    std::unique_ptr<VMTracer> m_first_tracer;
+
 public:
     inline constexpr VM() noexcept;
 
-    using TracerListNode::add_tracer;
-
-    [[nodiscard]] VMTracer* get_tracer() const noexcept
+    void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
     {
-        return TracerListNode::get_next_tracer();
+        // Find the first empty unique_ptr and assign the new tracer to it.
+        auto* end = &m_first_tracer;
+        while (*end)
+            end = &(*end)->m_next_tracer;
+        *end = std::move(tracer);
     }
+
+    [[nodiscard]] VMTracer* get_tracer() const noexcept { return m_first_tracer.get(); }
 };
 }  // namespace evmone

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -9,40 +9,42 @@
 
 namespace evmone
 {
-class VMTracer
+class VMTracer;
+
+class TracerListNode
 {
     std::unique_ptr<VMTracer> m_next_tracer;
 
 public:
-    virtual ~VMTracer() = default;
+    [[nodiscard]] VMTracer* get_next_tracer() const noexcept { return m_next_tracer.get(); }
 
-    void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
-    {
-        if (m_next_tracer)
-            m_next_tracer->add_tracer(std::move(tracer));
-        else
-            m_next_tracer = std::move(tracer);
-    }
+    inline void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept;
+};
+
+class VMTracer : public TracerListNode
+{
+public:
+    virtual ~VMTracer() = default;
 
     void notify_execution_start() noexcept
     {
         onBeginExecution();
-        if (m_next_tracer)
-            m_next_tracer->notify_execution_start();
+        if (auto* tracer = get_next_tracer())
+            tracer->notify_execution_start();
     }
 
     void notify_execution_end() noexcept
     {
         onEndExecution();
-        if (m_next_tracer)
-            m_next_tracer->notify_execution_end();
+        if (auto* tracer = get_next_tracer())
+            tracer->notify_execution_end();
     }
 
     void notify_instruction_start(evmc_opcode opcode) noexcept
     {
         onOpcode(opcode);
-        if (m_next_tracer)
-            m_next_tracer->notify_instruction_start(opcode);
+        if (auto* tracer = get_next_tracer())
+            tracer->notify_instruction_start(opcode);
     }
 
 protected:
@@ -51,22 +53,25 @@ protected:
     virtual void onEndExecution() noexcept = 0;
 };
 
-/// The evmone EVMC instance.
-class VM : public evmc_vm
+void TracerListNode::add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
 {
-    std::unique_ptr<VMTracer> m_tracer;
+    if (m_next_tracer)
+        m_next_tracer->add_tracer(std::move(tracer));
+    else
+        m_next_tracer = std::move(tracer);
+}
 
+/// The evmone EVMC instance.
+class VM : public evmc_vm, TracerListNode
+{
 public:
     inline constexpr VM() noexcept;
 
-    [[nodiscard]] VMTracer* get_tracer() const noexcept { return m_tracer.get(); }
+    using TracerListNode::add_tracer;
 
-    void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
+    [[nodiscard]] VMTracer* get_tracer() const noexcept
     {
-        if (m_tracer)
-            m_tracer->add_tracer(std::move(tracer));
-        else
-            m_tracer = std::move(tracer);
+        return TracerListNode::get_next_tracer();
     }
 };
 }  // namespace evmone

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -3,64 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "tracing.hpp"
 #include <evmc/evmc.h>
-#include <evmc/instructions.h>
-#include <memory>
 
 namespace evmone
 {
-class VMTracer;
-
-class TracerListNode
-{
-    std::unique_ptr<VMTracer> m_next_tracer;
-
-protected:
-    [[nodiscard]] VMTracer* get_next_tracer() const noexcept { return m_next_tracer.get(); }
-
-    inline void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept;
-};
-
-class VMTracer : public TracerListNode
-{
-public:
-    virtual ~VMTracer() = default;
-
-    void notify_execution_start() noexcept
-    {
-        onBeginExecution();
-        if (auto* tracer = get_next_tracer())
-            tracer->notify_execution_start();
-    }
-
-    void notify_execution_end() noexcept
-    {
-        onEndExecution();
-        if (auto* tracer = get_next_tracer())
-            tracer->notify_execution_end();
-    }
-
-    void notify_instruction_start(evmc_opcode opcode) noexcept
-    {
-        onOpcode(opcode);
-        if (auto* tracer = get_next_tracer())
-            tracer->notify_instruction_start(opcode);
-    }
-
-protected:
-    virtual void onBeginExecution() noexcept = 0;
-    virtual void onOpcode(evmc_opcode opcode) noexcept = 0;
-    virtual void onEndExecution() noexcept = 0;
-};
-
-void TracerListNode::add_tracer(std::unique_ptr<VMTracer> tracer) noexcept
-{
-    if (m_next_tracer)
-        m_next_tracer->add_tracer(std::move(tracer));
-    else
-        m_next_tracer = std::move(tracer);
-}
-
 /// The evmone EVMC instance.
 class VM : public evmc_vm, TracerListNode
 {

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -15,7 +15,7 @@ class TracerListNode
 {
     std::unique_ptr<VMTracer> m_next_tracer;
 
-public:
+protected:
     [[nodiscard]] VMTracer* get_next_tracer() const noexcept { return m_next_tracer.get(); }
 
     inline void add_tracer(std::unique_ptr<VMTracer> tracer) noexcept;

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(evmone-unittests
     evmone_test.cpp
     execution_state_test.cpp
     op_table_test.cpp
+    tracing_test.cpp
     utils_test.cpp
 )
 target_link_libraries(evmone-unittests PRIVATE evmone testutils evmc::instructions GTest::gtest GTest::gtest_main)

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -1,0 +1,89 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "test/utils/bytecode.hpp"
+#include <evmc/evmc.hpp>
+#include <evmone/evmone.h>
+#include <evmone/tracing.hpp>
+#include <evmone/vm.hpp>
+#include <gmock/gmock.h>
+
+using namespace testing;
+
+class tracing : public Test
+{
+private:
+    evmc::VM m_baseline_vm;
+
+protected:
+    evmone::VM& vm;
+
+    std::ostringstream trace_stream;
+
+    tracing()
+      : m_baseline_vm{evmc_create_evmone(), {{"O", "0"}}},
+        vm{*static_cast<evmone::VM*>(m_baseline_vm.get_raw_pointer())}
+    {}
+
+    std::string trace(bytes_view code)
+    {
+        evmc_message msg{};
+        msg.gas = 1000000;
+        m_baseline_vm.execute(EVMC_LONDON, msg, code.data(), code.size());
+        auto result = trace_stream.str();
+        trace_stream.str({});
+        return result;
+    }
+
+    class OpcodeTracer final : public evmone::VMTracer
+    {
+        std::string m_name;
+        std::ostringstream& m_trace;
+        int m_counter = 0;
+
+        void onBeginExecution() noexcept override {}
+        void onEndExecution() noexcept override {}
+
+        void onOpcode(evmc_opcode opcode) noexcept override
+        {
+            m_trace << m_name << (++m_counter) << ":"
+                    << evmc_get_instruction_names_table(EVMC_MAX_REVISION)[opcode] << " ";
+        }
+
+    public:
+        explicit OpcodeTracer(tracing& parent, std::string name) noexcept
+          : m_name{std::move(name)}, m_trace{parent.trace_stream}
+        {}
+    };
+};
+
+
+TEST_F(tracing, no_tracer)
+{
+    EXPECT_EQ(vm.get_tracer(), nullptr);
+}
+
+TEST_F(tracing, one_tracer)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, ""));
+
+    EXPECT_EQ(trace(add(1, 2)), "1:PUSH1 2:PUSH1 3:ADD ");
+}
+
+TEST_F(tracing, two_tracers)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "A"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "B"));
+
+    EXPECT_EQ(trace(add(1, 2)), "A1:PUSH1 B1:PUSH1 A2:PUSH1 B2:PUSH1 A3:ADD B3:ADD ");
+}
+
+TEST_F(tracing, three_tracers)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "A"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "B"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "C"));
+
+    EXPECT_EQ(trace(dup1(0)), "A1:PUSH1 B1:PUSH1 C1:PUSH1 A2:DUP1 B2:DUP1 C2:DUP1 ");
+}


### PR DESCRIPTION
1. This adds evmone::VM class where we can store additional data.
   This is rather trivial change, but should be a separate commit.
2. Adds "trace" EVMC option.
3. Add opcode tracing to baseline interpreter.

```
evmc/bin/evmc run --vm ./lib/libevmone.so,O=0,trace 602060070260F053600160F0F3
Executing on Istanbul with 1000000 gas limit
in ./lib/libevmone.so,O=0,trace
PUSH1
PUSH1
MUL
PUSH1
MSTORE8
PUSH1
PUSH1
RETURN

Result:   success
Gas used: 47
Output:   e0
```