### PR TITLE
bench: Modernize CLI parsing, ignore empty args

### DIFF
--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -38,3 +38,19 @@ if(NOT HAVE_STD_FILESYSTEM)
 elseif(UNIX AND NOT APPLE)
     target_link_libraries(evmone-bench PRIVATE stdc++fs)
 endif()
+
+
+# Tests
+
+set(PREFIX evmone/bench)
+
+# Check if DIR argument works.
+add_test(NAME ${PREFIX}/dir COMMAND evmone-bench ${CMAKE_CURRENT_SOURCE_DIR}/../benchmarks --benchmark_list_tests)
+
+# Empty DIR name should run no benchmarks.
+add_test(NAME ${PREFIX}/dirname_empty COMMAND evmone-bench "" --benchmark_list_tests)
+set_tests_properties(${PREFIX}/dirname_empty PROPERTIES PASS_REGULAR_EXPRESSION "Failed to match any benchmarks")
+
+# Missing DIR argument is an error.
+add_test(NAME ${PREFIX}/no_dir COMMAND evmone-bench)
+set_tests_properties(${PREFIX}/no_dir PROPERTIES PASS_REGULAR_EXPRESSION "DIR argument .* missing")

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -209,6 +209,9 @@ std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
 
     switch (argc)
     {
+    case 1:
+        std::cerr << "DIR argument (path to a directory with benchmarks) missing\n";
+        return {cli_parsing_error, {}};
     case 2:
         benchmarks_dir = argv[1];
         break;
@@ -222,7 +225,8 @@ std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
         expected_output_hex = argv[3];
         break;
     default:
-        return {cli_parsing_error, {}};  // Incorrect number of arguments.
+        std::cerr << "Too many arguments\n";
+        return {cli_parsing_error, {}};
     }
 
     if (evmc_config)
@@ -269,7 +273,7 @@ int main(int argc, char** argv)
     using namespace evmone::test;
     try
     {
-        Initialize(&argc, argv);
+        Initialize(&argc, argv);  // Consumes --benchmark_ options.
         const auto [ec, benchmark_cases] = parseargs(argc, argv);
         if (ec == cli_parsing_error && ReportUnrecognizedArguments(argc, argv))
             return ec;

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -201,11 +201,11 @@ constexpr auto cli_parsing_error = -3;
 std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
 {
     // Arguments' placeholders:
-    const char* evmc_config{};
-    const char* benchmarks_dir{};
-    const char* code_hex_file{};
-    const char* input_hex{};
-    const char* expected_output_hex{};
+    std::string evmc_config;
+    std::string benchmarks_dir;
+    std::string code_hex_file;
+    std::string input_hex;
+    std::string expected_output_hex;
 
     switch (argc)
     {
@@ -229,10 +229,10 @@ std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
         return {cli_parsing_error, {}};
     }
 
-    if (evmc_config)
+    if (!evmc_config.empty())
     {
         auto ec = evmc_loader_error_code{};
-        registered_vms["external"] = evmc::VM{evmc_load_and_configure(evmc_config, &ec)};
+        registered_vms["external"] = evmc::VM{evmc_load_and_configure(evmc_config.c_str(), &ec)};
 
         if (ec != EVMC_LOADER_SUCCESS)
         {
@@ -246,11 +246,12 @@ std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
         std::cout << "External VM: " << evmc_config << "\n";
     }
 
-    if (benchmarks_dir)
+    if (!benchmarks_dir.empty())
     {
         return {0, load_benchmarks_from_dir(benchmarks_dir)};
     }
-    else
+
+    if (!code_hex_file.empty())
     {
         std::ifstream file{code_hex_file};
         std::string code_hex{
@@ -264,6 +265,8 @@ std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
 
         return {0, {std::move(b)}};
     }
+
+    return {0, {}};
 }
 }  // namespace
 }  // namespace evmone::test

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -207,24 +207,23 @@ std::tuple<int, std::vector<BenchmarkCase>> parseargs(int argc, char** argv)
     const char* input_hex{};
     const char* expected_output_hex{};
 
-    if (argc == 2)
+    switch (argc)
     {
+    case 2:
         benchmarks_dir = argv[1];
-    }
-    else if (argc == 3)
-    {
+        break;
+    case 3:
         evmc_config = argv[1];
         benchmarks_dir = argv[2];
-    }
-    else if (argc == 4)
-    {
+        break;
+    case 4:
         code_hex_file = argv[1];
         input_hex = argv[2];
         expected_output_hex = argv[3];
-    }
-    else
+        break;
+    default:
         return {cli_parsing_error, {}};  // Incorrect number of arguments.
-
+    }
 
     if (evmc_config)
     {


### PR DESCRIPTION
This improves CLI handling in `evmone-bench` slightly, but this remains very messy piece of code.
The main goal is to allow skipping loading benchmarks from a dir. Here this can be achieve by passing `""` dirname, but #278 may want to allowing omitting the arg.