### PR TITLE
Homestead/Tangerine/Spurious: Undefined instruction error on revert

### DIFF
--- a/test/unittests/evm_state_test.cpp
+++ b/test/unittests/evm_state_test.cpp
@@ -763,3 +763,33 @@ TEST_P(evm, extcodecopy_buffer_overflow)
         }
     }
 }
+
+TEST_P(evm, undefined_revert_homestead_tangerine_spurious)
+{
+    auto revs = {EVMC_HOMESTEAD, EVMC_TANGERINE_WHISTLE, EVMC_SPURIOUS_DRAGON};
+    for (auto r : revs)
+    {
+        rev = r;
+        auto code = std::string{};
+        code = "700400000000000000000000000000000001";   // PUSH17
+        code += "700400000000000000000000000000000001";  // PUSH17
+        code += "fd";                                    // REVERT
+        execute(code);
+        EXPECT_EQ(result.status_code, EVMC_REVERT);
+    }
+}
+
+TEST_P(evm, revert_ge_byzantium)
+{
+    auto revs = {EVMC_BYZANTIUM, EVMC_CONSTANTINOPLE, EVMC_PETERSBURG, EVMC_ISTANBUL, EVMC_BERLIN};
+    for (auto r : revs)
+    {
+        rev = r;
+        auto code = std::string{};
+        code = "700400000000000000000000000000000001";   // PUSH17
+        code += "700400000000000000000000000000000001";  // PUSH17
+        code += "fd";                                    // REVERT
+        execute(code);
+        EXPECT_EQ(result.status_code, EVMC_REVERT);
+    }
+}

--- a/test/unittests/evm_state_test.cpp
+++ b/test/unittests/evm_state_test.cpp
@@ -775,7 +775,7 @@ TEST_P(evm, undefined_revert_homestead_tangerine_spurious)
         code += "700400000000000000000000000000000001";  // PUSH17
         code += "fd";                                    // REVERT
         execute(code);
-        EXPECT_EQ(result.status_code, EVMC_REVERT);
+        EXPECT_STATUS(EVMC_OUT_OF_GAS);
     }
 }
 
@@ -790,6 +790,6 @@ TEST_P(evm, revert_ge_byzantium)
         code += "700400000000000000000000000000000001";  // PUSH17
         code += "fd";                                    // REVERT
         execute(code);
-        EXPECT_EQ(result.status_code, EVMC_REVERT);
+        EXPECT_STATUS(EVMC_OUT_OF_GAS);
     }
 }


### PR DESCRIPTION
I created this PR to document the behavior of evmone for homestead/tangerine/spurious when a revert on large memory offset/size is issued.