### PR TITLE
PoC: assume code ends with STOP

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -112,7 +112,7 @@ evmc_result baseline_execute(ExecutionState& state) noexcept
 
     const auto code_end = code + code_size;
     auto* pc = code;
-    while (pc != code_end)
+    while (true)  // Guaranteed to terminate because code must end with STOP.
     {
         const auto op = *pc;
 

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -41,14 +41,10 @@ const uint8_t* op_jump(ExecutionState& state, const JumpdestMap& jumpdest_map) n
 }
 
 template <size_t Len>
-inline const uint8_t* load_push(
-    ExecutionState& state, const uint8_t* code, const uint8_t* code_end) noexcept
+inline const uint8_t* load_push(ExecutionState& state, const uint8_t* code) noexcept
 {
-    // TODO: Also last full push can be ignored.
-    if (code + Len > code_end)  // Trimmed push data can be ignored.
-        return code_end;
-
     uint8_t buffer[Len];
+    // This cannot overflow code buffer because code ends with valid STOP instruction.
     std::memcpy(buffer, code, Len);
     state.stack.push(intx::be::load<intx::uint256>(buffer));
     return code + Len;
@@ -110,7 +106,6 @@ evmc_result baseline_execute(ExecutionState& state) noexcept
     const auto instruction_metrics = evmc_get_instruction_metrics_table(rev);
     const auto jumpdest_map = build_jumpdest_map(code, code_size);
 
-    const auto code_end = code + code_size;
     auto* pc = code;
     while (true)  // Guaranteed to terminate because code must end with STOP.
     {
@@ -400,100 +395,100 @@ evmc_result baseline_execute(ExecutionState& state) noexcept
             break;
 
         case OP_PUSH1:
-            pc = load_push<1>(state, pc + 1, code_end);
+            pc = load_push<1>(state, pc + 1);
             continue;
         case OP_PUSH2:
-            pc = load_push<2>(state, pc + 1, code_end);
+            pc = load_push<2>(state, pc + 1);
             continue;
         case OP_PUSH3:
-            pc = load_push<3>(state, pc + 1, code_end);
+            pc = load_push<3>(state, pc + 1);
             continue;
         case OP_PUSH4:
-            pc = load_push<4>(state, pc + 1, code_end);
+            pc = load_push<4>(state, pc + 1);
             continue;
         case OP_PUSH5:
-            pc = load_push<5>(state, pc + 1, code_end);
+            pc = load_push<5>(state, pc + 1);
             continue;
         case OP_PUSH6:
-            pc = load_push<6>(state, pc + 1, code_end);
+            pc = load_push<6>(state, pc + 1);
             continue;
         case OP_PUSH7:
-            pc = load_push<7>(state, pc + 1, code_end);
+            pc = load_push<7>(state, pc + 1);
             continue;
         case OP_PUSH8:
-            pc = load_push<8>(state, pc + 1, code_end);
+            pc = load_push<8>(state, pc + 1);
             continue;
         case OP_PUSH9:
-            pc = load_push<9>(state, pc + 1, code_end);
+            pc = load_push<9>(state, pc + 1);
             continue;
         case OP_PUSH10:
-            pc = load_push<10>(state, pc + 1, code_end);
+            pc = load_push<10>(state, pc + 1);
             continue;
         case OP_PUSH11:
-            pc = load_push<11>(state, pc + 1, code_end);
+            pc = load_push<11>(state, pc + 1);
             continue;
         case OP_PUSH12:
-            pc = load_push<12>(state, pc + 1, code_end);
+            pc = load_push<12>(state, pc + 1);
             continue;
         case OP_PUSH13:
-            pc = load_push<13>(state, pc + 1, code_end);
+            pc = load_push<13>(state, pc + 1);
             continue;
         case OP_PUSH14:
-            pc = load_push<14>(state, pc + 1, code_end);
+            pc = load_push<14>(state, pc + 1);
             continue;
         case OP_PUSH15:
-            pc = load_push<15>(state, pc + 1, code_end);
+            pc = load_push<15>(state, pc + 1);
             continue;
         case OP_PUSH16:
-            pc = load_push<16>(state, pc + 1, code_end);
+            pc = load_push<16>(state, pc + 1);
             continue;
         case OP_PUSH17:
-            pc = load_push<17>(state, pc + 1, code_end);
+            pc = load_push<17>(state, pc + 1);
             continue;
         case OP_PUSH18:
-            pc = load_push<18>(state, pc + 1, code_end);
+            pc = load_push<18>(state, pc + 1);
             continue;
         case OP_PUSH19:
-            pc = load_push<19>(state, pc + 1, code_end);
+            pc = load_push<19>(state, pc + 1);
             continue;
         case OP_PUSH20:
-            pc = load_push<20>(state, pc + 1, code_end);
+            pc = load_push<20>(state, pc + 1);
             continue;
         case OP_PUSH21:
-            pc = load_push<21>(state, pc + 1, code_end);
+            pc = load_push<21>(state, pc + 1);
             continue;
         case OP_PUSH22:
-            pc = load_push<22>(state, pc + 1, code_end);
+            pc = load_push<22>(state, pc + 1);
             continue;
         case OP_PUSH23:
-            pc = load_push<23>(state, pc + 1, code_end);
+            pc = load_push<23>(state, pc + 1);
             continue;
         case OP_PUSH24:
-            pc = load_push<24>(state, pc + 1, code_end);
+            pc = load_push<24>(state, pc + 1);
             continue;
         case OP_PUSH25:
-            pc = load_push<25>(state, pc + 1, code_end);
+            pc = load_push<25>(state, pc + 1);
             continue;
         case OP_PUSH26:
-            pc = load_push<26>(state, pc + 1, code_end);
+            pc = load_push<26>(state, pc + 1);
             continue;
         case OP_PUSH27:
-            pc = load_push<27>(state, pc + 1, code_end);
+            pc = load_push<27>(state, pc + 1);
             continue;
         case OP_PUSH28:
-            pc = load_push<28>(state, pc + 1, code_end);
+            pc = load_push<28>(state, pc + 1);
             continue;
         case OP_PUSH29:
-            pc = load_push<29>(state, pc + 1, code_end);
+            pc = load_push<29>(state, pc + 1);
             continue;
         case OP_PUSH30:
-            pc = load_push<30>(state, pc + 1, code_end);
+            pc = load_push<30>(state, pc + 1);
             continue;
         case OP_PUSH31:
-            pc = load_push<31>(state, pc + 1, code_end);
+            pc = load_push<31>(state, pc + 1);
             continue;
         case OP_PUSH32:
-            pc = load_push<32>(state, pc + 1, code_end);
+            pc = load_push<32>(state, pc + 1);
             continue;
 
         case OP_DUP1:


### PR DESCRIPTION
Assumption that code always ends with valid STOP instruction eliminates the "end-of-code" checks in the interpreter loop and in push data load. See individual commits for more information.

Benchmarks with evmone/Baseline interpreter build with Clang 11 on Haswell CPU 4.0 GHz, "main" benchmark set:
- time reduced by -2% to -11%,
- geometric mean: -7.2%.


```
Comparing o/baseline to o/valid_stop                                                                                                                                                                                              
Benchmark                                                                Time             CPU      Time Old      Time New       CPU Old       CPU New                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------
baseline/execute/main/blake2b_huff/empty_mean                         -0.0617         -0.0618            25            23            25            23
baseline/execute/main/blake2b_huff/2805nulls_mean                     -0.1125         -0.1125           408           362           408           362
baseline/execute/main/blake2b_huff/5610nulls_mean                     -0.1004         -0.1004           783           704           783           704
baseline/execute/main/blake2b_huff/8415nulls_mean                     -0.1051         -0.1051          1148          1027          1148          1027
baseline/execute/main/blake2b_huff/65536nulls_mean                    -0.1039         -0.1039          8843          7924          8843          7924
baseline/execute/main/blake2b_shifts/2805nulls_mean                   -0.0740         -0.0740          3945          3653          3945          3653
baseline/execute/main/blake2b_shifts/5610nulls_mean                   -0.0810         -0.0810          8156          7495          8156          7495
baseline/execute/main/blake2b_shifts/8415nulls_mean                   -0.0814         -0.0814         12305         11303         12305         11303
baseline/execute/main/blake2b_shifts/65536nulls_mean                  -0.0897         -0.0897         89394         81377         89394         81378
baseline/execute/main/sha1_divs/empty_mean                            -0.0539         -0.0538            65            61            65            61
baseline/execute/main/sha1_divs/1351_mean                             -0.0570         -0.0570          1329          1254          1329          1254
baseline/execute/main/sha1_divs/2737_mean                             -0.0539         -0.0539          2593          2453          2593          2453
baseline/execute/main/sha1_divs/5311_mean                             -0.0573         -0.0573          5071          4780          5071          4780
baseline/execute/main/sha1_divs/65536_mean                            -0.0562         -0.0561         61711         58245         61711         58246
baseline/execute/main/sha1_shifts/empty_mean                          -0.0960         -0.0960            42            38            42            38
baseline/execute/main/sha1_shifts/1351_mean                           -0.1126         -0.1126           868           770           868           770
baseline/execute/main/sha1_shifts/2737_mean                           -0.1036         -0.1036          1677          1503          1677          1503
baseline/execute/main/sha1_shifts/5311_mean                           -0.1062         -0.1062          3287          2938          3287          2938
baseline/execute/main/sha1_shifts/65536_mean                          -0.0990         -0.0990         39656         35729         39656         35730
baseline/execute/main/weierstrudel/0_mean                             -0.0261         -0.0261           198           192           198           192
baseline/execute/main/weierstrudel/1_mean                             -0.0250         -0.0250           434           423           434           423
baseline/execute/main/weierstrudel/3_mean                             -0.0259         -0.0259           675           658           675           658
baseline/execute/main/weierstrudel/9_mean                             -0.0201         -0.0201          1393          1365          1393          1365
baseline/execute/main/weierstrudel/14_mean                            -0.0196         -0.0196          1992          1953          1992          1953
```

