### PR TITLE
Provide better execute() C++ API

### DIFF
--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -55,14 +55,7 @@ struct AdvancedExecutionState : ExecutionState
     /// Pointer to code analysis.
     const AdvancedCodeAnalysis* analysis = nullptr;
 
-    AdvancedExecutionState() = default;
-
-    AdvancedExecutionState(const evmc_message& message, evmc_revision revision,
-        const evmc_host_interface& host_interface, evmc_host_context* host_ctx,
-        const uint8_t* code_ptr, size_t code_size, const AdvancedCodeAnalysis& a) noexcept
-      : ExecutionState{message, revision, host_interface, host_ctx, code_ptr, code_size},
-        analysis{&a}
-    {}
+    using ExecutionState::ExecutionState;
 
     /// Terminates the execution with the given status code.
     const instruction* exit(evmc_status_code status_code) noexcept
@@ -74,11 +67,11 @@ struct AdvancedExecutionState : ExecutionState
     /// Resets the contents of the execution_state so that it could be reused.
     void reset(const evmc_message& message, evmc_revision revision,
         const evmc_host_interface& host_interface, evmc_host_context* host_ctx,
-        const uint8_t* code_ptr, size_t code_size, const AdvancedCodeAnalysis& a) noexcept
+        const uint8_t* code_ptr, size_t code_size) noexcept
     {
         ExecutionState::reset(message, revision, host_interface, host_ctx, code_ptr, code_size);
         current_block_cost = 0;
-        analysis = &a;
+        analysis = nullptr;
     }
 };
 

--- a/lib/evmone/execution.cpp
+++ b/lib/evmone/execution.cpp
@@ -8,22 +8,26 @@
 
 namespace evmone
 {
+evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& analysis) noexcept
+{
+    state.analysis = &analysis;  // Allow accessing the analysis by instructions.
+
+    const auto* instr = &state.analysis->instrs[0];  // Start with the first instruction.
+    while (instr != nullptr)
+        instr = instr->fn(instr, state);
+
+    const auto gas_left =
+        (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
+
+    return evmc::make_result(
+        state.status, gas_left, &state.memory[state.output_offset], state.output_size);
+}
+
 evmc_result execute(evmc_vm* /*unused*/, const evmc_host_interface* host, evmc_host_context* ctx,
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept
 {
     const auto analysis = analyze(rev, code, code_size);
-
-    auto state =
-        std::make_unique<AdvancedExecutionState>(*msg, rev, *host, ctx, code, code_size, analysis);
-
-    const auto* instr = &state->analysis->instrs[0];
-    while (instr != nullptr)
-        instr = instr->fn(instr, *state);
-
-    const auto gas_left =
-        (state->status == EVMC_SUCCESS || state->status == EVMC_REVERT) ? state->gas_left : 0;
-
-    return evmc::make_result(
-        state->status, gas_left, &state->memory[state->output_offset], state->output_size);
+    auto state = std::make_unique<AdvancedExecutionState>(*msg, rev, *host, ctx, code, code_size);
+    return execute(*state, analysis);
 }
 }  // namespace evmone

--- a/lib/evmone/execution.hpp
+++ b/lib/evmone/execution.hpp
@@ -7,6 +7,13 @@
 
 namespace evmone
 {
+struct AdvancedExecutionState;
+struct AdvancedCodeAnalysis;
+
+/// Execute the already analyzed code using the provided execution state.
+evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& analysis) noexcept;
+
+/// EVMC-compatible execute() function.
 evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_context* ctx,
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept;
 }  // namespace evmone

--- a/test/unittests/execution_state_test.cpp
+++ b/test/unittests/execution_state_test.cpp
@@ -117,10 +117,8 @@ TEST(execution_state, reset_advanced)
         msg2.gas = 13;
         const evmc_host_interface host_interface2{};
         const uint8_t code2[]{0x80, 0x81};
-        evmone::AdvancedCodeAnalysis analysis2;
 
-        st.reset(
-            msg2, EVMC_HOMESTEAD, host_interface2, nullptr, code2, std::size(code2), analysis2);
+        st.reset(msg2, EVMC_HOMESTEAD, host_interface2, nullptr, code2, std::size(code2));
 
         // TODO: We are not able to test HostContext with current API. It may require an execution
         //       test.
@@ -136,7 +134,7 @@ TEST(execution_state, reset_advanced)
         EXPECT_EQ(st.output_offset, 0);
         EXPECT_EQ(st.output_size, 0);
         EXPECT_EQ(st.current_block_cost, 0u);
-        EXPECT_EQ(st.analysis, &analysis2);
+        EXPECT_EQ(st.analysis, nullptr);
     }
 }
 


### PR DESCRIPTION
Change the execute API for Advanced interpreter to map the Baseline API.
The new API requires to provide the execution state object (user can
make better decision how to allocate it) and the code analysis (it is
bound to the code itself so user can cache them together).