### PR TITLE
Optimize Baseline interpreter by using padded code

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -58,14 +58,10 @@ const uint8_t* op_jump(
 }
 
 template <size_t Len>
-inline const uint8_t* load_push(
-    ExecutionState& state, const uint8_t* code, const uint8_t* code_end) noexcept
+inline const uint8_t* load_push(ExecutionState& state, const uint8_t* code) noexcept
 {
-    // TODO: Also last full push can be ignored.
-    if (code + Len > code_end)  // Trimmed push data can be ignored.
-        return code_end;
-
     uint8_t buffer[Len];
+    // This valid because code is padded with garbage to satisfy push data read pass the code end.
     std::memcpy(buffer, code, Len);
     state.stack.push(intx::be::load<intx::uint256>(buffer));
     return code + Len;
@@ -122,7 +118,6 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
     const auto instruction_metrics = evmc_get_instruction_metrics_table(state.rev);
 
     const auto* const code = state.code.data();
-    const auto* const code_end = code + state.code.size();
     auto pc = code;
     while (true)  // Guaranteed to terminate because padded code ends with STOP.
     {
@@ -448,100 +443,100 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
             break;
 
         case OP_PUSH1:
-            pc = load_push<1>(state, pc + 1, code_end);
+            pc = load_push<1>(state, pc + 1);
             continue;
         case OP_PUSH2:
-            pc = load_push<2>(state, pc + 1, code_end);
+            pc = load_push<2>(state, pc + 1);
             continue;
         case OP_PUSH3:
-            pc = load_push<3>(state, pc + 1, code_end);
+            pc = load_push<3>(state, pc + 1);
             continue;
         case OP_PUSH4:
-            pc = load_push<4>(state, pc + 1, code_end);
+            pc = load_push<4>(state, pc + 1);
             continue;
         case OP_PUSH5:
-            pc = load_push<5>(state, pc + 1, code_end);
+            pc = load_push<5>(state, pc + 1);
             continue;
         case OP_PUSH6:
-            pc = load_push<6>(state, pc + 1, code_end);
+            pc = load_push<6>(state, pc + 1);
             continue;
         case OP_PUSH7:
-            pc = load_push<7>(state, pc + 1, code_end);
+            pc = load_push<7>(state, pc + 1);
             continue;
         case OP_PUSH8:
-            pc = load_push<8>(state, pc + 1, code_end);
+            pc = load_push<8>(state, pc + 1);
             continue;
         case OP_PUSH9:
-            pc = load_push<9>(state, pc + 1, code_end);
+            pc = load_push<9>(state, pc + 1);
             continue;
         case OP_PUSH10:
-            pc = load_push<10>(state, pc + 1, code_end);
+            pc = load_push<10>(state, pc + 1);
             continue;
         case OP_PUSH11:
-            pc = load_push<11>(state, pc + 1, code_end);
+            pc = load_push<11>(state, pc + 1);
             continue;
         case OP_PUSH12:
-            pc = load_push<12>(state, pc + 1, code_end);
+            pc = load_push<12>(state, pc + 1);
             continue;
         case OP_PUSH13:
-            pc = load_push<13>(state, pc + 1, code_end);
+            pc = load_push<13>(state, pc + 1);
             continue;
         case OP_PUSH14:
-            pc = load_push<14>(state, pc + 1, code_end);
+            pc = load_push<14>(state, pc + 1);
             continue;
         case OP_PUSH15:
-            pc = load_push<15>(state, pc + 1, code_end);
+            pc = load_push<15>(state, pc + 1);
             continue;
         case OP_PUSH16:
-            pc = load_push<16>(state, pc + 1, code_end);
+            pc = load_push<16>(state, pc + 1);
             continue;
         case OP_PUSH17:
-            pc = load_push<17>(state, pc + 1, code_end);
+            pc = load_push<17>(state, pc + 1);
             continue;
         case OP_PUSH18:
-            pc = load_push<18>(state, pc + 1, code_end);
+            pc = load_push<18>(state, pc + 1);
             continue;
         case OP_PUSH19:
-            pc = load_push<19>(state, pc + 1, code_end);
+            pc = load_push<19>(state, pc + 1);
             continue;
         case OP_PUSH20:
-            pc = load_push<20>(state, pc + 1, code_end);
+            pc = load_push<20>(state, pc + 1);
             continue;
         case OP_PUSH21:
-            pc = load_push<21>(state, pc + 1, code_end);
+            pc = load_push<21>(state, pc + 1);
             continue;
         case OP_PUSH22:
-            pc = load_push<22>(state, pc + 1, code_end);
+            pc = load_push<22>(state, pc + 1);
             continue;
         case OP_PUSH23:
-            pc = load_push<23>(state, pc + 1, code_end);
+            pc = load_push<23>(state, pc + 1);
             continue;
         case OP_PUSH24:
-            pc = load_push<24>(state, pc + 1, code_end);
+            pc = load_push<24>(state, pc + 1);
             continue;
         case OP_PUSH25:
-            pc = load_push<25>(state, pc + 1, code_end);
+            pc = load_push<25>(state, pc + 1);
             continue;
         case OP_PUSH26:
-            pc = load_push<26>(state, pc + 1, code_end);
+            pc = load_push<26>(state, pc + 1);
             continue;
         case OP_PUSH27:
-            pc = load_push<27>(state, pc + 1, code_end);
+            pc = load_push<27>(state, pc + 1);
             continue;
         case OP_PUSH28:
-            pc = load_push<28>(state, pc + 1, code_end);
+            pc = load_push<28>(state, pc + 1);
             continue;
         case OP_PUSH29:
-            pc = load_push<29>(state, pc + 1, code_end);
+            pc = load_push<29>(state, pc + 1);
             continue;
         case OP_PUSH30:
-            pc = load_push<30>(state, pc + 1, code_end);
+            pc = load_push<30>(state, pc + 1);
             continue;
         case OP_PUSH31:
-            pc = load_push<31>(state, pc + 1, code_end);
+            pc = load_push<31>(state, pc + 1);
             continue;
         case OP_PUSH32:
-            pc = load_push<32>(state, pc + 1, code_end);
+            pc = load_push<32>(state, pc + 1);
             continue;
 
         case OP_DUP1:

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -124,7 +124,7 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
     const auto* const code = state.code.data();
     const auto* const code_end = code + state.code.size();
     auto pc = code;
-    while (pc != code_end)
+    while (true)  // Guaranteed to terminate because padded code ends with STOP.
     {
         if constexpr (TracingEnabled)
         {

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -6,6 +6,7 @@
 #include "execution_state.hpp"
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
+#include <memory>
 #include <vector>
 
 namespace evmone
@@ -18,7 +19,8 @@ struct CodeAnalysis
 {
     using JumpdestMap = std::vector<bool>;
 
-    JumpdestMap jumpdest_map;
+    const std::unique_ptr<uint8_t[]> padded_code;
+    const JumpdestMap jumpdest_map;
 };
 
 /// Analyze the code to build the bitmap of valid JUMPDEST locations.

--- a/test/bench/helpers.hpp
+++ b/test/bench/helpers.hpp
@@ -23,7 +23,7 @@ inline void analyse(benchmark::State& state, evmc_revision rev, bytes_view code)
     for (auto _ : state)
     {
         auto r = evmone::analyze(rev, code.data(), code.size());
-        benchmark::DoNotOptimize(r);
+        benchmark::DoNotOptimize(&r);
         bytes_analysed += code.size();
     }
 
@@ -38,7 +38,7 @@ inline void baseline_analyze(benchmark::State& state, bytes_view code) noexcept
     for (auto _ : state)
     {
         auto r = evmone::baseline::analyze(code.data(), code.size());
-        benchmark::DoNotOptimize(r);
+        benchmark::DoNotOptimize(&r);
         bytes_analysed += code.size();
     }
 


### PR DESCRIPTION
During code analysis the code is copied and padded with 33 zero bytes. This guarantees that push data is always available in the code buffer and the code ends with STOP. This allows optimizing the interpreter loop and PUSH instructions.

Performance gains are up to ~5%.

This is also needed to enable other optimization: implementing interpreter with "computed goto" or "tail calls".  