### PR TITLE
Basic opcode tracer, histogram tracer, stub for eip3155 tracer

### DIFF
--- a/include/evmone/evmone.h
+++ b/include/evmone/evmone.h
@@ -7,6 +7,7 @@
 
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
+#include <memory>
 
 #if __cplusplus
 extern "C" {
@@ -16,6 +17,29 @@ EVMC_EXPORT struct evmc_vm* evmc_create_evmone(void) EVMC_NOEXCEPT;
 
 #if __cplusplus
 }
+
+#include <evmc/instructions.h>
+
+namespace evmone
+{
+struct VMTracer
+{
+    virtual ~VMTracer() {}
+
+    virtual void onBeginExecution() noexcept = 0;
+    virtual void onOpcodeBefore(evmc_opcode opcode, uint64_t pc) noexcept = 0;
+    virtual void onOpcodeAfter() noexcept = 0;
+    virtual void onEndExecution() noexcept = 0;
+};
+
+struct VM : evmc_vm
+{
+    std::unique_ptr<VMTracer> tracer;
+
+    inline constexpr VM() noexcept;
+};
+}  // namespace evmone
+
 #endif
 
 #endif  // EVMONE_H

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -115,7 +115,8 @@ evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_cont
     return result;
 }
 
-evmc_result execute(ExecutionState& state, std::unique_ptr<VMTracer>& tracer, const CodeAnalysis& analysis) noexcept
+evmc_result execute(
+    ExecutionState& state, std::unique_ptr<VMTracer>& tracer, const CodeAnalysis& analysis) noexcept
 {
     const auto rev = state.rev;
     const auto code = state.code.data();

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -7,6 +7,8 @@
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
 #include <vector>
+#include <memory>
+#include <evmone/evmone.h>
 
 namespace evmone::baseline
 {
@@ -25,5 +27,5 @@ evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_cont
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept;
 
 /// Executes in Baseline interpreter on the given external and initialized state.
-evmc_result execute(ExecutionState& state, const CodeAnalysis& analysis) noexcept;
+evmc_result execute(ExecutionState& state, std::unique_ptr<VMTracer>& tracer, const CodeAnalysis& analysis) noexcept;
 }  // namespace evmone::baseline

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -6,9 +6,9 @@
 #include "execution_state.hpp"
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
-#include <vector>
-#include <memory>
 #include <evmone/evmone.h>
+#include <memory>
+#include <vector>
 
 namespace evmone::baseline
 {
@@ -27,5 +27,6 @@ evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_cont
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept;
 
 /// Executes in Baseline interpreter on the given external and initialized state.
-evmc_result execute(ExecutionState& state, std::unique_ptr<VMTracer>& tracer, const CodeAnalysis& analysis) noexcept;
+evmc_result execute(ExecutionState& state, std::unique_ptr<VMTracer>& tracer,
+    const CodeAnalysis& analysis) noexcept;
 }  // namespace evmone::baseline

--- a/lib/evmone/evmone.cpp
+++ b/lib/evmone/evmone.cpp
@@ -10,14 +10,137 @@
 #include "execution.hpp"
 #include <evmone/evmone.h>
 
+#include "instruction_traits.hpp"
+#include <evmc/instructions.h>
+#include <cstdio>
+#include <cstring>
+#include <map>
+
+#include <intx/intx.hpp>
+#include <iostream>
+
 namespace evmone
 {
 namespace
 {
+struct EVMTracer : VMTracer
+{
+    uint64_t step_pc;
+    std::string step_op_name;
+    std::unique_ptr<VMTracer> next_tracer;
+
+    EVMTracer(std::unique_ptr<VMTracer> _next_tracer = nullptr)
+      : next_tracer{std::move(_next_tracer)}
+    {}
+
+    void onBeginExecution() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onBeginExecution();
+    }
+
+    void onOpcodeBefore(evmc_opcode opcode, uint64_t pc) noexcept final
+    {
+        this->step_pc = pc;
+        this->step_op_name = instr::traits[opcode].name;
+
+        if (next_tracer)
+            next_tracer->onOpcodeBefore(opcode, pc);
+    }
+
+    void onOpcodeAfter() noexcept final
+    {
+        std::cout << "{pc:" << this->step_pc << ", op:\"" << this->step_op_name.c_str() << "\"}\n";
+
+        if (next_tracer)
+            next_tracer->onOpcodeAfter();
+    }
+
+    void onEndExecution() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onEndExecution();
+    }
+};
+
+struct BasicTracer : VMTracer
+{
+    std::unique_ptr<VMTracer> next_tracer;
+
+    BasicTracer(std::unique_ptr<VMTracer> _next_tracer = nullptr)
+      : next_tracer{std::move(_next_tracer)}
+    {}
+
+    void onBeginExecution() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onBeginExecution();
+    }
+
+    void onOpcodeBefore(evmc_opcode opcode, uint64_t pc) noexcept final
+    {
+        std::puts(instr::traits[opcode].name);
+        if (next_tracer)
+            next_tracer->onOpcodeBefore(opcode, pc);
+    }
+
+    void onOpcodeAfter() noexcept final {}
+
+    void onEndExecution() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onEndExecution();
+    }
+};
+
+struct HistogramTracer : VMTracer
+{
+    std::unique_ptr<VMTracer> next_tracer;
+    std::map<evmc_opcode, int> opcode_counter;
+
+    HistogramTracer(std::unique_ptr<VMTracer> _next_tracer = nullptr)
+      : next_tracer{std::move(_next_tracer)}
+    {}
+
+    void onBeginExecution() noexcept final
+    {
+        opcode_counter.clear();
+        if (next_tracer)
+            next_tracer->onBeginExecution();
+    }
+
+    void onOpcodeBefore(evmc_opcode opcode, uint64_t pc) noexcept final
+    {
+        ++opcode_counter[opcode];
+        if (next_tracer)
+            next_tracer->onOpcodeBefore(opcode, pc);
+    }
+
+    void onOpcodeAfter() noexcept final
+    {
+        if (next_tracer)
+            next_tracer->onOpcodeAfter();
+    }
+
+    void onEndExecution() noexcept final
+    {
+        std::puts("\nHistogram:");
+        int all = 0;
+        for (const auto [opcode, count] : opcode_counter)
+        {
+            printf("%s,%d\n", instr::traits[opcode].name, count);
+            all += count;
+        }
+        printf("all,%d\n", all);
+        if (next_tracer)
+            next_tracer->onEndExecution();
+    }
+};
+
 void destroy(evmc_vm* vm) noexcept
 {
     // TODO: Mark function with [[gnu:nonnull]] or add CHECK().
-    delete vm;
+    delete static_cast<VM*>(vm);
 }
 
 constexpr evmc_capabilities_flagset get_capabilities(evmc_vm* /*vm*/) noexcept
@@ -41,15 +164,32 @@ evmc_set_option_result set_option(evmc_vm* vm, char const* name, char const* val
         }
         return EVMC_SET_OPTION_INVALID_VALUE;
     }
+    else if (std::strcmp(name, "evmtrace") == 0)
+    {
+        auto& tracer = static_cast<VM*>(vm)->tracer;
+        tracer = std::make_unique<EVMTracer>(std::move(tracer));
+        return EVMC_SET_OPTION_SUCCESS;
+    }
+    else if (std::strcmp(name, "basictrace") == 0)
+    {
+        auto& tracer = static_cast<VM*>(vm)->tracer;
+        tracer = std::make_unique<BasicTracer>(std::move(tracer));
+        return EVMC_SET_OPTION_SUCCESS;
+    }
+    else if (std::strcmp(name, "histogram") == 0)
+    {
+        auto& tracer = static_cast<VM*>(vm)->tracer;
+        tracer = std::make_unique<HistogramTracer>(std::move(tracer));
+        return EVMC_SET_OPTION_SUCCESS;
+    }
     return EVMC_SET_OPTION_INVALID_NAME;
 }
-}  // namespace
-}  // namespace evmone
 
-extern "C" {
-EVMC_EXPORT evmc_vm* evmc_create_evmone() noexcept
-{
-    return new evmc_vm{
+}  // namespace
+
+
+inline constexpr VM::VM() noexcept
+  : evmc_vm{
         EVMC_ABI_VERSION,
         "evmone",
         PROJECT_VERSION,
@@ -57,6 +197,14 @@ EVMC_EXPORT evmc_vm* evmc_create_evmone() noexcept
         evmone::execute,
         evmone::get_capabilities,
         evmone::set_option,
-    };
+    }
+{}
+
+}  // namespace evmone
+
+extern "C" {
+EVMC_EXPORT evmc_vm* evmc_create_evmone() noexcept
+{
+    return new evmone::VM{};
 }
 }


### PR DESCRIPTION
Builds on top of https://github.com/ethereum/evmone/pull/285:
* Modifies the tracing interface to expose a pre/post opcode execution hook.
* Adds a stub tracer for pending implementation of the standardized EVM trace format specified in https://eips.ethereum.org/EIPS/eip-3155 .  Example output:
````
> evmc/build/bin/evmc run --vm build/lib/libevmone.so,O=0,evmtrace 604080536040604055604060006040600060025afa6040f3
Executing on Istanbul with 1000000 gas limit
in build/lib/libevmone.so,O=0,evmtrace
{pc:0, op:"PUSH1"}
{pc:2, op:"DUP1"}
{pc:3, op:"MSTORE8"}
{pc:4, op:"PUSH1"}
{pc:6, op:"PUSH1"}
{pc:8, op:"SSTORE"}
{pc:9, op:"PUSH1"}
{pc:11, op:"PUSH1"}
{pc:13, op:"PUSH1"}
{pc:15, op:"PUSH1"}
{pc:17, op:"PUSH1"}
{pc:19, op:"GAS"}
{pc:20, op:"STATICCALL"}
{pc:21, op:"PUSH1"}
{pc:23, op:"RETURN"}

Result:   success
Gas used: 984403
Output:   40
```