### PR TITLE
bench: Run execution benchmarks with MockedHost

### DIFF
--- a/test/bench/helpers.hpp
+++ b/test/bench/helpers.hpp
@@ -6,6 +6,7 @@
 #include "test/utils/utils.hpp"
 #include <benchmark/benchmark.h>
 #include <evmc/evmc.hpp>
+#include <evmc/mocked_host.hpp>
 #include <evmone/analysis.hpp>
 #include <evmone/baseline.hpp>
 
@@ -46,14 +47,14 @@ inline void baseline_analyze(benchmark::State& state, bytes_view code) noexcept
     state.counters["rate"] = Counter(static_cast<double>(bytes_analysed), Counter::kIsRate);
 }
 
-inline evmc::result execute(
-    evmc::VM& vm, evmc_revision rev, int64_t gas_limit, bytes_view code, bytes_view input) noexcept
+inline evmc::result execute(evmc::VM& vm, evmc::Host& host, evmc_revision rev, int64_t gas_limit,
+    bytes_view code, bytes_view input) noexcept
 {
     auto msg = evmc_message{};
     msg.gas = gas_limit;
     msg.input_data = input.data();
     msg.input_size = input.size();
-    return vm.execute(rev, msg, code.data(), code.size());
+    return vm.execute(host, rev, msg, code.data(), code.size());
 }
 
 inline void execute(benchmark::State& state, evmc::VM& vm, bytes_view code, bytes_view input = {},
@@ -61,8 +62,11 @@ inline void execute(benchmark::State& state, evmc::VM& vm, bytes_view code, byte
 {
     constexpr auto rev = default_revision;
     constexpr auto gas_limit = default_gas_limit;
+
+    evmc::MockedHost host;
+
     {  // Test run.
-        const auto r = execute(vm, rev, gas_limit, code, input);
+        const auto r = execute(vm, host, rev, gas_limit, code, input);
         if (r.status_code != EVMC_SUCCESS)
         {
             state.SkipWithError(("failure: " + std::to_string(r.status_code)).c_str());
@@ -85,7 +89,7 @@ inline void execute(benchmark::State& state, evmc::VM& vm, bytes_view code, byte
     auto iteration_gas_used = int64_t{0};
     for (auto _ : state)
     {
-        auto r = execute(vm, rev, gas_limit, code, input);
+        auto r = execute(vm, host, rev, gas_limit, code, input);
         iteration_gas_used = gas_limit - r.gas_left;
         total_gas_used += iteration_gas_used;
     }


### PR DESCRIPTION
This allows using state-access instructions in benchmarks. Previously
such benchmarks would crash.