### PR TITLE
Add tracing infrastructure to Baseline interpreter

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -21,7 +21,9 @@ add_library(evmone
     instructions_calls.cpp
     limits.hpp
     opcodes_helpers.h
+    tracing.hpp
     vm.cpp
+    vm.hpp
 )
 target_link_libraries(evmone PUBLIC evmc::evmc intx::intx PRIVATE evmc::instructions ethash::keccak)
 target_include_directories(evmone PUBLIC

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -95,12 +95,12 @@ inline evmc_status_code check_requirements(const char* const* instruction_names,
 
     return EVMC_SUCCESS;
 }
-}  // namespace
 
+template <bool TracingEnabled>
 evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& analysis) noexcept
 {
     auto* tracer = vm.get_tracer();
-    if (INTX_UNLIKELY(tracer != nullptr))
+    if constexpr (TracingEnabled)
         tracer->notify_execution_start(state.rev, *state.msg, state.code);
 
     const auto rev = state.rev;
@@ -114,11 +114,10 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
     auto* pc = code;
     while (pc != code_end)
     {
-        const auto op = *pc;
-
-        if (INTX_UNLIKELY(tracer != nullptr))
+        if constexpr (TracingEnabled)
             tracer->notify_instruction_start(static_cast<uint32_t>(pc - code));
 
+        const auto op = *pc;
         const auto status = check_requirements(instruction_names, instruction_metrics, state, op);
         if (status != EVMC_SUCCESS)
         {
@@ -761,10 +760,19 @@ exit:
     const auto result = evmc::make_result(state.status, gas_left,
         state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
 
-    if (INTX_UNLIKELY(tracer != nullptr))
+    if constexpr (TracingEnabled)
         tracer->notify_execution_end(result);
 
     return result;
+}
+}  // namespace
+
+evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& analysis) noexcept
+{
+    if (INTX_UNLIKELY(vm.get_tracer() != nullptr))
+        return execute<true>(vm, state, analysis);
+
+    return execute<false>(vm, state, analysis);
 }
 
 evmc_result execute(evmc_vm* c_vm, const evmc_host_interface* host, evmc_host_context* ctx,

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -1,0 +1,51 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/instructions.h>
+#include <memory>
+#include <string_view>
+
+namespace evmone
+{
+using bytes_view = std::basic_string_view<uint8_t>;
+
+class Tracer
+{
+    friend class VM;  // Has access the the m_next_tracer to traverse the list forward.
+    std::unique_ptr<Tracer> m_next_tracer;
+
+public:
+    virtual ~Tracer() = default;
+
+    void notify_execution_start(
+        evmc_revision rev, const evmc_message& msg, bytes_view code) noexcept
+    {
+        on_execution_start(rev, msg, code);
+        if (m_next_tracer)
+            m_next_tracer->notify_execution_start(rev, msg, code);
+    }
+
+    void notify_execution_end(const evmc_result& result) noexcept  // NOLINT(misc-no-recursion)
+    {
+        on_execution_end(result);
+        if (m_next_tracer)
+            m_next_tracer->notify_execution_end(result);
+    }
+
+    void notify_instruction_start(uint32_t pc) noexcept  // NOLINT(misc-no-recursion)
+    {
+        on_instruction_start(pc);
+        if (m_next_tracer)
+            m_next_tracer->notify_instruction_start(pc);
+    }
+
+private:
+    virtual void on_execution_start(
+        evmc_revision rev, const evmc_message& msg, bytes_view code) noexcept = 0;
+    virtual void on_instruction_start(uint32_t pc) noexcept = 0;
+    virtual void on_execution_end(const evmc_result& result) noexcept = 0;
+};
+
+}  // namespace evmone

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "tracing.hpp"
 #include <evmc/evmc.h>
 
 namespace evmone
@@ -10,7 +11,20 @@ namespace evmone
 /// The evmone EVMC instance.
 class VM : public evmc_vm
 {
+    std::unique_ptr<Tracer> m_first_tracer;
+
 public:
     inline constexpr VM() noexcept;
+
+    void add_tracer(std::unique_ptr<Tracer> tracer) noexcept
+    {
+        // Find the first empty unique_ptr and assign the new tracer to it.
+        auto* end = &m_first_tracer;
+        while (*end)
+            end = &(*end)->m_next_tracer;
+        *end = std::move(tracer);
+    }
+
+    [[nodiscard]] Tracer* get_tracer() const noexcept { return m_first_tracer.get(); }
 };
 }  // namespace evmone

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(evmone-unittests
     evmone_test.cpp
     execution_state_test.cpp
     op_table_test.cpp
+    tracing_test.cpp
     utils_test.cpp
 )
 target_link_libraries(evmone-unittests PRIVATE evmone testutils evmc::instructions GTest::gtest GTest::gtest_main)

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -1,0 +1,97 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "test/utils/bytecode.hpp"
+#include <evmc/evmc.hpp>
+#include <evmc/mocked_host.hpp>
+#include <evmone/evmone.h>
+#include <evmone/tracing.hpp>
+#include <evmone/vm.hpp>
+#include <gmock/gmock.h>
+
+using namespace testing;
+
+class tracing : public Test
+{
+private:
+    evmc::VM m_baseline_vm;
+
+protected:
+    evmone::VM& vm;
+
+    std::ostringstream trace_stream;
+
+    tracing()
+      : m_baseline_vm{evmc_create_evmone(), {{"O", "0"}}},
+        vm{*static_cast<evmone::VM*>(m_baseline_vm.get_raw_pointer())}
+    {}
+
+    std::string trace(bytes_view code)
+    {
+        evmc::MockedHost host;
+        evmc_message msg{};
+        msg.gas = 1000000;
+        m_baseline_vm.execute(host, EVMC_BERLIN, msg, code.data(), code.size());
+        auto result = trace_stream.str();
+        trace_stream.str({});
+        return result;
+    }
+
+    class OpcodeTracer final : public evmone::Tracer
+    {
+        std::string m_name;
+        std::ostringstream& m_trace;
+        const uint8_t* m_code = nullptr;
+
+        void on_execution_start(
+            evmc_revision /*rev*/, const evmc_message& /*msg*/, bytes_view code) noexcept override
+        {
+            m_code = code.data();
+        }
+
+        void on_execution_end(const evmc_result& /*result*/) noexcept override { m_code = nullptr; }
+
+        void on_instruction_start(uint32_t pc) noexcept override
+        {
+            const auto opcode = m_code[pc];
+            m_trace << m_name << pc << ":"
+                    << evmc_get_instruction_names_table(EVMC_MAX_REVISION)[opcode] << " ";
+        }
+
+    public:
+        explicit OpcodeTracer(tracing& parent, std::string name) noexcept
+          : m_name{std::move(name)}, m_trace{parent.trace_stream}
+        {}
+    };
+};
+
+
+TEST_F(tracing, no_tracer)
+{
+    EXPECT_EQ(vm.get_tracer(), nullptr);
+}
+
+TEST_F(tracing, one_tracer)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, ""));
+
+    EXPECT_EQ(trace(add(1, 2)), "0:PUSH1 2:PUSH1 4:ADD ");
+}
+
+TEST_F(tracing, two_tracers)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "A"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "B"));
+
+    EXPECT_EQ(trace(add(1, 2)), "A0:PUSH1 B0:PUSH1 A2:PUSH1 B2:PUSH1 A4:ADD B4:ADD ");
+}
+
+TEST_F(tracing, three_tracers)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "A"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "B"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "C"));
+
+    EXPECT_EQ(trace(dup1(0)), "A0:PUSH1 B0:PUSH1 C0:PUSH1 A2:DUP1 B2:DUP1 C2:DUP1 ");
+}


### PR DESCRIPTION
With the templated implementation there is no change in the performance. Without a template, the overhead can be up to 10%.

The `Tracer` interface is:
```cpp
class Tracer
{ 
    virtual void on_execution_start(
        evmc_revision rev, const evmc_message& msg, bytes_view code) noexcept = 0;
    virtual void on_instruction_start(uint32_t pc) noexcept = 0;
    virtual void on_execution_end(const evmc_result& result) noexcept = 0;
};
```

It can be extended/modified easily depending on needs of the practical tracer implementations.