### PR TITLE
Instruction tracing with EIP-3155 JSONL output

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(evmone
     vm.cpp
     vm.hpp
 )
-target_link_libraries(evmone PUBLIC evmc::evmc intx::intx PRIVATE evmc::instructions ethash::keccak)
+target_link_libraries(evmone PUBLIC evmc::evmc intx::intx PRIVATE evmc::instructions evmc::hex ethash::keccak)
 target_include_directories(evmone PUBLIC
     $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -115,7 +115,7 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
     while (pc != code_end)
     {
         if constexpr (TracingEnabled)
-            tracer->notify_instruction_start(static_cast<uint32_t>(pc - code));
+            tracer->notify_instruction_start(static_cast<uint32_t>(pc - code), state);
 
         const auto op = *pc;
         const auto status = check_requirements(instruction_names, instruction_metrics, state, op);

--- a/lib/evmone/tracing.cpp
+++ b/lib/evmone/tracing.cpp
@@ -40,7 +40,7 @@ class HistogramTracer : public Tracer
         m_contexts.emplace(msg.depth, code.data(), evmc_get_instruction_names_table(rev));
     }
 
-    void on_instruction_start(uint32_t pc) noexcept override
+    void on_instruction_start(uint32_t pc, const ExecutionState& /*state*/) noexcept override
     {
         auto& ctx = m_contexts.top();
         ++ctx.counts[ctx.code[pc]];

--- a/lib/evmone/tracing.cpp
+++ b/lib/evmone/tracing.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "tracing.hpp"
+#include "execution_state.hpp"
+#include "instruction_traits.hpp"
 #include <evmc/hex.hpp>
 #include <stack>
 
@@ -64,10 +66,103 @@ class HistogramTracer : public Tracer
 public:
     explicit HistogramTracer(std::ostream& out) noexcept : m_out{out} {}
 };
+
+
+class InstructionTracer : public Tracer
+{
+    struct Context
+    {
+        const uint8_t* const code;  ///< Reference to the code being executed.
+        const int64_t start_gas;
+
+        Context(const uint8_t* c, int64_t g) noexcept : code{c}, start_gas{g} {}
+    };
+
+    std::stack<Context> m_contexts;
+    const char* const* m_opcode_names = nullptr;
+    std::ostream& m_out;  ///< Output stream.
+
+    void output_stack(const Stack& stack)
+    {
+        const auto top = stack.size() - 1;
+        m_out << R"(,"stack":[)";
+        for (int i = top; i >= 0; --i)
+        {
+            if (i != top)
+                m_out << ',';
+            m_out << R"("0x)" << to_string(stack[i], 16) << '"';
+        }
+        m_out << ']';
+    }
+
+    void on_execution_start(
+        evmc_revision rev, const evmc_message& msg, bytes_view code) noexcept override
+    {
+        if (m_contexts.empty())
+            m_opcode_names = evmc_get_instruction_names_table(rev);
+        m_contexts.emplace(code.data(), msg.gas);
+
+        m_out << "{";
+        m_out << R"("depth":)" << msg.depth;
+        m_out << R"(,"rev":")" << rev << '"';
+        m_out << R"(,"static":)" << (((msg.flags & EVMC_STATIC) != 0) ? "true" : "false");
+        m_out << "}\n";
+    }
+
+    void on_instruction_start(uint32_t pc, const ExecutionState& state) noexcept override
+    {
+        const auto& ctx = m_contexts.top();
+
+        const auto opcode = ctx.code[pc];
+        m_out << "{";
+        m_out << R"("pc":)" << pc;
+        m_out << R"(,"op":)" << int{opcode};
+        m_out << R"(,"opName":")" << get_name(m_opcode_names, opcode) << '"';
+        m_out << R"(,"gas":)" << state.gas_left;
+        output_stack(state.stack);
+
+        // Full memory can be dumped as evmc::hex({state.memory.data(), state.memory.size()}),
+        // but this should not be done by default. Adding --tracing=+memory option would be nice.
+        m_out << R"(,"memorySize":)" << state.memory.size();
+
+        m_out << "}\n";
+    }
+
+    void on_execution_end(const evmc_result& result) noexcept override
+    {
+        const auto& ctx = m_contexts.top();
+
+        m_out << "{";
+        m_out << R"("error":)";
+        if (result.status_code == EVMC_SUCCESS)
+            m_out << "null";
+        else
+            m_out << '"' << result.status_code << '"';
+        m_out << R"(,"gas":)" << result.gas_left;
+        m_out << R"(,"gasUsed":)" << (ctx.start_gas - result.gas_left);
+        m_out << R"(,"output":")" << evmc::hex({result.output_data, result.output_size}) << '"';
+        m_out << "}\n";
+
+        m_contexts.pop();
+        if (m_contexts.empty())
+            m_opcode_names = nullptr;
+    }
+
+public:
+    explicit InstructionTracer(std::ostream& out) noexcept : m_out{out}
+    {
+        m_out << std::dec;  // Set number formatting to dec, JSON does not support other forms.
+    }
+};
 }  // namespace
 
 std::unique_ptr<Tracer> create_histogram_tracer(std::ostream& out)
 {
     return std::make_unique<HistogramTracer>(out);
+}
+
+std::unique_ptr<Tracer> create_instruction_tracer(std::ostream& out)
+{
+    return std::make_unique<InstructionTracer>(out);
 }
 }  // namespace evmone

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -59,4 +59,6 @@ private:
 /// @return     Histogram tracer object.
 EVMC_EXPORT std::unique_ptr<Tracer> create_histogram_tracer(std::ostream& out);
 
+EVMC_EXPORT std::unique_ptr<Tracer> create_instruction_tracer(std::ostream& out);
+
 }  // namespace evmone

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -46,6 +46,11 @@ evmc_set_option_result set_option(evmc_vm* c_vm, char const* c_name, char const*
         }
         return EVMC_SET_OPTION_INVALID_VALUE;
     }
+    else if (name == "trace")
+    {
+        vm.add_tracer(create_instruction_tracer(std::cerr));
+        return EVMC_SET_OPTION_SUCCESS;
+    }
     else if (name == "histogram")
     {
         vm.add_tracer(create_histogram_tracer(std::cerr));

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -19,6 +19,19 @@ PUSH1,1
 DUP1,4
 ")
 
+    add_test(NAME ${PREFIX}/trace COMMAND $<TARGET_FILE:evmc::tool> --vm $<TARGET_FILE:evmone>,O=0,trace run 60006002800103)
+    set_tests_properties(
+        ${PREFIX}/trace PROPERTIES PASS_REGULAR_EXPRESSION
+        "{\"depth\":0,\"rev\":\"Berlin\",\"static\":false}
+{\"pc\":0,\"op\":96,\"opName\":\"PUSH1\",\"gas\":1000000,\"stack\":\\[\\],\"memorySize\":0}
+{\"pc\":2,\"op\":96,\"opName\":\"PUSH1\",\"gas\":999997,\"stack\":\\[\"0x0\"\\],\"memorySize\":0}
+{\"pc\":4,\"op\":128,\"opName\":\"DUP1\",\"gas\":999994,\"stack\":\\[\"0x0\",\"0x2\"\\],\"memorySize\":0}
+{\"pc\":5,\"op\":1,\"opName\":\"ADD\",\"gas\":999991,\"stack\":\\[\"0x0\",\"0x2\",\"0x2\"\\],\"memorySize\":0}
+{\"pc\":6,\"op\":3,\"opName\":\"SUB\",\"gas\":999988,\"stack\":\\[\"0x0\",\"0x4\"\\],\"memorySize\":0}
+{\"error\":null,\"gas\":999985,\"gasUsed\":15,\"output\":\"\"}
+")
+
+
     get_property(ALL_TESTS DIRECTORY PROPERTY TESTS)
-    set_tests_properties("${ALL_TESTS}" PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/integration-%p.profraw)
+    set_tests_properties(${ALL_TESTS} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/integration-%p.profraw)
 endif()

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -53,7 +53,8 @@ protected:
 
         void on_execution_end(const evmc_result& /*result*/) noexcept override { m_code = nullptr; }
 
-        void on_instruction_start(uint32_t pc) noexcept override
+        void on_instruction_start(
+            uint32_t pc, const evmone::ExecutionState& /*state*/) noexcept override
         {
             const auto opcode = m_code[pc];
             m_trace << m_name << pc << ":"


### PR DESCRIPTION
Implementation of EVM tracing following the [EIP-3155](https://eips.ethereum.org/EIPS/eip-3155) (draft). It outputs log line with JSON (jsonl) for every instruction to standard error output.

Differences from the spec:
1. All calls start with non-standard "start call" log: 
   ```json
   {"kind":"call","static":false,"depth":0,"rev":"Berlin"}
   ```
2. All calls end with non-standard "end call" log as a replacement for single _summerical info_ at the end of transaction execution.
   ```json
   {"error":null,"gas":964766,"gasUsed":35234,"output":"da39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000"}
   ```
   - the `"stateRoot"` is omitted as there is no way to compute it,
   - the `"error"` is taken from the instruction trace log, replaces `"pass"` or `"successful"`.
3. The `"gasCost"` is omitted. This is difficult to compute as "dynamic" gas cost is calculated together with execution but the spec forces these to be separated.
4. The `"depth"` is omitted as already presented in "start call".
5. The `"returnData"` is not implemented. This is doable, but seems unnecessary because this is available in `"output"` in "end call".
6. The `"refund"` is omitted, currently not doable.
7. The `"memory"` was initially implemented, then removed because makes traces huge. It is recommended to enabled it with a flag. This is easy to implement in future.

Example (SHA1):
```json
{"kind":"call","static":false,"depth":0,"rev":"Berlin"}
{"pc":0,"op":96,"opName":"PUSH1","gas":1000000,"stack":[],"memorySize":0}
{"pc":2,"op":96,"opName":"PUSH1","gas":999997,"stack":["0x80"],"memorySize":0}
{"pc":4,"op":82,"opName":"MSTORE","gas":999994,"stack":["0x40","0x80"],"memorySize":0}
{"pc":5,"op":52,"opName":"CALLVALUE","gas":999982,"stack":[],"memorySize":96}
{"pc":6,"op":128,"opName":"DUP1","gas":999980,"stack":["0x0"],"memorySize":96}
{"pc":7,"op":21,"opName":"ISZERO","gas":999977,"stack":["0x0","0x0"],"memorySize":96}
{"pc":8,"op":97,"opName":"PUSH2","gas":999974,"stack":["0x1","0x0"],"memorySize":96}
{"pc":11,"op":87,"opName":"JUMPI","gas":999971,"stack":["0x10","0x1","0x0"],"memorySize":96}
{"pc":16,"op":91,"opName":"JUMPDEST","gas":999961,"stack":["0x0"],"memorySize":96}
{"pc":17,"op":80,"opName":"POP","gas":999960,"stack":["0x0"],"memorySize":96}

...

{"pc":1207,"op":23,"opName":"OR","gas":964862,"stack":["0xda39a3ee5e6b4b0d3255bfef0000000000000000","0x9560189000000000","0xafd80709","0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0x0","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1208,"op":23,"opName":"OR","gas":964859,"stack":["0xda39a3ee5e6b4b0d3255bfef9560189000000000","0xafd80709","0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0x0","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1209,"op":96,"opName":"PUSH1","gas":964856,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709","0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0x0","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1211,"op":27,"opName":"SHL","gas":964853,"stack":["0x60","0xda39a3ee5e6b4b0d3255bfef95601890afd80709","0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0x0","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1212,"op":148,"opName":"SWAP5","gas":964850,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0x0","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1213,"op":80,"opName":"POP","gas":964847,"stack":["0x0","0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1214,"op":80,"opName":"POP","gas":964845,"stack":["0xda39a3ee005e6b4b0d003255bfef009560189000afd80709","0x40","0x0","0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1215,"op":80,"opName":"POP","gas":964843,"stack":["0x40","0x0","0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1216,"op":80,"opName":"POP","gas":964841,"stack":["0x0","0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1217,"op":80,"opName":"POP","gas":964839,"stack":["0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1218,"op":145,"opName":"SWAP2","gas":964837,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xa0","0xd6","0x1605782b"],"memorySize":512}
{"pc":1219,"op":144,"opName":"SWAP1","gas":964834,"stack":["0xd6","0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":1220,"op":80,"opName":"POP","gas":964831,"stack":["0xa0","0xd6","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":1221,"op":86,"opName":"JUMP","gas":964829,"stack":["0xd6","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":214,"op":91,"opName":"JUMPDEST","gas":964821,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":215,"op":96,"opName":"PUSH1","gas":964820,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":217,"op":128,"opName":"DUP1","gas":964817,"stack":["0x40","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":218,"op":81,"opName":"MLOAD","gas":964814,"stack":["0x40","0x40","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":219,"op":107,"opName":"PUSH12","gas":964811,"stack":["0xa0","0x40","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":232,"op":25,"opName":"NOT","gas":964808,"stack":["0xffffffffffffffffffffffff","0xa0","0x40","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":233,"op":144,"opName":"SWAP1","gas":964805,"stack":["0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000","0xa0","0x40","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":234,"op":146,"opName":"SWAP3","gas":964802,"stack":["0xa0","0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000","0x40","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x1605782b"],"memorySize":512}
{"pc":235,"op":22,"opName":"AND","gas":964799,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000","0x40","0xa0","0x1605782b"],"memorySize":512}
{"pc":236,"op":130,"opName":"DUP3","gas":964796,"stack":["0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x40","0xa0","0x1605782b"],"memorySize":512}
{"pc":237,"op":82,"opName":"MSTORE","gas":964793,"stack":["0xa0","0xda39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000","0x40","0xa0","0x1605782b"],"memorySize":512}
{"pc":238,"op":81,"opName":"MLOAD","gas":964790,"stack":["0x40","0xa0","0x1605782b"],"memorySize":512}
{"pc":239,"op":144,"opName":"SWAP1","gas":964787,"stack":["0xa0","0xa0","0x1605782b"],"memorySize":512}
{"pc":240,"op":129,"opName":"DUP2","gas":964784,"stack":["0xa0","0xa0","0x1605782b"],"memorySize":512}
{"pc":241,"op":144,"opName":"SWAP1","gas":964781,"stack":["0xa0","0xa0","0xa0","0x1605782b"],"memorySize":512}
{"pc":242,"op":3,"opName":"SUB","gas":964778,"stack":["0xa0","0xa0","0xa0","0x1605782b"],"memorySize":512}
{"pc":243,"op":96,"opName":"PUSH1","gas":964775,"stack":["0x0","0xa0","0x1605782b"],"memorySize":512}
{"pc":245,"op":1,"opName":"ADD","gas":964772,"stack":["0x20","0x0","0xa0","0x1605782b"],"memorySize":512}
{"pc":246,"op":144,"opName":"SWAP1","gas":964769,"stack":["0x20","0xa0","0x1605782b"],"memorySize":512}
{"pc":247,"op":243,"opName":"RETURN","gas":964766,"stack":["0xa0","0x20","0x1605782b"],"memorySize":512}
{"error":null,"gas":964766,"gasUsed":35234,"output":"da39a3ee5e6b4b0d3255bfef95601890afd80709000000000000000000000000"}
```

[sha1.txt](https://github.com/ethereum/evmone/files/6524230/sha1.txt)

