### PR TITLE
baseline: Use custom instruction table

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(evmone
     analysis.hpp
     baseline.cpp
     baseline.hpp
+    baseline_instruction_table.cpp
+    baseline_instruction_table.hpp
     execution.cpp
     execution.hpp
     instruction_traits.hpp

--- a/lib/evmone/baseline_instruction_table.cpp
+++ b/lib/evmone/baseline_instruction_table.cpp
@@ -1,0 +1,52 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2020 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "baseline_instruction_table.hpp"
+#include "instruction_traits.hpp"
+#include <cassert>
+
+namespace evmone
+{
+namespace
+{
+template <evmc_revision Rev>
+constexpr InstructionTable create_instruction_table() noexcept
+{
+    InstructionTable table{};
+    for (size_t i = 0; i < table.size(); ++i)
+    {
+        auto& t = table[i];
+        const auto gas_cost = instr::gas_costs<Rev>[i];
+        t.gas_cost = gas_cost;  // Include instr::undefined in the table.
+        t.stack_height_required = instr::traits[i].stack_height_required;
+
+        // Because any instruction can increase stack height at most of 1,
+        // stack overflow can only happen if stack height is already at the limit.
+        assert(instr::traits[i].stack_height_change <= 1);
+        t.can_overflow_stack = instr::traits[i].stack_height_change > 0;
+    }
+    return table;
+}
+
+constexpr InstructionTable instruction_tables[] = {
+    create_instruction_table<EVMC_FRONTIER>(),
+    create_instruction_table<EVMC_HOMESTEAD>(),
+    create_instruction_table<EVMC_TANGERINE_WHISTLE>(),
+    create_instruction_table<EVMC_SPURIOUS_DRAGON>(),
+    create_instruction_table<EVMC_BYZANTIUM>(),
+    create_instruction_table<EVMC_CONSTANTINOPLE>(),
+    create_instruction_table<EVMC_PETERSBURG>(),
+    create_instruction_table<EVMC_ISTANBUL>(),
+    create_instruction_table<EVMC_BERLIN>(),
+    create_instruction_table<EVMC_LONDON>(),
+};
+static_assert(std::size(instruction_tables) == EVMC_MAX_REVISION + 1,
+    "instruction table entry missing for an EVMC revision");
+}  // namespace
+
+const InstructionTable& get_baseline_instruction_table(evmc_revision rev) noexcept
+{
+    return instruction_tables[rev];
+}
+}  // namespace evmone

--- a/lib/evmone/baseline_instruction_table.hpp
+++ b/lib/evmone/baseline_instruction_table.hpp
@@ -1,0 +1,21 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2020 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.h>
+#include <array>
+
+namespace evmone
+{
+struct InstructionTableEntry
+{
+    int16_t gas_cost;
+    int8_t stack_height_required;
+    bool can_overflow_stack;
+};
+
+using InstructionTable = std::array<InstructionTableEntry, 256>;
+
+const InstructionTable& get_baseline_instruction_table(evmc_revision rev) noexcept;
+}  // namespace evmone


### PR DESCRIPTION
Previously EVMC instruction tables were used (for quick head start).
Now two EVMC tables are replaced with single one. This at least cuts memory bandwidth from 12 bytes to 4 bytes per instruction.
Changes to instruction requirements checks are minimal but the stack overflow is checked differently.
The check can be further optimized but this will be done separately.