### PR TITLE
Upgrade intx to 0.6.0

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -4,9 +4,9 @@
 
 hunter_config(
     intx
-    VERSION 0.5.1
-    URL https://github.com/chfast/intx/archive/v0.5.1.tar.gz
-    SHA1 743c46a82750143bd302a4394b7008a2112fc97b
+    VERSION 0.6.0
+    URL https://github.com/chfast/intx/archive/v0.6.0.tar.gz
+    SHA1 507827495de07412863349bc8c2a8704c7b0e5d4
 )
 
 hunter_config(

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -122,7 +122,7 @@ inline evmc_status_code exp(ExecutionState& state) noexcept
     auto& exponent = state.stack.top();
 
     const auto exponent_significant_bytes =
-        static_cast<int>(intx::count_significant_words<uint8_t>(exponent));
+        static_cast<int>(intx::count_significant_bytes(exponent));
     const auto exponent_cost = state.rev >= EVMC_SPURIOUS_DRAGON ? 50 : 10;
     const auto additional_cost = exponent_significant_bytes * exponent_cost;
     if ((state.gas_left -= additional_cost) < 0)
@@ -156,26 +156,19 @@ inline void lt(Stack& stack) noexcept
 inline void gt(Stack& stack) noexcept
 {
     const auto x = stack.pop();
-    stack[0] = stack[0] < x;  // TODO: Using < is faster than >.
+    stack[0] = stack[0] < x;  // Arguments are swapped and < is used.
 }
 
 inline void slt(Stack& stack) noexcept
 {
-    // TODO: Move this to intx.
     const auto x = stack.pop();
-    auto& y = stack[0];
-    const auto x_neg = x.hi.hi >> 63;
-    const auto y_neg = y.hi.hi >> 63;
-    y = ((x_neg ^ y_neg) != 0) ? x_neg : x < y;
+    stack[0] = slt(x, stack[0]);
 }
 
 inline void sgt(Stack& stack) noexcept
 {
     const auto x = stack.pop();
-    auto& y = stack[0];
-    const auto x_neg = x.hi.hi >> 63;
-    const auto y_neg = y.hi.hi >> 63;
-    y = ((x_neg ^ y_neg) != 0) ? y_neg : y < x;
+    stack[0] = slt(stack[0], x);  // Arguments are swapped and SLT is used.
 }
 
 inline void eq(Stack& stack) noexcept

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -499,6 +499,22 @@ TEST_P(evm, exp)
     EXPECT_EQ(bytes(&result.output_data[0], 32), a);
 }
 
+TEST_P(evm, exp_1_0)
+{
+    const auto code = push(0) + push(1) + OP_EXP + ret_top();
+    execute(31, code);
+    EXPECT_GAS_USED(EVMC_SUCCESS, 31);
+    EXPECT_OUTPUT_INT(1);
+}
+
+TEST_P(evm, exp_0_0)
+{
+    const auto code = push(0) + push(0) + OP_EXP + ret_top();
+    execute(31, code);
+    EXPECT_GAS_USED(EVMC_SUCCESS, 31);
+    EXPECT_OUTPUT_INT(1);
+}
+
 TEST_P(evm, exp_oog)
 {
     auto code = "6001600003800a";


### PR DESCRIPTION
[intx 0.6.0](https://github.com/chfast/intx/releases/tag/v0.6.0)

Haswell 4.0 GHz, clang-12
```
Comparing o/main-master to o/main-intx06
Benchmark                                                                Time             CPU      Time Old      Time New       CPU Old       CPU New
-----------------------------------------------------------------------------------------------------------------------------------------------------
advanced/execute/main/blake2b_huff/empty_mean                         +0.0172         +0.0172            13            13            13            13
baseline/execute/main/blake2b_huff/empty_mean                         -0.0001         -0.0001            16            16            16            16
advanced/execute/main/blake2b_huff/2805nulls_mean                     +0.0181         +0.0180           275           280           275           280
baseline/execute/main/blake2b_huff/2805nulls_mean                     -0.0025         -0.0025           343           342           343           342
advanced/execute/main/blake2b_huff/5610nulls_mean                     +0.0197         +0.0197           536           547           536           547
baseline/execute/main/blake2b_huff/5610nulls_mean                     +0.0019         +0.0019           669           670           669           670
advanced/execute/main/blake2b_huff/8415nulls_mean                     +0.0189         +0.0189           785           800           785           800
baseline/execute/main/blake2b_huff/8415nulls_mean                     +0.0114         +0.0114           976           987           976           987
advanced/execute/main/blake2b_huff/65536nulls_mean                    +0.0152         +0.0152          6109          6202          6109          6202
baseline/execute/main/blake2b_huff/65536nulls_mean                    +0.0023         +0.0023          7603          7620          7603          7620
advanced/execute/main/blake2b_shifts/2805nulls_mean                   -0.0134         -0.0134          3798          3747          3798          3747
baseline/execute/main/blake2b_shifts/2805nulls_mean                   -0.0380         -0.0380          3382          3254          3382          3254
advanced/execute/main/blake2b_shifts/5610nulls_mean                   -0.0149         -0.0149          7586          7473          7586          7473
baseline/execute/main/blake2b_shifts/5610nulls_mean                   -0.0366         -0.0366          6750          6503          6750          6503
advanced/execute/main/blake2b_shifts/8415nulls_mean                   -0.0126         -0.0126         11353         11209         11353         11209
baseline/execute/main/blake2b_shifts/8415nulls_mean                   -0.0344         -0.0344         10122          9774         10123          9774
advanced/execute/main/blake2b_shifts/65536nulls_mean                  -0.0115         -0.0115         87868         86858         87868         86858
baseline/execute/main/blake2b_shifts/65536nulls_mean                  -0.0280         -0.0280         78062         75875         78062         75875
advanced/execute/main/sha1_divs/empty_mean                            -0.0079         -0.0079            56            56            56            56
baseline/execute/main/sha1_divs/empty_mean                            -0.0007         -0.0007            59            59            59            59
advanced/execute/main/sha1_divs/1351_mean                             -0.0014         -0.0014          1153          1152          1153          1152
baseline/execute/main/sha1_divs/1351_mean                             -0.0033         -0.0033          1230          1226          1230          1226
advanced/execute/main/sha1_divs/2737_mean                             -0.0002         -0.0002          2251          2250          2251          2250
baseline/execute/main/sha1_divs/2737_mean                             -0.0065         -0.0065          2407          2391          2407          2391
advanced/execute/main/sha1_divs/5311_mean                             +0.0015         +0.0015          4384          4391          4384          4391
baseline/execute/main/sha1_divs/5311_mean                             -0.0057         -0.0056          4694          4667          4694          4667
advanced/execute/main/sha1_divs/65536_mean                            +0.0008         +0.0008         53528         53572         53528         53572
baseline/execute/main/sha1_divs/65536_mean                            -0.0021         -0.0021         57029         56909         57029         56910
advanced/execute/main/sha1_shifts/empty_mean                          -0.0016         -0.0016            32            32            32            32
baseline/execute/main/sha1_shifts/empty_mean                          -0.0072         -0.0072            35            35            35            35
advanced/execute/main/sha1_shifts/1351_mean                           -0.0041         -0.0041           673           670           673           670
baseline/execute/main/sha1_shifts/1351_mean                           -0.0049         -0.0049           744           740           744           740
advanced/execute/main/sha1_shifts/2737_mean                           -0.0059         -0.0059          1315          1307          1315          1307
baseline/execute/main/sha1_shifts/2737_mean                           -0.0077         -0.0077          1460          1449          1460          1449
advanced/execute/main/sha1_shifts/5311_mean                           -0.0007         -0.0007          2558          2556          2558          2556
baseline/execute/main/sha1_shifts/5311_mean                           -0.0092         -0.0092          2844          2818          2845          2818
advanced/execute/main/sha1_shifts/65536_mean                          -0.0004         -0.0004         31126         31112         31126         31112
baseline/execute/main/sha1_shifts/65536_mean                          -0.0086         -0.0086         34792         34494         34792         34494
advanced/execute/main/weierstrudel/0_mean                             -0.0764         -0.0764           183           169           183           169
baseline/execute/main/weierstrudel/0_mean                             -0.0932         -0.0932           188           170           188           170
advanced/execute/main/weierstrudel/1_mean                             -0.1011         -0.1011           416           374           416           374
baseline/execute/main/weierstrudel/1_mean                             -0.0958         -0.0958           421           381           421           381
advanced/execute/main/weierstrudel/3_mean                             -0.1032         -0.1032           651           584           651           584
baseline/execute/main/weierstrudel/3_mean                             -0.0984         -0.0984           659           594           659           594
advanced/execute/main/weierstrudel/9_mean                             -0.1045         -0.1045          1351          1210          1351          1210
baseline/execute/main/weierstrudel/9_mean                             -0.1015         -0.1015          1372          1232          1372          1232
advanced/execute/main/weierstrudel/14_mean                            -0.1035         -0.1035          1934          1734          1934          1734
```