### PR TITLE
Uniform access to code analysis via ExecutionState

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ executors:
       - image: ethereum/cpp-build-env:16-clang-11
   macos:
     macos:
-      xcode: 11.1.0
+      xcode: 12.5.1
 
 commands:
   build_silkworm:

--- a/lib/evmone/analysis.hpp
+++ b/lib/evmone/analysis.hpp
@@ -42,8 +42,6 @@ struct block_info
 };
 static_assert(sizeof(block_info) == 8);
 
-struct AdvancedCodeAnalysis;
-
 /// The execution state specialized for the Advanced interpreter.
 struct AdvancedExecutionState : ExecutionState
 {
@@ -51,9 +49,6 @@ struct AdvancedExecutionState : ExecutionState
     ///
     /// This is only needed to correctly calculate the "current gas left" value.
     uint32_t current_block_cost = 0;
-
-    /// Pointer to code analysis.
-    const AdvancedCodeAnalysis* analysis = nullptr;
 
     using ExecutionState::ExecutionState;
 
@@ -70,8 +65,8 @@ struct AdvancedExecutionState : ExecutionState
         const uint8_t* code_ptr, size_t code_size) noexcept
     {
         ExecutionState::reset(message, revision, host_interface, host_ctx, code_ptr, code_size);
+        analysis.advanced = nullptr;  // For consistency with previous behavior.
         current_block_cost = 0;
-        analysis = nullptr;
     }
 };
 

--- a/lib/evmone/execution.cpp
+++ b/lib/evmone/execution.cpp
@@ -10,9 +10,9 @@ namespace evmone
 {
 evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& analysis) noexcept
 {
-    state.analysis = &analysis;  // Allow accessing the analysis by instructions.
+    state.analysis.advanced = &analysis;  // Allow accessing the analysis by instructions.
 
-    const auto* instr = &state.analysis->instrs[0];  // Start with the first instruction.
+    const auto* instr = &state.analysis.advanced->instrs[0];  // Start with the first instruction.
     while (instr != nullptr)
         instr = instr->fn(instr, state);
 

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -10,6 +10,12 @@
 
 namespace evmone
 {
+struct AdvancedCodeAnalysis;
+namespace baseline
+{
+struct CodeAnalysis;
+}
+
 using uint256 = intx::uint256;
 using bytes = std::basic_string<uint8_t>;
 using bytes_view = std::basic_string_view<uint8_t>;
@@ -105,6 +111,14 @@ struct ExecutionState
     evmc_status_code status = EVMC_SUCCESS;
     size_t output_offset = 0;
     size_t output_size = 0;
+
+    /// Pointer to code analysis.
+    /// This should be set and used internally by execute() function of a particular interpreter.
+    union
+    {
+        const baseline::CodeAnalysis* baseline = nullptr;
+        const AdvancedCodeAnalysis* advanced;
+    } analysis{};
 
     ExecutionState() noexcept = default;
 

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -107,7 +107,11 @@ struct ExecutionState
     evmc::HostContext host;
     evmc_revision rev = {};
     bytes return_data;
+
+    /// Reference to original EVM code.
+    /// TODO: Code should be accessed via code analysis only and this should be removed.
     bytes_view code;
+
     evmc_status_code status = EVMC_SUCCESS;
     size_t output_offset = 0;
     size_t output_size = 0;

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -44,10 +44,10 @@ const instruction* op_jump(const instruction*, AdvancedExecutionState& state) no
     const auto dst = state.stack.pop();
     auto pc = -1;
     if (std::numeric_limits<int>::max() < dst ||
-        (pc = find_jumpdest(*state.analysis, static_cast<int>(dst))) < 0)
+        (pc = find_jumpdest(*state.analysis.advanced, static_cast<int>(dst))) < 0)
         return state.exit(EVMC_BAD_JUMP_DESTINATION);
 
-    return &state.analysis->instrs[static_cast<size_t>(pc)];
+    return &state.analysis.advanced->instrs[static_cast<size_t>(pc)];
 }
 
 const instruction* op_jumpi(const instruction* instr, AdvancedExecutionState& state) noexcept

--- a/test/unittests/execution_state_test.cpp
+++ b/test/unittests/execution_state_test.cpp
@@ -75,7 +75,7 @@ TEST(execution_state, default_construct_advanced)
     EXPECT_EQ(st.output_size, 0);
 
     EXPECT_EQ(st.current_block_cost, 0u);
-    EXPECT_EQ(st.analysis, nullptr);
+    EXPECT_EQ(st.analysis.advanced, nullptr);
 }
 
 TEST(execution_state, reset_advanced)
@@ -96,7 +96,7 @@ TEST(execution_state, reset_advanced)
     st.output_offset = 3;
     st.output_size = 4;
     st.current_block_cost = 5;
-    st.analysis = &analysis;
+    st.analysis.advanced = &analysis;
 
     EXPECT_EQ(st.gas_left, 1);
     EXPECT_EQ(st.stack.size(), 1);
@@ -110,7 +110,7 @@ TEST(execution_state, reset_advanced)
     EXPECT_EQ(st.output_offset, 3);
     EXPECT_EQ(st.output_size, 4u);
     EXPECT_EQ(st.current_block_cost, 5u);
-    EXPECT_EQ(st.analysis, &analysis);
+    EXPECT_EQ(st.analysis.advanced, &analysis);
 
     {
         evmc_message msg2{};
@@ -134,7 +134,7 @@ TEST(execution_state, reset_advanced)
         EXPECT_EQ(st.output_offset, 0);
         EXPECT_EQ(st.output_size, 0);
         EXPECT_EQ(st.current_block_cost, 0u);
-        EXPECT_EQ(st.analysis, nullptr);
+        EXPECT_EQ(st.analysis.advanced, nullptr);
     }
 }
 


### PR DESCRIPTION
Add pointer to code analysis to ExecutionState to unify signature of instruction implementations.