### PR TITLE
Return new pc from instruction implementation

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -59,16 +59,6 @@ inline const uint8_t* jump(ExecutionState& state) noexcept
     return &state.code[static_cast<size_t>(dst)];
 }
 
-template <size_t Len>
-inline const uint8_t* load_push(ExecutionState& state, const uint8_t* code) noexcept
-{
-    uint8_t buffer[Len];
-    // This valid because code is padded with garbage to satisfy push data read pass the code end.
-    std::memcpy(buffer, code, Len);
-    state.stack.push(intx::be::load<intx::uint256>(buffer));
-    return code + Len;
-}
-
 inline evmc_status_code check_requirements(
     const InstructionTable& instruction_table, ExecutionState& state, uint8_t op) noexcept
 {
@@ -441,100 +431,100 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
             DISPATCH_NEXT();
 
         case OP_PUSH1:
-            code_it = load_push<1>(state, code_it + 1);
+            code_it = code + push<1>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH2:
-            code_it = load_push<2>(state, code_it + 1);
+            code_it = code + push<2>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH3:
-            code_it = load_push<3>(state, code_it + 1);
+            code_it = code + push<3>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH4:
-            code_it = load_push<4>(state, code_it + 1);
+            code_it = code + push<4>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH5:
-            code_it = load_push<5>(state, code_it + 1);
+            code_it = code + push<5>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH6:
-            code_it = load_push<6>(state, code_it + 1);
+            code_it = code + push<6>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH7:
-            code_it = load_push<7>(state, code_it + 1);
+            code_it = code + push<7>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH8:
-            code_it = load_push<8>(state, code_it + 1);
+            code_it = code + push<8>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH9:
-            code_it = load_push<9>(state, code_it + 1);
+            code_it = code + push<9>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH10:
-            code_it = load_push<10>(state, code_it + 1);
+            code_it = code + push<10>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH11:
-            code_it = load_push<11>(state, code_it + 1);
+            code_it = code + push<11>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH12:
-            code_it = load_push<12>(state, code_it + 1);
+            code_it = code + push<12>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH13:
-            code_it = load_push<13>(state, code_it + 1);
+            code_it = code + push<13>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH14:
-            code_it = load_push<14>(state, code_it + 1);
+            code_it = code + push<14>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH15:
-            code_it = load_push<15>(state, code_it + 1);
+            code_it = code + push<15>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH16:
-            code_it = load_push<16>(state, code_it + 1);
+            code_it = code + push<16>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH17:
-            code_it = load_push<17>(state, code_it + 1);
+            code_it = code + push<17>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH18:
-            code_it = load_push<18>(state, code_it + 1);
+            code_it = code + push<18>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH19:
-            code_it = load_push<19>(state, code_it + 1);
+            code_it = code + push<19>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH20:
-            code_it = load_push<20>(state, code_it + 1);
+            code_it = code + push<20>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH21:
-            code_it = load_push<21>(state, code_it + 1);
+            code_it = code + push<21>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH22:
-            code_it = load_push<22>(state, code_it + 1);
+            code_it = code + push<22>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH23:
-            code_it = load_push<23>(state, code_it + 1);
+            code_it = code + push<23>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH24:
-            code_it = load_push<24>(state, code_it + 1);
+            code_it = code + push<24>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH25:
-            code_it = load_push<25>(state, code_it + 1);
+            code_it = code + push<25>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH26:
-            code_it = load_push<26>(state, code_it + 1);
+            code_it = code + push<26>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH27:
-            code_it = load_push<27>(state, code_it + 1);
+            code_it = code + push<27>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH28:
-            code_it = load_push<28>(state, code_it + 1);
+            code_it = code + push<28>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH29:
-            code_it = load_push<29>(state, code_it + 1);
+            code_it = code + push<29>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH30:
-            code_it = load_push<30>(state, code_it + 1);
+            code_it = code + push<30>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH31:
-            code_it = load_push<31>(state, code_it + 1);
+            code_it = code + push<31>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
         case OP_PUSH32:
-            code_it = load_push<32>(state, code_it + 1);
+            code_it = code + push<32>(state, static_cast<size_t>(code_it - code)).pc;
             DISPATCH();
 
         case OP_DUP1:

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -45,34 +45,6 @@ CodeAnalysis analyze(const uint8_t* code, size_t code_size)
 
 namespace
 {
-/// Helper for JUMP/JUMPI instructions to check validity of a jump destination.
-inline InstrResult resolve_jump_destination(
-    const CodeAnalysis& analysis, const uint256& dst) noexcept
-{
-    const auto& jumpdest_map = analysis.jumpdest_map;
-    if (dst >= jumpdest_map.size() || !jumpdest_map[static_cast<size_t>(dst)])
-        return {EVMC_BAD_JUMP_DESTINATION, 0};
-
-    return {EVMC_SUCCESS, static_cast<size_t>(dst)};
-}
-
-/// JUMP instruction implementation using baseline::CodeAnalysis.
-inline InstrResult jump(ExecutionState& state, size_t /*pc*/) noexcept
-{
-    return resolve_jump_destination(*state.analysis.baseline, state.stack.pop());
-}
-
-/// JUMPI instruction implementation using baseline::CodeAnalysis.
-inline InstrResult jumpi(ExecutionState& state, size_t pc) noexcept
-{
-    const auto dst = state.stack.pop();
-    const auto cond = state.stack.pop();
-    if (cond)
-        return resolve_jump_destination(*state.analysis.baseline, dst);
-    else
-        return {EVMC_SUCCESS, pc + 1};
-}
-
 inline evmc_status_code check_requirements(
     const InstructionTable& instruction_table, ExecutionState& state, uint8_t op) noexcept
 {

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -408,8 +408,9 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
             DISPATCH();
 
         case OP_PC:
-            state.stack.push(code_it - code);
-            DISPATCH_NEXT();
+            code_it = code + pc(state, static_cast<size_t>(code_it - code)).pc;
+            DISPATCH();
+
         case OP_MSIZE:
             msize(state);
             DISPATCH_NEXT();

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -732,6 +732,21 @@ inline evmc_status_code gas(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
+/// PUSH instruction implementation.
+/// @tparam Len The number of push data bytes, e.g. PUSH3 is push<3>.
+///
+/// It assumes that the whole data read is valid so code padding is required for some EVM bytecodes
+/// having an "incomplete" PUSH instruction at the very end.
+template <size_t Len>
+inline InstrResult push(ExecutionState& state, size_t pc) noexcept
+{
+    const auto data_pos = state.code.data() + pc + 1;
+    uint8_t buffer[Len];
+    std::memcpy(buffer, data_pos, Len);  // Valid by the assumption code is padded.
+    state.stack.push(intx::be::load<intx::uint256>(buffer));
+    return {EVMC_SUCCESS, pc + 1 + Len};
+}
+
 /// DUP instruction implementation.
 /// @tparam N  The number as in the instruction definition, e.g. DUP3 is dup<3>.
 template <size_t N>

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -9,6 +9,13 @@
 
 namespace evmone
 {
+/// Full status of an instruction execution.
+struct InstrResult
+{
+    evmc_status_code status;  ///< Status code.
+    size_t pc;                ///< Code offset of the next instruction (PC).
+};
+
 /// Function signature of the core implementation (without requirements check)
 /// of an EVM instruction.
 using InstrFn = evmc_status_code(ExecutionState&) noexcept;
@@ -707,6 +714,11 @@ inline evmc_status_code sstore(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
+inline InstrResult pc(ExecutionState& state, size_t pc) noexcept
+{
+    state.stack.push(pc);
+    return {EVMC_SUCCESS, pc + 1};
+}
 
 inline evmc_status_code msize(ExecutionState& state) noexcept
 {
@@ -826,4 +838,5 @@ inline evmc_status_code selfdestruct(ExecutionState& state) noexcept
     state.host.selfdestruct(state.msg->destination, beneficiary);
     return EVMC_SUCCESS;
 }
+
 }  // namespace evmone


### PR DESCRIPTION
This introduces new "more unified" instruction implementation signature which receives current PC and returns new PC. Allows implementing PUSH, JUMP and JUMPI instructions.