### PR TITLE
Optimize BYTE and SAR for code size

### DIFF
--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -269,20 +269,15 @@ inline evmc_status_code shr(ExecutionState& state) noexcept
 
 inline evmc_status_code sar(ExecutionState& state) noexcept
 {
-    if ((state.stack[1] & (uint256{1} << 255)) == 0)
-        return shr(state);
+    const auto y = state.stack.pop();
+    auto& x = state.stack.top();
 
-    constexpr auto allones = ~uint256{};
+    const bool is_neg = static_cast<int64_t>(x[3]) < 0;  // Inspect the top bit (words are LE).
+    const auto sign_mask = is_neg ? ~uint256{} : uint256{};
 
-    if (state.stack[0] >= 256)
-        state.stack[1] = allones;
-    else
-    {
-        const auto shift = static_cast<unsigned>(state.stack[0]);
-        state.stack[1] = (state.stack[1] >> shift) | (allones << (256 - shift));
-    }
+    const auto mask_shift = (y < 256) ? (256 - y[0]) : 0;
+    x = (x >> y) | (sign_mask << mask_shift);
 
-    state.stack.pop();
     return EVMC_SUCCESS;
 }
 

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -244,14 +244,14 @@ inline evmc_status_code byte(ExecutionState& state) noexcept
     const auto n = state.stack.pop();
     auto& x = state.stack.top();
 
-    if (n > 31)
-        x = 0;
-    else
-    {
-        auto sh = (31 - static_cast<unsigned>(n)) * 8;
-        auto y = x >> sh;
-        x = y & 0xff;
-    }
+    const bool n_valid = n < 32;
+    const uint64_t byte_mask = (n_valid ? 0xff : 0);
+
+    const auto index = 31 - static_cast<unsigned>(n[0] % 32);
+    const auto word = x[index / 8];
+    const auto byte_index = index % 8;
+    const auto byte = (word >> (byte_index * 8)) & byte_mask;
+    x = byte;
     return EVMC_SUCCESS;
 }
 

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -398,6 +398,17 @@ TEST_P(evm, byte)
     EXPECT_EQ(result.output_data[6], 0);
 }
 
+TEST_P(evm, byte_overflow)
+{
+    const auto code = not_(0) + push(32) + OP_BYTE + ret_top();
+    execute(code);
+    EXPECT_OUTPUT_INT(0);
+
+    const auto code2 = not_(0) + push("ffffffffffffffffffffffffffffffffffff") + OP_BYTE + ret_top();
+    execute(code2);
+    EXPECT_OUTPUT_INT(0);
+}
+
 TEST_P(evm, addmod_mulmod)
 {
     std::string s;


### PR DESCRIPTION
Rework implementations of `BYTE` and `SAR` to make its code size smaller. The `BYTE` now has branchless implementation. The `SAR` is still not inlined by is 33% smaller by assembly lines.