### PR TITLE
Switch find_jumpdest (Advanced Interpreter) to unrolled binary search

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(evmone
     opcodes_helpers.h
     tracing.cpp
     tracing.hpp
+    unrolled_binary_search.hpp
     vm.cpp
     vm.hpp
 )

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -189,9 +189,9 @@ AdvancedCodeAnalysis analyze(evmc_revision rev, const uint8_t* code, size_t code
     assert(analysis.push_values.size() <= max_args_storage_size);
 
     // pad jumpdest_offsets to make it suitable for unrolled_binary_search
-    const size_t padded_size_of_jumpdest_offsets =
-        bit_ceil(analysis.jumpdest_offsets.size() + 1) - 1;
-    analysis.jumpdest_offsets.resize(padded_size_of_jumpdest_offsets, INT32_MAX);
+    const uint64_t padded_size =
+        bit_ceil(static_cast<uint64_t>(analysis.jumpdest_offsets.size()) + 1) - 1;
+    analysis.jumpdest_offsets.resize(static_cast<size_t>(padded_size), INT32_MAX);
 
     return analysis;
 }

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -43,7 +43,7 @@ const instruction* op_jump(const instruction*, AdvancedExecutionState& state) no
 {
     const auto dst = state.stack.pop();
     auto pc = -1;
-    if (std::numeric_limits<int>::max() < dst ||
+    if (dst >= INT32_MAX ||  // find_jumpdest can't handle INT32_MAX
         (pc = find_jumpdest(*state.analysis.advanced, static_cast<int>(dst))) < 0)
         return state.exit(EVMC_BAD_JUMP_DESTINATION);
 

--- a/lib/evmone/unrolled_binary_search.hpp
+++ b/lib/evmone/unrolled_binary_search.hpp
@@ -21,6 +21,9 @@ namespace evmone
 template <typename T>
 const T* unrolled_binary_search(const T* vec, size_t n, const T& key)
 {
+    if (n == 0)
+        return vec;
+
     int pos = -1;
     switch (n + 1)
     {

--- a/lib/evmone/unrolled_binary_search.hpp
+++ b/lib/evmone/unrolled_binary_search.hpp
@@ -1,5 +1,5 @@
 // evmone: Fast Ethereum Virtual Machine implementation
-// Copyright 2019-2020 The evmone Authors.
+// Copyright 2021 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/lib/evmone/unrolled_binary_search.hpp
+++ b/lib/evmone/unrolled_binary_search.hpp
@@ -1,0 +1,64 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2019-2020 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+namespace evmone
+{
+// Unrolled version of the binary search that shines for small (pre-sorted) arrays/vectors.
+//
+// See
+// https://dirtyhandscoding.wordpress.com/2017/08/25/performance-comparison-linear-search-vs-binary-search/
+// and
+// https://arxiv.org/abs/1509.05053
+//
+// Only suitable for arrays whose size + 1 equals a power of 2!!!
+// i.e. ∃ k: n + 1 = 2^k.
+// Falls back to std::lower_bound otherwise.
+template <typename T>
+const T* unrolled_binary_search(const T* vec, size_t n, const T& key)
+{
+    int pos = -1;
+    switch (n + 1)
+    {
+    case 1u << 10:
+        pos = (vec[pos + (1 << 9)] < key ? pos + (1 << 9) : pos);
+        [[fallthrough]];
+    case 1u << 9:
+        pos = (vec[pos + (1 << 8)] < key ? pos + (1 << 8) : pos);
+        [[fallthrough]];
+    case 1u << 8:
+        pos = (vec[pos + (1 << 7)] < key ? pos + (1 << 7) : pos);
+        [[fallthrough]];
+    case 1u << 7:
+        pos = (vec[pos + (1 << 6)] < key ? pos + (1 << 6) : pos);
+        [[fallthrough]];
+    case 1u << 6:
+        pos = (vec[pos + (1 << 5)] < key ? pos + (1 << 5) : pos);
+        [[fallthrough]];
+    case 1u << 5:
+        pos = (vec[pos + (1 << 4)] < key ? pos + (1 << 4) : pos);
+        [[fallthrough]];
+    case 1u << 4:
+        pos = (vec[pos + (1 << 3)] < key ? pos + (1 << 3) : pos);
+        [[fallthrough]];
+    case 1u << 3:
+        pos = (vec[pos + (1 << 2)] < key ? pos + (1 << 2) : pos);
+        [[fallthrough]];
+    case 1u << 2:
+        pos = (vec[pos + (1 << 1)] < key ? pos + (1 << 1) : pos);
+        [[fallthrough]];
+    case 1u << 1:
+        pos = (vec[pos + (1 << 0)] < key ? pos + (1 << 0) : pos);
+        [[fallthrough]];
+    case 1u << 0:
+        return vec + pos + 1;
+    }
+
+    return std::lower_bound(vec, vec + n, key);
+}
+
+}  // namespace evmone

--- a/lib/evmone/unrolled_binary_search.hpp
+++ b/lib/evmone/unrolled_binary_search.hpp
@@ -25,41 +25,62 @@ const T* unrolled_binary_search(const T* vec, size_t n, const T& key)
         return vec;
 
     int pos = -1;
+    int step = -1;
+
+#if defined(__GNUC__) && !defined(__clang__)
+// For some reason gcc doesn't generate cmov with the ternary operator
+#define EVMONE_BINARY_SEARCH_BRANCHLESS_STEP pos += (vec[pos + step] < key) * step;
+#else
+#define EVMONE_BINARY_SEARCH_BRANCHLESS_STEP pos = (vec[pos + step] < key ? pos + step : pos)
+#endif
+
     switch (n + 1)
     {
     case 1u << 10:
-        pos = (vec[pos + (1 << 9)] < key ? pos + (1 << 9) : pos);
+        step = 1 << 9;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 9:
-        pos = (vec[pos + (1 << 8)] < key ? pos + (1 << 8) : pos);
+        step = 1 << 8;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 8:
-        pos = (vec[pos + (1 << 7)] < key ? pos + (1 << 7) : pos);
+        step = 1 << 7;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 7:
-        pos = (vec[pos + (1 << 6)] < key ? pos + (1 << 6) : pos);
+        step = 1 << 6;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 6:
-        pos = (vec[pos + (1 << 5)] < key ? pos + (1 << 5) : pos);
+        step = 1 << 5;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 5:
-        pos = (vec[pos + (1 << 4)] < key ? pos + (1 << 4) : pos);
+        step = 1 << 4;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 4:
-        pos = (vec[pos + (1 << 3)] < key ? pos + (1 << 3) : pos);
+        step = 1 << 3;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 3:
-        pos = (vec[pos + (1 << 2)] < key ? pos + (1 << 2) : pos);
+        step = 1 << 2;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 2:
-        pos = (vec[pos + (1 << 1)] < key ? pos + (1 << 1) : pos);
+        step = 1 << 1;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 1:
-        pos = (vec[pos + (1 << 0)] < key ? pos + (1 << 0) : pos);
+        step = 1 << 0;
+        EVMONE_BINARY_SEARCH_BRANCHLESS_STEP;
         [[fallthrough]];
     case 1u << 0:
         return vec + pos + 1;
     }
+
+#undef EVMONE_BINARY_SEARCH_BRANCHLESS_STEP
 
     return std::lower_bound(vec, vec + n, key);
 }

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -161,8 +161,8 @@ TEST(analysis, jumpdests_groups)
     EXPECT_EQ(analysis.instrs[9].fn, op_tbl[OPX_BEGINBLOCK].fn);
     EXPECT_EQ(analysis.instrs[10].fn, op_tbl[OP_STOP].fn);
 
-
-    ASSERT_EQ(analysis.jumpdest_offsets.size(), 6);
+    // jumpdest_offsets is padded to 2^k-1 for unrolled_binary_search
+    ASSERT_EQ(analysis.jumpdest_offsets.size(), 7);
     ASSERT_EQ(analysis.jumpdest_targets.size(), 6);
     EXPECT_EQ(analysis.jumpdest_offsets[0], 0);
     EXPECT_EQ(analysis.jumpdest_targets[0], 0);
@@ -176,4 +176,5 @@ TEST(analysis, jumpdests_groups)
     EXPECT_EQ(analysis.jumpdest_targets[4], 5);
     EXPECT_EQ(analysis.jumpdest_offsets[5], 7);
     EXPECT_EQ(analysis.jumpdest_targets[5], 6);
+    EXPECT_EQ(analysis.jumpdest_offsets[6], INT32_MAX);
 }


### PR DESCRIPTION
With this change `op_jump` is about 2 times faster.

Please see https://dirtyhandscoding.wordpress.com/2017/08/25/performance-comparison-linear-search-vs-binary-search  and https://arxiv.org/abs/1509.05053.