### PR TITLE
Fix potentially uninitialized padded_code

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -35,7 +35,8 @@ CodeAnalysis analyze(const uint8_t* code, size_t code_size)
     // Using "raw" new operator instead of std::make_unique() to get uninitialized array.
     std::unique_ptr<uint8_t[]> padded_code{new uint8_t[i + 1]};  // +1 for the final STOP.
     std::copy_n(code, code_size, padded_code.get());
-    padded_code[i] = OP_STOP;  // Set final STOP at the code end.
+    // Set final STOP at the code end.
+    std::fill_n(padded_code.get() + code_size, i + 1 - code_size, OP_STOP);
 
     // TODO: Using fixed-size padding of 33, the padded code buffer and jumpdest bitmap can be
     //       created with single allocation.

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -36,7 +36,7 @@ CodeAnalysis analyze(const uint8_t* code, size_t code_size)
     std::unique_ptr<uint8_t[]> padded_code{new uint8_t[i + 1]};  // +1 for the final STOP.
     std::copy_n(code, code_size, padded_code.get());
     // Set final STOP at the code end.
-    std::fill_n(padded_code.get() + code_size, i + 1 - code_size, OP_STOP);
+    std::fill_n(padded_code.get() + code_size, i + 1 - code_size, uint8_t{OP_STOP});
 
     // TODO: Using fixed-size padding of 33, the padded code buffer and jumpdest bitmap can be
     //       created with single allocation.


### PR DESCRIPTION
Fixes https://github.com/torquem-ch/silkworm/issues/305. Consensus test `randomStatetest445_d0g0v0_Berlin` was intermittently failing on Windows. Kudos to Andrea Lanfranchi for initial investigation.