### PR TITLE
baseline: Fix incorrect exit after invalid jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
 
+## [0.8.1] — unreleased
+
+### Fixed
+
+- baseline: Fix incorrect exit after invalid jump.
+  [#370](https://github.com/ethereum/evmone/pull/370)
+
+
 ## [0.8.0] — 2021-07-01
 
 ## Added
@@ -265,6 +273,7 @@ It delivers fully-compatible and high-speed EVM implementation.
 - The [intx 0.2.0](https://github.com/chfast/intx/releases/tag/v0.2.0) library is used for 256-bit precision arithmetic. 
 
 
+[0.8.1]: https://github.com/ethereum/evmone/compare/v0.8.0..release/v0.8.0
 [0.8.0]: https://github.com/ethereum/evmone/releases/tag/v0.8.0
 [0.7.0]: https://github.com/ethereum/evmone/releases/tag/v0.7.0
 [0.6.0]: https://github.com/ethereum/evmone/releases/tag/v0.6.0

--- a/circle.yml
+++ b/circle.yml
@@ -283,6 +283,22 @@ jobs:
       - upload_coverage:
           flags: unittests
 
+  gcc-latest-memcheck:
+    executor: linux-gcc-latest
+    environment:
+      BUILD_TYPE: Debug
+      CMAKE_OPTIONS: -DCMAKE_CXX_FLAGS=-O1
+    steps:
+      - build
+      - test
+      - run:
+          name: "Install valgrind"
+          command: sudo apt-get -q update && sudo apt-get -qy install --no-install-recommends valgrind
+      - run:
+          name: "memcheck"
+          working_directory: ~/build
+          command: valgrind --vgdb=no --error-exitcode=99 bin/evmone-unittests
+
   gcc-32bit:
     docker:
       - image: ethereum/cpp-build-env:15-gcc-10-multilib
@@ -370,6 +386,7 @@ workflows:
       - consensus-tests
       - gcc-min
       - gcc-latest-coverage
+      - gcc-latest-memcheck
       - clang-latest-ubsan
       - clang-latest-coverage
       - macos-asan

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -35,7 +35,8 @@ CodeAnalysis analyze(const uint8_t* code, size_t code_size)
     // Using "raw" new operator instead of std::make_unique() to get uninitialized array.
     std::unique_ptr<uint8_t[]> padded_code{new uint8_t[i + 1]};  // +1 for the final STOP.
     std::copy_n(code, code_size, padded_code.get());
-    padded_code[i] = OP_STOP;  // Set final STOP at the code end.
+    padded_code[code_size] = OP_STOP;  // Used to terminate invalid jumps, see op_jump().
+    padded_code[i] = OP_STOP;  // Set final STOP at the code end - guarantees loop termination.
 
     // TODO: Using fixed-size padding of 33, the padded code buffer and jumpdest bitmap can be
     //       created with single allocation.

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -333,6 +333,18 @@ TEST_P(evm, jump_over_jumpdest)
     EXPECT_GAS_USED(EVMC_SUCCESS, 3 + 8 + 1);
 }
 
+TEST_P(evm, jump_to_missing_push_data)
+{
+    execute(push(5) + OP_JUMP + OP_PUSH1);
+    EXPECT_STATUS(EVMC_BAD_JUMP_DESTINATION);
+}
+
+TEST_P(evm, jump_to_missing_push_data2)
+{
+    execute(push(6) + OP_JUMP + OP_PUSH2 + "ef");
+    EXPECT_STATUS(EVMC_BAD_JUMP_DESTINATION);
+}
+
 TEST_P(evm, pc_sum)
 {
     const auto code = 4 * OP_PC + 3 * OP_ADD + ret_top();


### PR DESCRIPTION
To handle invalid jump the implementation targets the byte just after
the official code length. For padded code this byte may be uninitialized
push data causing unpredictable behavior. The fix is to also init this
byte to OP_STOP.

The bug was detected in https://github.com/torquem-ch/silkworm/issues/305.

Here two simple unit tests were added which are able to detect the core issue in MSVC/ASan/memcheck builds.