### PR TITLE
Add StopToken type

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -705,7 +705,7 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
             DISPATCH_NEXT();
         }
         case OP_RETURN:
-            state.status = return_<EVMC_SUCCESS>(state);
+            state.status = return_<EVMC_SUCCESS>(state).status;
             goto exit;
         case OP_DELEGATECALL:
         {
@@ -738,13 +738,13 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
             DISPATCH_NEXT();
         }
         case OP_REVERT:
-            state.status = return_<EVMC_REVERT>(state);
+            state.status = return_<EVMC_REVERT>(state).status;
             goto exit;
         case OP_INVALID:
-            state.status = invalid(state);
+            state.status = invalid(state).status;
             goto exit;
         case OP_SELFDESTRUCT:
-            state.status = selfdestruct(state);
+            state.status = selfdestruct(state).status;
             goto exit;
         default:
             INTX_UNREACHABLE();

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -161,7 +161,7 @@ const instruction* op_undefined(const instruction*, AdvancedExecutionState& stat
 
 const instruction* op_selfdestruct(const instruction*, AdvancedExecutionState& state) noexcept
 {
-    return state.exit(selfdestruct(state));
+    return state.exit(selfdestruct(state).status);
 }
 
 const instruction* opx_beginblock(const instruction* instr, AdvancedExecutionState& state) noexcept

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -674,6 +674,13 @@ TEST_P(evm, inner_revert)
     EXPECT_GAS_USED(EVMC_REVERT, 6);
 }
 
+TEST_P(evm, inner_invalid)
+{
+    const auto code = push(0) + "fe" + OP_POP;
+    execute(5, code);
+    EXPECT_GAS_USED(EVMC_INVALID_INSTRUCTION, 5);
+}
+
 TEST_P(evm, inner_selfdestruct)
 {
     rev = EVMC_FRONTIER;


### PR DESCRIPTION
Add StopToken type as a status code wrapper to indicate instructions
unconditionally terminating execution.