### PR TITLE
memory: Use realloc() to grow memory

### DIFF
--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -85,9 +85,18 @@ class Memory
     /// The size of allocated memory. The initialization value is the initial capacity.
     size_t m_capacity = page_size;
 
+    [[noreturn, gnu::cold]] static void handle_out_of_memory() noexcept { std::terminate(); }
+
+    void allocate_capacity() noexcept
+    {
+        m_data = static_cast<uint8_t*>(std::realloc(m_data, m_capacity));
+        if (m_data == nullptr)
+            handle_out_of_memory();
+    }
+
 public:
     /// Creates Memory object with initial capacity allocation.
-    Memory() noexcept { m_data = static_cast<uint8_t*>(std::malloc(m_capacity)); }
+    Memory() noexcept { allocate_capacity(); }
 
     /// Frees all allocated memory.
     ~Memory() noexcept { std::free(m_data); }
@@ -123,7 +132,7 @@ public:
                 m_capacity = ((new_size + (page_size - 1)) / page_size) * page_size;
             }
 
-            m_data = static_cast<uint8_t*>(std::realloc(m_data, m_capacity));
+            allocate_capacity();
         }
         std::memset(m_data + m_size, 0, new_size - m_size);
         m_size = new_size;

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -69,46 +69,68 @@ struct Stack
 
 /// The EVM memory.
 ///
-/// At this point it is a wrapper for std::vector<uint8_t> with initial allocation of 4k.
+/// The implementations uses initial allocation of 4k and then grows capacity with 2x factor.
 /// Some benchmarks has been done to confirm 4k is ok-ish value.
-/// Also std::basic_string<uint8_t> has been tried but not faster and we don't want SSO
-/// if initial_capacity is used.
-/// In future, transition to std::realloc() + std::free() planned.
 class Memory
 {
-    /// The initial memory allocation.
-    static constexpr size_t initial_capacity = 4 * 1024;
+    /// The size of allocation "page".
+    static constexpr size_t page_size = 4 * 1024;
 
-    std::vector<uint8_t> m_memory;
+    /// Pointer to allocated memory.
+    uint8_t* m_data = nullptr;
+
+    /// The "virtual" size of the memory.
+    size_t m_size = 0;
+
+    /// The size of allocated memory. The initialization value is the initial capacity.
+    size_t m_capacity = page_size;
 
 public:
-    Memory() noexcept { m_memory.reserve(initial_capacity); }
+    /// Creates Memory object with initial capacity allocation.
+    Memory() noexcept { m_data = static_cast<uint8_t*>(std::malloc(m_capacity)); }
+
+    /// Frees all allocated memory.
+    ~Memory() noexcept { std::free(m_data); }
 
     Memory(const Memory&) = delete;
     Memory& operator=(const Memory&) = delete;
 
-    uint8_t& operator[](size_t index) noexcept { return m_memory[index]; }
+    uint8_t& operator[](size_t index) noexcept { return m_data[index]; }
 
-    [[nodiscard]] const uint8_t* data() const noexcept { return m_memory.data(); }
-    [[nodiscard]] size_t size() const noexcept { return m_memory.size(); }
+    [[nodiscard]] const uint8_t* data() const noexcept { return m_data; }
+    [[nodiscard]] size_t size() const noexcept { return m_size; }
 
     /// Grows the memory to the given size. The extend is filled with zeros.
     ///
     /// @param new_size  New memory size. Must be larger than the current size and multiple of 32.
-    void grow(size_t new_size)
+    void grow(size_t new_size) noexcept
     {
         // Restriction for future changes. EVM always has memory size as multiple of 32 bytes.
         assert(new_size % 32 == 0);
 
         // Allow only growing memory. Include hint for optimizing compiler.
-        assert(new_size > m_memory.size());
-        if (new_size <= m_memory.size())
+        assert(new_size > m_size);
+        if (new_size <= m_size)
             INTX_UNREACHABLE();
 
-        m_memory.resize(new_size);
+        if (new_size > m_capacity)
+        {
+            m_capacity *= 2;  // Double the capacity.
+
+            if (m_capacity < new_size)  // If not enough.
+            {
+                // Set capacity to required size rounded to multiple of page_size.
+                m_capacity = ((new_size + (page_size - 1)) / page_size) * page_size;
+            }
+
+            m_data = static_cast<uint8_t*>(std::realloc(m_data, m_capacity));
+        }
+        std::memset(m_data + m_size, 0, new_size - m_size);
+        m_size = new_size;
     }
 
-    void clear() noexcept { m_memory.clear(); }
+    /// Virtually clears the memory by setting its size to 0. The capacity stays unchanged.
+    void clear() noexcept { m_size = 0; }
 };
 
 /// Generic execution state for generic instructions implementations.


### PR DESCRIPTION
```
advanced/execute/main/blake2b_huff/empty_mean                          -0.0304         -0.0304            13            12            13            12                                                                            
baseline/execute/main/blake2b_huff/empty_mean                          -0.0117         -0.0117            15            15            15            15                                                                            
advanced/execute/main/blake2b_huff/2805nulls_mean                      -0.0381         -0.0381           279           269           279           269                                                                            
baseline/execute/main/blake2b_huff/2805nulls_mean                      -0.0081         -0.0081           334           331           334           331                                                                            
advanced/execute/main/blake2b_huff/5610nulls_mean                      -0.0302         -0.0302           545           528           545           528                                                                            
baseline/execute/main/blake2b_huff/5610nulls_mean                      -0.0039         -0.0039           650           647           650           647                                                                            
advanced/execute/main/blake2b_huff/8415nulls_mean                      -0.0350         -0.0350           801           773           801           773                                                                            
baseline/execute/main/blake2b_huff/8415nulls_mean                      -0.0084         -0.0084           957           948           957           948
advanced/execute/main/blake2b_huff/65536nulls_mean                     -0.0354         -0.0354          6200          5980          6200          5980
baseline/execute/main/blake2b_huff/65536nulls_mean                     -0.0058         -0.0058          7409          7367          7410          7367
advanced/execute/main/blake2b_shifts/2805nulls_mean                    -0.0244         -0.0244          3722          3631          3722          3631
baseline/execute/main/blake2b_shifts/2805nulls_mean                    -0.0005         -0.0005          3177          3176          3177          3176
advanced/execute/main/blake2b_shifts/5610nulls_mean                    -0.0161         -0.0161          7374          7255          7374          7255
baseline/execute/main/blake2b_shifts/5610nulls_mean                    +0.0081         +0.0081          6279          6329          6279          6330
advanced/execute/main/blake2b_shifts/8415nulls_mean                    -0.0194         -0.0194         11055         10841         11055         10841
baseline/execute/main/blake2b_shifts/8415nulls_mean                    +0.0037         +0.0037          9432          9467          9432          9467
advanced/execute/main/blake2b_shifts/65536nulls_mean                   -0.0105         -0.0105         85701         84803         85702         84804
baseline/execute/main/blake2b_shifts/65536nulls_mean                   +0.0033         +0.0033         72996         73240         72996         73240
advanced/execute/main/sha1_divs/empty_mean                             -0.0130         -0.0130            56            55            56            55
baseline/execute/main/sha1_divs/empty_mean                             +0.0112         +0.0112            59            59            59            59
advanced/execute/main/sha1_divs/1351_mean                              -0.0099         -0.0099          1161          1150          1161          1150
baseline/execute/main/sha1_divs/1351_mean                              +0.0108         +0.0108          1235          1248          1235          1248
advanced/execute/main/sha1_divs/2737_mean                              -0.0062         -0.0062          2262          2248          2262          2248
baseline/execute/main/sha1_divs/2737_mean                              +0.0108         +0.0108          2411          2437          2411          2437
advanced/execute/main/sha1_divs/5311_mean                              -0.0071         -0.0071          4418          4386          4418          4386
baseline/execute/main/sha1_divs/5311_mean                              +0.0122         +0.0122          4709          4767          4709          4767
advanced/execute/main/sha1_divs/65536_mean                             -0.0085         -0.0085         53843         53386         53843         53386
baseline/execute/main/sha1_divs/65536_mean                             +0.0094         +0.0094         57463         58004         57464         58005
advanced/execute/main/sha1_shifts/empty_mean                           -0.0101         -0.0101            32            32            32            32
baseline/execute/main/sha1_shifts/empty_mean                           -0.0022         -0.0022            34            34            34            34
advanced/execute/main/sha1_shifts/1351_mean                            -0.0130         -0.0130           670           661           670           661
baseline/execute/main/sha1_shifts/1351_mean                            +0.0000         +0.0000           740           740           740           740
advanced/execute/main/sha1_shifts/2737_mean                            -0.0074         -0.0074          1301          1291          1301          1291
baseline/execute/main/sha1_shifts/2737_mean                            +0.0053         +0.0053          1438          1446          1438          1446
advanced/execute/main/sha1_shifts/5311_mean                            -0.0105         -0.0105          2545          2518          2545          2518
baseline/execute/main/sha1_shifts/5311_mean                            +0.0272         +0.0272          2802          2878          2802          2878
advanced/execute/main/sha1_shifts/65536_mean                           -0.0088         -0.0088         30932         30661         30933         30661
baseline/execute/main/sha1_shifts/65536_mean                           +0.0038         +0.0038         34202         34333         34202         34333
advanced/execute/main/weierstrudel/0_mean                              -0.0082         -0.0082           171           170           171           170
baseline/execute/main/weierstrudel/0_mean                              +0.0074         +0.0074           169           170           169           170
advanced/execute/main/weierstrudel/1_mean                              -0.0160         -0.0160           381           375           381           375
baseline/execute/main/weierstrudel/1_mean                              +0.0099         +0.0099           378           382           378           382
advanced/execute/main/weierstrudel/3_mean                              -0.0122         -0.0122           595           588           595           588
baseline/execute/main/weierstrudel/3_mean                              +0.0083         +0.0083           593           598           593           598
advanced/execute/main/weierstrudel/9_mean                              -0.0093         -0.0093          1226          1215          1226          1215
baseline/execute/main/weierstrudel/9_mean                              +0.0078         +0.0078          1233          1242          1233          1242
advanced/execute/main/weierstrudel/14_mean                             -0.0074         -0.0075          1750          1737          1750          1737
baseline/execute/main/weierstrudel/14_mean                             +0.0036         +0.0036          1771          1778          1771          1778
advanced/execute/micro/memory_grow_mload/nogrow_mean                   -0.0104         -0.0104            48            48            48            48
baseline/execute/micro/memory_grow_mload/nogrow_mean                   -0.0240         -0.0240            60            59            60            59
advanced/execute/micro/memory_grow_mload/by1_mean                      -0.0105         -0.0105            52            52            52            52
baseline/execute/micro/memory_grow_mload/by1_mean                      -0.0192         -0.0192            63            62            63            62
advanced/execute/micro/memory_grow_mload/by16_mean                     -0.0644         -0.0644            63            59            63            59
baseline/execute/micro/memory_grow_mload/by16_mean                     -0.0863         -0.0863            73            67            73            67
advanced/execute/micro/memory_grow_mload/by32_mean                     -0.0811         -0.0811            77            70            77            70
baseline/execute/micro/memory_grow_mload/by32_mean                     -0.1161         -0.1161            86            76            86            76
advanced/execute/micro/memory_grow_mstore/nogrow_mean                  +0.0076         +0.0076            53            53            53            53
baseline/execute/micro/memory_grow_mstore/nogrow_mean                  -0.0189         -0.0189            62            61            62            61
advanced/execute/micro/memory_grow_mstore/by1_mean                     -0.0144         -0.0144            57            56            57            56
baseline/execute/micro/memory_grow_mstore/by1_mean                     -0.0123         -0.0123            64            63            64            63
advanced/execute/micro/memory_grow_mstore/by16_mean                    -0.0521         -0.0521            67            64            67            64
baseline/execute/micro/memory_grow_mstore/by16_mean                    -0.0592         -0.0592            75            71            75            71
advanced/execute/micro/memory_grow_mstore/by32_mean                    -0.0804         -0.0804            82            76            82            76
baseline/execute/micro/memory_grow_mstore/by32_mean                    -0.0879         -0.0879            89            81            89            81
```