### PR TITLE
advanced: Reuse more generic instructions

### DIFF
--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -19,6 +19,7 @@ evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& a
     const auto gas_left =
         (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
 
+    assert(state.output_size != 0 || state.output_offset == 0);
     return evmc::make_result(
         state.status, gas_left, state.memory.data() + state.output_offset, state.output_size);
 }

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -358,6 +358,7 @@ exit:
     const auto gas_left =
         (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
 
+    assert(state.output_size != 0 || state.output_offset == 0);
     const auto result = evmc::make_result(state.status, gas_left,
         state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
 

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -841,8 +841,9 @@ inline StopToken return_impl(ExecutionState& state) noexcept
     if (!check_memory(state, offset, size))
         return {EVMC_OUT_OF_GAS};
 
-    state.output_offset = static_cast<size_t>(offset);  // Can be garbage if size is 0.
     state.output_size = static_cast<size_t>(size);
+    if (state.output_size != 0)
+        state.output_offset = static_cast<size_t>(offset);
     return {StatusCode};
 }
 inline constexpr auto return_ = return_impl<EVMC_SUCCESS>;


### PR DESCRIPTION
Advanced can easily wrap also generic instruction implementations with `StopToken`.