### PR TITLE
Introduce instruction "core" implementations

### DIFF
--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -47,7 +47,7 @@ const Instruction* op_sstore(const Instruction* instr, AdvancedExecutionState& s
     const auto gas_left_correction = state.current_block_cost - instr->arg.number;
     state.gas_left += gas_left_correction;
 
-    const auto status = instr::sstore(state);
+    const auto status = instr::impl<OP_SSTORE>(state);
     if (status != EVMC_SUCCESS)
         return state.exit(status);
 
@@ -117,7 +117,7 @@ const Instruction* op_call(const Instruction* instr, AdvancedExecutionState& sta
     const auto gas_left_correction = state.current_block_cost - instr->arg.number;
     state.gas_left += gas_left_correction;
 
-    const auto status = instr::call_impl<Op>(state);
+    const auto status = instr::impl<Op>(state);
     if (status != EVMC_SUCCESS)
         return state.exit(status);
 
@@ -133,7 +133,7 @@ const Instruction* op_create(const Instruction* instr, AdvancedExecutionState& s
     const auto gas_left_correction = state.current_block_cost - instr->arg.number;
     state.gas_left += gas_left_correction;
 
-    const auto status = instr::create_impl<Op>(state);
+    const auto status = instr::impl<Op>(state);
     if (status != EVMC_SUCCESS)
         return state.exit(status);
 
@@ -170,7 +170,7 @@ constexpr std::array<instruction_exec_fn, 256> instruction_implementations = [](
     std::array<instruction_exec_fn, 256> table{};
 
     // Init table with wrapped generic implementations.
-#define X(OPCODE, IDENTIFIER) table[OPCODE] = op<instr::IDENTIFIER>;
+#define X(OPCODE, IGNORED) table[OPCODE] = op<instr::impl<(OPCODE)>>;
     MAP_OPCODE_TO_IDENTIFIER
 #undef X
 

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -926,6 +926,7 @@ MAP_OPCODE_TO_IDENTIFIER
 }  // namespace core
 
 /// Instruction implementations - "core" instruction + stack height adjustment.
+/// TODO: These are only used by Advanced, so can be moved there.
 /// @{
 template <evmc_opcode Op, void CoreFn(StackTop) noexcept = core::impl<Op>>
 inline void impl(ExecutionState& state) noexcept

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -13,6 +13,31 @@ namespace evmone
 {
 using code_iterator = const uint8_t*;
 
+/// Represents the pointer to the stack top item
+/// and allows retrieving stack items and manipulating the pointer.
+class StackTop
+{
+    uint256* m_top;
+
+public:
+    StackTop(uint256* top) noexcept : m_top{top} {}
+
+    /// Returns the reference to the stack item by index, where 0 means the top item
+    /// and positive index values the items further down the stack.
+    /// Using [-1] is also valid, but .push() should be used instead.
+    [[nodiscard]] uint256& operator[](int index) noexcept { return m_top[-index]; }
+
+    /// Returns the reference to the stack top item.
+    [[nodiscard]] uint256& top() noexcept { return *m_top; }
+
+    /// Returns the current top item and move the stack top pointer down.
+    /// The value is returned by reference because the stack slot remains valid.
+    [[nodiscard]] uint256& pop() noexcept { return *m_top--; }
+
+    /// Assigns the value to the stack top and moves the stack top pointer up.
+    void push(const uint256& value) noexcept { *++m_top = value; }
+};
+
 /// A wrapper for evmc_status_code to indicate that an instruction
 /// unconditionally terminates execution.
 struct StopToken
@@ -91,75 +116,87 @@ inline bool check_memory(ExecutionState& state, const uint256& offset, const uin
 namespace instr
 {
 
-inline StopToken stop(ExecutionState& /*state*/) noexcept
+/// The "core" instruction implementations.
+///
+/// These are minimal EVM instruction implementations which assume:
+/// - the stack requirements (overflow, underflow) have already been checked,
+/// - the "base" gas const has already been charged,
+/// - the `stack` pointer points to the EVM stack top element.
+/// Moreover, these implementations _do not_ inform about new stack height
+/// after execution. The adjustment must be performed by the caller.
+namespace core
 {
-    return {EVMC_SUCCESS};
+inline void noop(StackTop /*stack*/) noexcept {}
+inline constexpr auto pop = noop;
+inline constexpr auto jumpdest = noop;
+
+template <evmc_status_code Status>
+inline StopToken stop_impl() noexcept
+{
+    return {Status};
+}
+inline constexpr auto stop = stop_impl<EVMC_SUCCESS>;
+inline constexpr auto invalid = stop_impl<EVMC_INVALID_INSTRUCTION>;
+
+inline void add(StackTop stack) noexcept
+{
+    stack.top() += stack.pop();
 }
 
-inline void add(ExecutionState& state) noexcept
+inline void mul(StackTop stack) noexcept
 {
-    state.stack.top() += state.stack.pop();
+    stack.top() *= stack.pop();
 }
 
-inline void mul(ExecutionState& state) noexcept
+inline void sub(StackTop stack) noexcept
 {
-    state.stack.top() *= state.stack.pop();
+    stack[1] = stack[0] - stack[1];
 }
 
-inline void sub(ExecutionState& state) noexcept
+inline void div(StackTop stack) noexcept
 {
-    state.stack[1] = state.stack[0] - state.stack[1];
-    state.stack.pop();
+    auto& v = stack[1];
+    v = v != 0 ? stack[0] / v : 0;
 }
 
-inline void div(ExecutionState& state) noexcept
+inline void sdiv(StackTop stack) noexcept
 {
-    auto& v = state.stack[1];
-    v = v != 0 ? state.stack[0] / v : 0;
-    state.stack.pop();
+    auto& v = stack[1];
+    v = v != 0 ? intx::sdivrem(stack[0], v).quot : 0;
 }
 
-inline void sdiv(ExecutionState& state) noexcept
+inline void mod(StackTop stack) noexcept
 {
-    auto& v = state.stack[1];
-    v = v != 0 ? intx::sdivrem(state.stack[0], v).quot : 0;
-    state.stack.pop();
+    auto& v = stack[1];
+    v = v != 0 ? stack[0] % v : 0;
 }
 
-inline void mod(ExecutionState& state) noexcept
+inline void smod(StackTop stack) noexcept
 {
-    auto& v = state.stack[1];
-    v = v != 0 ? state.stack[0] % v : 0;
-    state.stack.pop();
+    auto& v = stack[1];
+    v = v != 0 ? intx::sdivrem(stack[0], v).rem : 0;
 }
 
-inline void smod(ExecutionState& state) noexcept
+inline void addmod(StackTop stack) noexcept
 {
-    auto& v = state.stack[1];
-    v = v != 0 ? intx::sdivrem(state.stack[0], v).rem : 0;
-    state.stack.pop();
-}
-
-inline void addmod(ExecutionState& state) noexcept
-{
-    const auto x = state.stack.pop();
-    const auto y = state.stack.pop();
-    auto& m = state.stack.top();
+    const auto& x = stack.pop();
+    const auto& y = stack.pop();
+    auto& m = stack.top();
     m = m != 0 ? intx::addmod(x, y, m) : 0;
 }
 
-inline void mulmod(ExecutionState& state) noexcept
+inline void mulmod(StackTop stack) noexcept
 {
-    const auto x = state.stack.pop();
-    const auto y = state.stack.pop();
-    auto& m = state.stack.top();
+    const auto& x = stack[0];
+    const auto& y = stack[1];
+    auto& m = stack[2];
     m = m != 0 ? intx::mulmod(x, y, m) : 0;
 }
 
-inline evmc_status_code exp(ExecutionState& state) noexcept
+inline evmc_status_code exp(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto base = state.stack.pop();
-    auto& exponent = state.stack.top();
+    const auto& base = stack.pop();
+    auto& exponent = stack.top();
 
     const auto exponent_significant_bytes =
         static_cast<int>(intx::count_significant_bytes(exponent));
@@ -172,10 +209,10 @@ inline evmc_status_code exp(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline void signextend(ExecutionState& state) noexcept
+inline void signextend(StackTop stack) noexcept
 {
-    const auto ext = state.stack.pop();
-    auto& x = state.stack.top();
+    const auto& ext = stack.pop();
+    auto& x = stack.top();
 
     if (ext < 31)  // For 31 we also don't need to do anything.
     {
@@ -205,65 +242,64 @@ inline void signextend(ExecutionState& state) noexcept
     }
 }
 
-inline void lt(ExecutionState& state) noexcept
+inline void lt(StackTop stack) noexcept
 {
-    const auto x = state.stack.pop();
-    state.stack[0] = x < state.stack[0];
+    const auto& x = stack.pop();
+    stack[0] = x < stack[0];
 }
 
-inline void gt(ExecutionState& state) noexcept
+inline void gt(StackTop stack) noexcept
 {
-    const auto x = state.stack.pop();
-    state.stack[0] = state.stack[0] < x;  // Arguments are swapped and < is used.
+    const auto& x = stack.pop();
+    stack[0] = stack[0] < x;  // Arguments are swapped and < is used.
 }
 
-inline void slt(ExecutionState& state) noexcept
+inline void slt(StackTop stack) noexcept
 {
-    const auto x = state.stack.pop();
-    state.stack[0] = slt(x, state.stack[0]);
+    const auto& x = stack.pop();
+    stack[0] = slt(x, stack[0]);
 }
 
-inline void sgt(ExecutionState& state) noexcept
+inline void sgt(StackTop stack) noexcept
 {
-    const auto x = state.stack.pop();
-    state.stack[0] = slt(state.stack[0], x);  // Arguments are swapped and SLT is used.
+    const auto& x = stack.pop();
+    stack[0] = slt(stack[0], x);  // Arguments are swapped and SLT is used.
 }
 
-inline void eq(ExecutionState& state) noexcept
+inline void eq(StackTop stack) noexcept
 {
-    state.stack[1] = state.stack[0] == state.stack[1];
-    state.stack.pop();
+    stack[1] = stack[0] == stack[1];
 }
 
-inline void iszero(ExecutionState& state) noexcept
+inline void iszero(StackTop stack) noexcept
 {
-    state.stack.top() = state.stack.top() == 0;
+    stack.top() = stack.top() == 0;
 }
 
-inline void and_(ExecutionState& state) noexcept
+inline void and_(StackTop stack) noexcept
 {
-    state.stack.top() &= state.stack.pop();
+    stack.top() &= stack.pop();
 }
 
-inline void or_(ExecutionState& state) noexcept
+inline void or_(StackTop stack) noexcept
 {
-    state.stack.top() |= state.stack.pop();
+    stack.top() |= stack.pop();
 }
 
-inline void xor_(ExecutionState& state) noexcept
+inline void xor_(StackTop stack) noexcept
 {
-    state.stack.top() ^= state.stack.pop();
+    stack.top() ^= stack.pop();
 }
 
-inline void not_(ExecutionState& state) noexcept
+inline void not_(StackTop stack) noexcept
 {
-    state.stack.top() = ~state.stack.top();
+    stack.top() = ~stack.top();
 }
 
-inline void byte(ExecutionState& state) noexcept
+inline void byte(StackTop stack) noexcept
 {
-    const auto n = state.stack.pop();
-    auto& x = state.stack.top();
+    const auto& n = stack.pop();
+    auto& x = stack.top();
 
     const bool n_valid = n < 32;
     const uint64_t byte_mask = (n_valid ? 0xff : 0);
@@ -275,20 +311,20 @@ inline void byte(ExecutionState& state) noexcept
     x = byte;
 }
 
-inline void shl(ExecutionState& state) noexcept
+inline void shl(StackTop stack) noexcept
 {
-    state.stack.top() <<= state.stack.pop();
+    stack.top() <<= stack.pop();
 }
 
-inline void shr(ExecutionState& state) noexcept
+inline void shr(StackTop stack) noexcept
 {
-    state.stack.top() >>= state.stack.pop();
+    stack.top() >>= stack.pop();
 }
 
-inline void sar(ExecutionState& state) noexcept
+inline void sar(StackTop stack) noexcept
 {
-    const auto y = state.stack.pop();
-    auto& x = state.stack.top();
+    const auto& y = stack.pop();
+    auto& x = stack.top();
 
     const bool is_neg = static_cast<int64_t>(x[3]) < 0;  // Inspect the top bit (words are LE).
     const auto sign_mask = is_neg ? ~uint256{} : uint256{};
@@ -297,11 +333,10 @@ inline void sar(ExecutionState& state) noexcept
     x = (x >> y) | (sign_mask << mask_shift);
 }
 
-
-inline evmc_status_code keccak256(ExecutionState& state) noexcept
+inline evmc_status_code keccak256(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto index = state.stack.pop();
-    auto& size = state.stack.top();
+    const auto& index = stack.pop();
+    auto& size = stack.top();
 
     if (!check_memory(state, index, size))
         return EVMC_OUT_OF_GAS;
@@ -319,14 +354,14 @@ inline evmc_status_code keccak256(ExecutionState& state) noexcept
 }
 
 
-inline void address(ExecutionState& state) noexcept
+inline void address(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.msg->recipient));
+    stack.push(intx::be::load<uint256>(state.msg->recipient));
 }
 
-inline evmc_status_code balance(ExecutionState& state) noexcept
+inline evmc_status_code balance(StackTop stack, ExecutionState& state) noexcept
 {
-    auto& x = state.stack.top();
+    auto& x = stack.top();
     const auto addr = intx::be::trunc<evmc::address>(x);
 
     if (state.rev >= EVMC_BERLIN && state.host.access_account(addr) == EVMC_ACCESS_COLD)
@@ -339,24 +374,24 @@ inline evmc_status_code balance(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline void origin(ExecutionState& state) noexcept
+inline void origin(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_origin));
+    stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_origin));
 }
 
-inline void caller(ExecutionState& state) noexcept
+inline void caller(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.msg->sender));
+    stack.push(intx::be::load<uint256>(state.msg->sender));
 }
 
-inline void callvalue(ExecutionState& state) noexcept
+inline void callvalue(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.msg->value));
+    stack.push(intx::be::load<uint256>(state.msg->value));
 }
 
-inline void calldataload(ExecutionState& state) noexcept
+inline void calldataload(StackTop stack, ExecutionState& state) noexcept
 {
-    auto& index = state.stack.top();
+    auto& index = stack.top();
 
     if (state.msg->input_size < index)
         index = 0;
@@ -373,16 +408,16 @@ inline void calldataload(ExecutionState& state) noexcept
     }
 }
 
-inline void calldatasize(ExecutionState& state) noexcept
+inline void calldatasize(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(state.msg->input_size);
+    stack.push(state.msg->input_size);
 }
 
-inline evmc_status_code calldatacopy(ExecutionState& state) noexcept
+inline evmc_status_code calldatacopy(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto mem_index = state.stack.pop();
-    const auto input_index = state.stack.pop();
-    const auto size = state.stack.pop();
+    const auto& mem_index = stack.pop();
+    const auto& input_index = stack.pop();
+    const auto& size = stack.pop();
 
     if (!check_memory(state, mem_index, size))
         return EVMC_OUT_OF_GAS;
@@ -406,18 +441,18 @@ inline evmc_status_code calldatacopy(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline void codesize(ExecutionState& state) noexcept
+inline void codesize(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(state.code.size());
+    stack.push(state.code.size());
 }
 
-inline evmc_status_code codecopy(ExecutionState& state) noexcept
+inline evmc_status_code codecopy(StackTop stack, ExecutionState& state) noexcept
 {
     // TODO: Similar to calldatacopy().
 
-    const auto mem_index = state.stack.pop();
-    const auto input_index = state.stack.pop();
-    const auto size = state.stack.pop();
+    const auto& mem_index = stack.pop();
+    const auto& input_index = stack.pop();
+    const auto& size = stack.pop();
 
     if (!check_memory(state, mem_index, size))
         return EVMC_OUT_OF_GAS;
@@ -443,19 +478,19 @@ inline evmc_status_code codecopy(ExecutionState& state) noexcept
 }
 
 
-inline void gasprice(ExecutionState& state) noexcept
+inline void gasprice(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_gas_price));
+    stack.push(intx::be::load<uint256>(state.host.get_tx_context().tx_gas_price));
 }
 
-inline void basefee(ExecutionState& state) noexcept
+inline void basefee(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_base_fee));
+    stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_base_fee));
 }
 
-inline evmc_status_code extcodesize(ExecutionState& state) noexcept
+inline evmc_status_code extcodesize(StackTop stack, ExecutionState& state) noexcept
 {
-    auto& x = state.stack.top();
+    auto& x = stack.top();
     const auto addr = intx::be::trunc<evmc::address>(x);
 
     if (state.rev >= EVMC_BERLIN && state.host.access_account(addr) == EVMC_ACCESS_COLD)
@@ -468,12 +503,12 @@ inline evmc_status_code extcodesize(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline evmc_status_code extcodecopy(ExecutionState& state) noexcept
+inline evmc_status_code extcodecopy(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto addr = intx::be::trunc<evmc::address>(state.stack.pop());
-    const auto mem_index = state.stack.pop();
-    const auto input_index = state.stack.pop();
-    const auto size = state.stack.pop();
+    const auto addr = intx::be::trunc<evmc::address>(stack.pop());
+    const auto& mem_index = stack.pop();
+    const auto& input_index = stack.pop();
+    const auto& size = stack.pop();
 
     if (!check_memory(state, mem_index, size))
         return EVMC_OUT_OF_GAS;
@@ -502,16 +537,16 @@ inline evmc_status_code extcodecopy(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline void returndatasize(ExecutionState& state) noexcept
+inline void returndatasize(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(state.return_data.size());
+    stack.push(state.return_data.size());
 }
 
-inline evmc_status_code returndatacopy(ExecutionState& state) noexcept
+inline evmc_status_code returndatacopy(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto mem_index = state.stack.pop();
-    const auto input_index = state.stack.pop();
-    const auto size = state.stack.pop();
+    const auto& mem_index = stack.pop();
+    const auto& input_index = stack.pop();
+    const auto& size = stack.pop();
 
     if (!check_memory(state, mem_index, size))
         return EVMC_OUT_OF_GAS;
@@ -536,9 +571,9 @@ inline evmc_status_code returndatacopy(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline evmc_status_code extcodehash(ExecutionState& state) noexcept
+inline evmc_status_code extcodehash(StackTop stack, ExecutionState& state) noexcept
 {
-    auto& x = state.stack.top();
+    auto& x = stack.top();
     const auto addr = intx::be::trunc<evmc::address>(x);
 
     if (state.rev >= EVMC_BERLIN && state.host.access_account(addr) == EVMC_ACCESS_COLD)
@@ -552,9 +587,9 @@ inline evmc_status_code extcodehash(ExecutionState& state) noexcept
 }
 
 
-inline void blockhash(ExecutionState& state) noexcept
+inline void blockhash(StackTop stack, ExecutionState& state) noexcept
 {
-    auto& number = state.stack.top();
+    auto& number = stack.top();
 
     const auto upper_bound = state.host.get_tx_context().block_number;
     const auto lower_bound = std::max(upper_bound - 256, decltype(upper_bound){0});
@@ -564,56 +599,47 @@ inline void blockhash(ExecutionState& state) noexcept
     number = intx::be::load<uint256>(header);
 }
 
-inline void coinbase(ExecutionState& state) noexcept
+inline void coinbase(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_coinbase));
+    stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_coinbase));
 }
 
-inline void timestamp(ExecutionState& state) noexcept
+inline void timestamp(StackTop stack, ExecutionState& state) noexcept
 {
     // TODO: Add tests for negative timestamp?
-    const auto timestamp = static_cast<uint64_t>(state.host.get_tx_context().block_timestamp);
-    state.stack.push(timestamp);
+    stack.push(static_cast<uint64_t>(state.host.get_tx_context().block_timestamp));
 }
 
-inline void number(ExecutionState& state) noexcept
+inline void number(StackTop stack, ExecutionState& state) noexcept
 {
     // TODO: Add tests for negative block number?
-    const auto block_number = static_cast<uint64_t>(state.host.get_tx_context().block_number);
-    state.stack.push(block_number);
+    stack.push(static_cast<uint64_t>(state.host.get_tx_context().block_number));
 }
 
-inline void difficulty(ExecutionState& state) noexcept
+inline void difficulty(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_difficulty));
+    stack.push(intx::be::load<uint256>(state.host.get_tx_context().block_difficulty));
 }
 
-inline void gaslimit(ExecutionState& state) noexcept
+inline void gaslimit(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto block_gas_limit = static_cast<uint64_t>(state.host.get_tx_context().block_gas_limit);
-    state.stack.push(block_gas_limit);
+    stack.push(static_cast<uint64_t>(state.host.get_tx_context().block_gas_limit));
 }
 
-inline void chainid(ExecutionState& state) noexcept
+inline void chainid(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(intx::be::load<uint256>(state.host.get_tx_context().chain_id));
+    stack.push(intx::be::load<uint256>(state.host.get_tx_context().chain_id));
 }
 
-inline void selfbalance(ExecutionState& state) noexcept
+inline void selfbalance(StackTop stack, ExecutionState& state) noexcept
 {
     // TODO: introduce selfbalance in EVMC?
-    state.stack.push(intx::be::load<uint256>(state.host.get_balance(state.msg->recipient)));
+    stack.push(intx::be::load<uint256>(state.host.get_balance(state.msg->recipient)));
 }
 
-
-inline void pop(ExecutionState& state) noexcept
+inline evmc_status_code mload(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.pop();
-}
-
-inline evmc_status_code mload(ExecutionState& state) noexcept
-{
-    auto& index = state.stack.top();
+    auto& index = stack.top();
 
     if (!check_memory(state, index, 32))
         return EVMC_OUT_OF_GAS;
@@ -622,10 +648,10 @@ inline evmc_status_code mload(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline evmc_status_code mstore(ExecutionState& state) noexcept
+inline evmc_status_code mstore(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto index = state.stack.pop();
-    const auto value = state.stack.pop();
+    const auto& index = stack.pop();
+    const auto& value = stack.pop();
 
     if (!check_memory(state, index, 32))
         return EVMC_OUT_OF_GAS;
@@ -634,10 +660,10 @@ inline evmc_status_code mstore(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline evmc_status_code mstore8(ExecutionState& state) noexcept
+inline evmc_status_code mstore8(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto index = state.stack.pop();
-    const auto value = state.stack.pop();
+    const auto& index = stack.pop();
+    const auto& value = stack.pop();
 
     if (!check_memory(state, index, 1))
         return EVMC_OUT_OF_GAS;
@@ -646,9 +672,9 @@ inline evmc_status_code mstore8(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline evmc_status_code sload(ExecutionState& state) noexcept
+inline evmc_status_code sload(StackTop stack, ExecutionState& state) noexcept
 {
-    auto& x = state.stack.top();
+    auto& x = stack.top();
     const auto key = intx::be::store<evmc::bytes32>(x);
 
     if (state.rev >= EVMC_BERLIN &&
@@ -667,7 +693,7 @@ inline evmc_status_code sload(ExecutionState& state) noexcept
     return EVMC_SUCCESS;
 }
 
-inline evmc_status_code sstore(ExecutionState& state) noexcept
+inline evmc_status_code sstore(StackTop stack, ExecutionState& state) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return EVMC_STATIC_MODE_VIOLATION;
@@ -675,8 +701,8 @@ inline evmc_status_code sstore(ExecutionState& state) noexcept
     if (state.rev >= EVMC_ISTANBUL && state.gas_left <= 2300)
         return EVMC_OUT_OF_GAS;
 
-    const auto key = intx::be::store<evmc::bytes32>(state.stack.pop());
-    const auto value = intx::be::store<evmc::bytes32>(state.stack.pop());
+    const auto key = intx::be::store<evmc::bytes32>(stack.pop());
+    const auto value = intx::be::store<evmc::bytes32>(stack.pop());
 
     int cost = 0;
     if (state.rev >= EVMC_BERLIN &&
@@ -728,36 +754,34 @@ inline code_iterator jump_impl(ExecutionState& state, const uint256& dst) noexce
 }
 
 /// JUMP instruction implementation using baseline::CodeAnalysis.
-inline code_iterator jump(ExecutionState& state, code_iterator /*pc*/) noexcept
+inline code_iterator jump(StackTop stack, ExecutionState& state, code_iterator /*pos*/) noexcept
 {
-    return jump_impl(state, state.stack.pop());
+    return jump_impl(state, stack.pop());
 }
 
 /// JUMPI instruction implementation using baseline::CodeAnalysis.
-inline code_iterator jumpi(ExecutionState& state, code_iterator pc) noexcept
+inline code_iterator jumpi(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
 {
-    const auto dst = state.stack.pop();
-    const auto cond = state.stack.pop();
-    return cond ? jump_impl(state, dst) : pc + 1;
+    const auto& dst = stack.pop();
+    const auto& cond = stack.pop();
+    return cond ? jump_impl(state, dst) : pos + 1;
 }
 
-inline code_iterator pc(ExecutionState& state, code_iterator pos) noexcept
+inline code_iterator pc(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
 {
-    state.stack.push(static_cast<uint64_t>(pos - state.code.data()));
+    stack.push(static_cast<uint64_t>(pos - state.code.data()));
     return pos + 1;
 }
 
-inline void msize(ExecutionState& state) noexcept
+inline void msize(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(state.memory.size());
+    stack.push(state.memory.size());
 }
 
-inline void gas(ExecutionState& state) noexcept
+inline void gas(StackTop stack, ExecutionState& state) noexcept
 {
-    state.stack.push(state.gas_left);
+    stack.push(state.gas_left);
 }
-
-inline void jumpdest(ExecutionState& /*state*/) noexcept {}
 
 /// PUSH instruction implementation.
 /// @tparam Len The number of push data bytes, e.g. PUSH3 is push<3>.
@@ -765,44 +789,44 @@ inline void jumpdest(ExecutionState& /*state*/) noexcept {}
 /// It assumes that the whole data read is valid so code padding is required for some EVM bytecodes
 /// having an "incomplete" PUSH instruction at the very end.
 template <size_t Len>
-inline code_iterator push(ExecutionState& state, code_iterator pos) noexcept
+inline code_iterator push(StackTop stack, ExecutionState& /*state*/, code_iterator pos) noexcept
 {
+    // TODO: state access not needed.
     const auto data_pos = pos + 1;
     uint8_t buffer[Len];
     std::memcpy(buffer, data_pos, Len);  // Valid by the assumption code is padded.
-    state.stack.push(intx::be::load<intx::uint256>(buffer));
+    stack.push(intx::be::load<uint256>(buffer));
     return pos + (Len + 1);
 }
 
 /// DUP instruction implementation.
 /// @tparam N  The number as in the instruction definition, e.g. DUP3 is dup<3>.
-template <size_t N>
-inline void dup(ExecutionState& state) noexcept
+template <int N>
+inline void dup(StackTop stack) noexcept
 {
     static_assert(N >= 1 && N <= 16);
-    state.stack.push(state.stack[N - 1]);
+    stack.push(stack[N - 1]);
 }
 
 /// SWAP instruction implementation.
 /// @tparam N  The number as in the instruction definition, e.g. SWAP3 is swap<3>.
-template <size_t N>
-inline void swap(ExecutionState& state) noexcept
+template <int N>
+inline void swap(StackTop stack) noexcept
 {
     static_assert(N >= 1 && N <= 16);
-    std::swap(state.stack.top(), state.stack[N]);
+    std::swap(stack.top(), stack[N]);
 }
 
-
 template <size_t NumTopics>
-inline evmc_status_code log(ExecutionState& state) noexcept
+inline evmc_status_code log(StackTop stack, ExecutionState& state) noexcept
 {
     static_assert(NumTopics <= 4);
 
     if (state.msg->flags & EVMC_STATIC)
         return EVMC_STATIC_MODE_VIOLATION;
 
-    const auto offset = state.stack.pop();
-    const auto size = state.stack.pop();
+    const auto& offset = stack.pop();
+    const auto& size = stack.pop();
 
     if (!check_memory(state, offset, size))
         return EVMC_OUT_OF_GAS;
@@ -816,7 +840,7 @@ inline evmc_status_code log(ExecutionState& state) noexcept
 
     std::array<evmc::bytes32, NumTopics> topics;  // NOLINT(cppcoreguidelines-pro-type-member-init)
     for (auto& topic : topics)
-        topic = intx::be::store<evmc::bytes32>(state.stack.pop());
+        topic = intx::be::store<evmc::bytes32>(stack.pop());
 
     const auto data = s != 0 ? &state.memory[o] : nullptr;
     state.host.emit_log(state.msg->recipient, data, s, topics.data(), NumTopics);
@@ -825,22 +849,22 @@ inline evmc_status_code log(ExecutionState& state) noexcept
 
 
 template <evmc_opcode Op>
-evmc_status_code call_impl(ExecutionState& state) noexcept;
+evmc_status_code call_impl(StackTop stack, ExecutionState& state) noexcept;
 inline constexpr auto call = call_impl<OP_CALL>;
 inline constexpr auto callcode = call_impl<OP_CALLCODE>;
 inline constexpr auto delegatecall = call_impl<OP_DELEGATECALL>;
 inline constexpr auto staticcall = call_impl<OP_STATICCALL>;
 
 template <evmc_opcode Op>
-evmc_status_code create_impl(ExecutionState& state) noexcept;
+evmc_status_code create_impl(StackTop stack, ExecutionState& state) noexcept;
 inline constexpr auto create = create_impl<OP_CREATE>;
 inline constexpr auto create2 = create_impl<OP_CREATE2>;
 
 template <evmc_status_code StatusCode>
-inline StopToken return_impl(ExecutionState& state) noexcept
+inline StopToken return_impl(StackTop stack, ExecutionState& state) noexcept
 {
-    const auto offset = state.stack[0];
-    const auto size = state.stack[1];
+    const auto& offset = stack[0];
+    const auto& size = stack[1];
 
     if (!check_memory(state, offset, size))
         return {EVMC_OUT_OF_GAS};
@@ -853,17 +877,12 @@ inline StopToken return_impl(ExecutionState& state) noexcept
 inline constexpr auto return_ = return_impl<EVMC_SUCCESS>;
 inline constexpr auto revert = return_impl<EVMC_REVERT>;
 
-inline StopToken invalid(ExecutionState& /*state*/) noexcept
-{
-    return {EVMC_INVALID_INSTRUCTION};
-}
-
-inline StopToken selfdestruct(ExecutionState& state) noexcept
+inline StopToken selfdestruct(StackTop stack, ExecutionState& state) noexcept
 {
     if (state.msg->flags & EVMC_STATIC)
         return {EVMC_STATIC_MODE_VIOLATION};
 
-    const auto beneficiary = intx::be::trunc<evmc::address>(state.stack[0]);
+    const auto beneficiary = intx::be::trunc<evmc::address>(stack[0]);
 
     if (state.rev >= EVMC_BERLIN && state.host.access_account(beneficiary) == EVMC_ACCESS_COLD)
     {
@@ -904,5 +923,55 @@ inline constexpr auto impl = nullptr;
     inline constexpr auto impl<OPCODE> = IDENTIFIER;  // opcode -> implementation
 MAP_OPCODE_TO_IDENTIFIER
 #undef X
+}  // namespace core
+
+/// Instruction implementations - "core" instruction + stack height adjustment.
+/// @{
+template <evmc_opcode Op, void CoreFn(StackTop) noexcept = core::impl<Op>>
+inline void impl(ExecutionState& state) noexcept
+{
+    CoreFn(state.stack.top_item);
+    state.stack.top_item += instr::traits[Op].stack_height_change;
+}
+
+template <evmc_opcode Op, void CoreFn(StackTop, ExecutionState&) noexcept = core::impl<Op>>
+inline void impl(ExecutionState& state) noexcept
+{
+    CoreFn(state.stack.top_item, state);
+    state.stack.top_item += instr::traits[Op].stack_height_change;
+}
+
+template <evmc_opcode Op,
+    evmc_status_code CoreFn(StackTop, ExecutionState&) noexcept = core::impl<Op>>
+inline evmc_status_code impl(ExecutionState& state) noexcept
+{
+    const auto status = CoreFn(state.stack.top_item, state);
+    state.stack.top_item += instr::traits[Op].stack_height_change;
+    return status;
+}
+
+template <evmc_opcode Op, StopToken CoreFn() noexcept = core::impl<Op>>
+inline StopToken impl(ExecutionState& /*state*/) noexcept
+{
+    return CoreFn();
+}
+
+template <evmc_opcode Op, StopToken CoreFn(StackTop, ExecutionState&) noexcept = core::impl<Op>>
+inline StopToken impl(ExecutionState& state) noexcept
+{
+    // Stack height adjustment may be omitted.
+    return CoreFn(state.stack.top_item, state);
+}
+
+template <evmc_opcode Op,
+    code_iterator CoreFn(StackTop, ExecutionState&, code_iterator) noexcept = core::impl<Op>>
+inline code_iterator impl(ExecutionState& state, code_iterator pos) noexcept
+{
+    const auto new_pos = CoreFn(state.stack.top_item, state, pos);
+    state.stack.top_item += instr::traits[Op].stack_height_change;
+    return new_pos;
+}
+/// @}
+
 }  // namespace instr
 }  // namespace evmone

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -105,7 +105,8 @@ TEST_P(evm, dup_stack_underflow)
 
 TEST_P(evm, sub_and_swap)
 {
-    execute(33, "600180810380829052602090f3");
+    execute(33, push(1) + OP_DUP1 + OP_DUP2 + OP_SUB + OP_DUP1 + OP_DUP3 + OP_SWAP1 + OP_MSTORE +
+                    push(32) + OP_SWAP1 + OP_RETURN);
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
     EXPECT_EQ(result.gas_left, 0);
     ASSERT_EQ(result.output_size, 32);


### PR DESCRIPTION
Introduce instruction "core" implementations which differ by not
adjusting EVM stack height. Also provide wrappers (instr::impl<Op>)
to support previous instruction functions.

Use "core" instructions in Baseline.