### PR TITLE
baseline: Track stack evolution separately

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -222,8 +222,9 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
         if constexpr (TracingEnabled)
         {
             const auto offset = static_cast<uint32_t>(position.code_it - code);
+            const auto stack_height = static_cast<int>(position.stack_top - stack_bottom);
             if (offset < state.code.size())  // Skip STOP from code padding.
-                tracer->notify_instruction_start(offset, state);
+                tracer->notify_instruction_start(offset, position.stack_top, stack_height, state);
         }
 
         const auto op = *position.code_it;

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <evmc/instructions.h>
+#include <intx/intx.hpp>
 #include <memory>
 #include <ostream>
 #include <string_view>
@@ -16,7 +17,7 @@ struct ExecutionState;
 
 class Tracer
 {
-    friend class VM;  // Has access the the m_next_tracer to traverse the list forward.
+    friend class VM;  // Has access the m_next_tracer to traverse the list forward.
     std::unique_ptr<Tracer> m_next_tracer;
 
 public:
@@ -38,17 +39,19 @@ public:
     }
 
     void notify_instruction_start(  // NOLINT(misc-no-recursion)
-        uint32_t pc, const ExecutionState& state) noexcept
+        uint32_t pc, intx::uint256* stack_top, int stack_height,
+        const ExecutionState& state) noexcept
     {
-        on_instruction_start(pc, state);
+        on_instruction_start(pc, stack_top, stack_height, state);
         if (m_next_tracer)
-            m_next_tracer->notify_instruction_start(pc, state);
+            m_next_tracer->notify_instruction_start(pc, stack_top, stack_height, state);
     }
 
 private:
     virtual void on_execution_start(
         evmc_revision rev, const evmc_message& msg, bytes_view code) noexcept = 0;
-    virtual void on_instruction_start(uint32_t pc, const ExecutionState& state) noexcept = 0;
+    virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height,
+        const ExecutionState& state) noexcept = 0;
     virtual void on_execution_end(const evmc_result& result) noexcept = 0;
 };
 

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -54,8 +54,8 @@ protected:
 
         void on_execution_end(const evmc_result& /*result*/) noexcept override { m_code = nullptr; }
 
-        void on_instruction_start(
-            uint32_t pc, const evmone::ExecutionState& /*state*/) noexcept override
+        void on_instruction_start(uint32_t pc, const intx::uint256* /*stack_top*/,
+            int /*stack_height*/, const evmone::ExecutionState& /*state*/) noexcept override
         {
             const auto opcode = m_code[pc];
             m_trace << m_name << pc << ":"


### PR DESCRIPTION
Track EVM stack top item outside of State object. This make the stack
top pointer always visible to the compiler and it is able to better
optimize the interpreter.