### PR TITLE
Move stack space allocation in ExecutionState back

### DIFF
--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -151,10 +151,9 @@ public:
 };
 
 /// Generic execution state for generic instructions implementations.
-struct ExecutionState  // TODO: NOLINT(clang-analyzer-optin.performance.Padding)
+struct ExecutionState
 {
     int64_t gas_left = 0;
-    Stack stack;
     Memory memory;
     const evmc_message* msg = nullptr;
     evmc::HostContext host;
@@ -176,6 +175,9 @@ struct ExecutionState  // TODO: NOLINT(clang-analyzer-optin.performance.Padding)
         const baseline::CodeAnalysis* baseline = nullptr;
         const advanced::AdvancedCodeAnalysis* advanced;
     } analysis{};
+
+    Stack stack;
+
 
     ExecutionState() noexcept = default;
 


### PR DESCRIPTION
Place the Stack field of ExecutionState in the end. It in-place
allocates the stack space so this improves ExecutionState layout:
all individual members are in front sharing cache lines and theirs
memory offsets are smaller. Also the struct padding is optimal.