### PR TITLE
ci: Upgrade Clang coverage build to clang 13.0.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -359,9 +359,7 @@ jobs:
       - test
 
   clang-latest-coverage:
-    docker:
-      # TODO: clang-13 is broken.
-      - image: ethereum/cpp-build-env:17-clang-12
+    executor: linux-clang-latest
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2


### PR DESCRIPTION
Fixes #398.