### PR TITLE
baseline: Drop [[always_inline]] from invoke()

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -33,7 +33,11 @@ target_include_directories(evmone PUBLIC
     $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 if(CABLE_COMPILER_GNULIKE)
-    target_compile_options(evmone PRIVATE -fno-exceptions)
+    target_compile_options(
+        evmone PRIVATE
+        -fno-exceptions
+        $<$<CXX_COMPILER_ID:GNU>:-Wstack-usage=2500>
+    )
     if(NOT SANITIZE MATCHES undefined)
         # RTTI can be disabled except for UBSan which checks vptr integrity.
         target_compile_options(evmone PRIVATE -fno-rtti)

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -163,8 +163,8 @@ inline code_iterator invoke(StopToken (*instr_fn)(StackTop, ExecutionState&) noe
 
 /// A helper to invoke the instruction implementation of the given opcode Op.
 template <evmc_opcode Op>
-[[gnu::always_inline]] inline Position invoke(const CostTable& cost_table,
-    const uint256* stack_bottom, Position pos, ExecutionState& state) noexcept
+inline Position invoke(const CostTable& cost_table, const uint256* stack_bottom, Position pos,
+    ExecutionState& state) noexcept
 {
     const auto stack_size = static_cast<int>(pos.stack_top - stack_bottom);
     if (const auto status = check_requirements<Op>(cost_table, state.gas_left, stack_size);


### PR DESCRIPTION
The [[gnu::always_inline]] attribute on the invoke() does not affect
optimized builds (the function is still inlined). But it saves stack
space in debug builds.
In particular the main baseline::execute() function in debug build:
- use 13872 bytes of stack space with [[gnu::always_inline]],
- 2432 without [[gnu::always_inline]],
- 608 with additional -Og optimization level
  (not enabled in this change).