### PR TITLE
RJUMP for legacy code

### DIFF
--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -138,6 +138,16 @@ const Instruction* op_jumpi(const Instruction* instr, AdvancedExecutionState& st
     return instr;
 }
 
+const Instruction* op_rjump(const Instruction*, AdvancedExecutionState& state) noexcept
+{
+    return state.exit(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+const Instruction* op_rjumpi(const Instruction*, AdvancedExecutionState& state) noexcept
+{
+    return state.exit(EVMC_UNDEFINED_INSTRUCTION);
+}
+
 const Instruction* op_pc(const Instruction* instr, AdvancedExecutionState& state) noexcept
 {
     state.stack.push(instr->arg.number);
@@ -231,6 +241,8 @@ constexpr std::array<instruction_exec_fn, 256> instruction_implementations = [](
     table[OP_SSTORE] = op_sstore;
     table[OP_JUMP] = op_jump;
     table[OP_JUMPI] = op_jumpi;
+    table[OP_RJUMP] = op_rjump;
+    table[OP_RJUMPI] = op_rjumpi;
     table[OP_PC] = op_pc;
     table[OP_GAS] = op_gas;
     table[OPX_BEGINBLOCK] = opx_beginblock;

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -765,6 +765,21 @@ inline code_iterator jumpi(StackTop stack, ExecutionState& state, code_iterator 
     return cond ? jump_impl(state, dst) : pos + 1;
 }
 
+inline code_iterator rjump(StackTop /*stack*/, ExecutionState& /*state*/, code_iterator pc) noexcept
+{
+    // Reading next 2 bytes is guaranteed to be safe by deploy-time validation.
+    const auto offset_hi = *(pc + 1);
+    const auto offset_lo = *(pc + 2);
+    const auto offset = static_cast<int16_t>((offset_hi << 8) + offset_lo);
+    return pc + 3 + offset;  // PC_post_rjump + offset
+}
+
+inline code_iterator rjumpi(StackTop stack, ExecutionState& state, code_iterator pc) noexcept
+{
+    const auto cond = stack.pop();
+    return cond ? rjump(stack, state, pc) : pc + 3;
+}
+
 inline code_iterator pc(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
 {
     stack.push(static_cast<uint64_t>(pos - state.code.data()));

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -164,6 +164,8 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
     table[EVMC_SHANGHAI][OP_PUSH0] = 2;
 
     table[EVMC_CANCUN] = table[EVMC_SHANGHAI];
+    table[EVMC_CANCUN][OP_RJUMP] = 5;
+    table[EVMC_CANCUN][OP_RJUMPI] = 7;
 
     return table;
 }();
@@ -283,6 +285,8 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_MSIZE] = {"MSIZE", 0, 1, EVMC_FRONTIER};
     table[OP_GAS] = {"GAS", 0, 1, EVMC_FRONTIER};
     table[OP_JUMPDEST] = {"JUMPDEST", 0, 0, EVMC_FRONTIER};
+    table[OP_RJUMP] = {"RJUMP", 0, 0, EVMC_CANCUN};
+    table[OP_RJUMPI] = {"RJUMPI", 1, -1, EVMC_CANCUN};
 
     table[OP_PUSH0] = {"PUSH0", 0, 1, EVMC_SHANGHAI};
 

--- a/lib/evmone/instructions_xmacro.hpp
+++ b/lib/evmone/instructions_xmacro.hpp
@@ -68,6 +68,8 @@
     X(OP_MSIZE, msize)                   \
     X(OP_GAS, gas)                       \
     X(OP_JUMPDEST, jumpdest)             \
+    X(OP_RJUMP, rjump)                   \
+    X(OP_RJUMPI, rjumpi)                 \
     X(OP_PUSH0, push0)                   \
     X(OP_PUSH1, push<1>)                 \
     X(OP_PUSH2, push<2>)                 \

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(evmone-unittests
     evm_memory_test.cpp
     evm_state_test.cpp
     evm_other_test.cpp
+    evm_rjump_test.cpp
     evm_benchmark_test.cpp
     evmone_test.cpp
     execution_state_test.cpp

--- a/test/unittests/evm_fixture.cpp
+++ b/test/unittests/evm_fixture.cpp
@@ -23,4 +23,10 @@ const char* print_vm_name(const testing::TestParamInfo<evmc::VM*>& info) noexcep
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(evmone, evm, testing::Values(&advanced_vm, &baseline_vm), print_vm_name);
+
+bool evm::isAdvanced() noexcept
+{
+    return GetParam() == &advanced_vm;
+}
+
 }  // namespace evmone::test

--- a/test/unittests/evm_fixture.hpp
+++ b/test/unittests/evm_fixture.hpp
@@ -32,6 +32,8 @@ namespace evmone::test
 class evm : public testing::TestWithParam<evmc::VM*>
 {
 protected:
+    static bool isAdvanced() noexcept;
+
     /// The VM handle.
     evmc::VM& vm;
 

--- a/test/unittests/evm_rjump_test.cpp
+++ b/test/unittests/evm_rjump_test.cpp
@@ -1,0 +1,118 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "evm_fixture.hpp"
+
+using evmone::test::evm;
+
+TEST_P(evm, eof2_rjump)
+{
+    // Relative jumps are not implemented in Advanced.
+    if (isAdvanced())
+        return;
+
+    rev = EVMC_CANCUN;
+    auto code = rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1);
+
+    execute(code);
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 1);
+}
+
+TEST_P(evm, eof2_rjump_backward)
+{
+    // Relative jumps are not implemented in Advanced.
+    if (isAdvanced())
+        return;
+
+    rev = EVMC_CANCUN;
+    auto code = rjump(11) + OP_INVALID + mstore8(0, 1) + ret(0, 1) + rjump(-13);
+
+    execute(code);
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 1);
+}
+
+TEST_P(evm, eof2_rjump_0_offset)
+{
+    // Relative jumps are not implemented in Advanced.
+    if (isAdvanced())
+        return;
+
+    rev = EVMC_CANCUN;
+    auto code = rjump(0) + mstore8(0, 1) + ret(0, 1);
+
+    execute(code);
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 1);
+}
+
+TEST_P(evm, eof2_rjumpi)
+{
+    // Relative jumps are not implemented in Advanced.
+    if (isAdvanced())
+        return;
+
+    rev = EVMC_CANCUN;
+    auto code =
+        rjumpi(10, calldataload(0)) + mstore8(0, 2) + ret(0, 1) + mstore8(0, 1) + ret(0, 1);
+
+    // RJUMPI condition is true
+    execute(code, "01");
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 1);
+
+    // RJUMPI condition is false
+    execute(code, "00");
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 2);
+}
+
+TEST_P(evm, eof2_rjumpi_backwards)
+{
+    // Relative jumps are not implemented in Advanced.
+    if (isAdvanced())
+        return;
+
+    rev = EVMC_CANCUN;
+    auto code = rjump(11) + OP_INVALID + mstore8(0, 1) + ret(0, 1) +
+                              rjumpi(-16, calldataload(0)) + mstore8(0, 2) + ret(0, 1);
+
+    // RJUMPI condition is true
+    execute(code, "01");
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 1);
+
+    // RJUMPI condition is false
+    execute(code, "00");
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+    EXPECT_EQ(result.output_data[0], 2);
+}
+
+TEST_P(evm, eof2_rjumpi_0_offset)
+{
+    // Relative jumps are not implemented in Advanced.
+    if (isAdvanced())
+        return;
+
+    rev = EVMC_CANCUN;
+    auto code = rjumpi(0, calldataload(0)) + mstore8(0, 1) + ret(0, 1);
+
+    // RJUMPI condition is true
+    execute(code, "01");
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+
+    // RJUMPI condition is false
+    execute(code, "01");
+    EXPECT_STATUS(EVMC_SUCCESS);
+    ASSERT_EQ(result.output_size, 1);
+}

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -64,6 +64,12 @@ inline bytecode operator*(int n, evmc_opcode op)
     return n * bytecode{op};
 }
 
+template <typename T>
+inline typename std::enable_if_t<std::is_same_v<T, uint16_t> || std::is_same_v<T, int16_t>, bytes>
+big_endian(T value)
+{
+    return {static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value & 0xff)};
+}
 
 inline bytecode push(bytes_view data)
 {
@@ -191,6 +197,16 @@ inline bytecode jump(bytecode target)
 inline bytecode jumpi(bytecode target, bytecode condition)
 {
     return condition + target + OP_JUMPI;
+}
+
+inline bytecode rjump(int16_t offset)
+{
+    return OP_RJUMP + big_endian(offset);
+}
+
+inline bytecode rjumpi(int16_t offset, bytecode condition)
+{
+    return condition + OP_RJUMPI + bytecode{big_endian(offset)};
 }
 
 inline bytecode ret(bytecode index, bytecode size)


### PR DESCRIPTION
The `RJUMP` and `RJUMPI` implementation ported from #389.

```sh
bin/evmc run --vm ./lib/libevmone.so,O=0,histogram --rev 12 5cfffd
Config: ./lib/libevmone.so,O=0,histogram
Executing on Cancun with 1000000 gas limit

--- # HISTOGRAM depth=0
opcode,count
RJUMP,200001
Result:   out of gas
Gas used: 1000000
```