### PR TITLE
Fix clang-tidy 14 warnings

### DIFF
--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -13,7 +13,7 @@ evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& a
 {
     state.analysis.advanced = &analysis;  // Allow accessing the analysis by instructions.
 
-    const auto* instr = &state.analysis.advanced->instrs[0];  // Start with the first instruction.
+    const auto* instr = state.analysis.advanced->instrs.data();  // Get the first instruction.
     while (instr != nullptr)
         instr = instr->fn(instr, state);
 

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -99,7 +99,7 @@ std::pair<EOFSectionHeaders, EOFValidationError> validate_eof_headers(bytes_view
 
 EOFValidationError validate_instructions(evmc_revision rev, bytes_view code) noexcept
 {
-    assert(code.size() > 0);  // guaranteed by EOF headers validation
+    assert(!code.empty());  // guaranteed by EOF headers validation
 
     size_t i = 0;
     uint8_t op = code[0];

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -64,7 +64,7 @@ TEST(analysis, push)
     ASSERT_EQ(analysis.push_values.size(), 1);
     EXPECT_EQ(analysis.instrs[0].fn, op_tbl[OPX_BEGINBLOCK].fn);
     EXPECT_EQ(analysis.instrs[1].arg.small_push_value, push_value);
-    EXPECT_EQ(analysis.instrs[2].arg.push_value, &analysis.push_values[0]);
+    EXPECT_EQ(analysis.instrs[2].arg.push_value, analysis.push_values.data());
     EXPECT_EQ(analysis.push_values[0], intx::uint256{0xee} << 240);
 }
 


### PR DESCRIPTION
The main addition is the [readability-container-data-pointer](https://clang.llvm.org/extra/clang-tidy/checks/readability-container-data-pointer.html) check. I think in some place the `&v[0]` is more meaningful than `v.data()` so we can disable the check.