### PR TITLE
advanced: Fix JUMPI followed by stack underflow

### DIFF
--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -141,18 +141,16 @@ const Instruction* op_jump(const Instruction*, AdvancedExecutionState& state) no
 const Instruction* op_jumpi(const Instruction* instr, AdvancedExecutionState& state) noexcept
 {
     if (state.stack[1] != 0)
-        instr = op_jump(instr, state);
+    {
+        instr = op_jump(instr, state);  // target
+        state.stack.pop();              // condition
+    }
     else
     {
-        state.stack.pop();
-
-        instr = opx_beginblock(instr, state);
+        state.stack.pop();                     // target
+        state.stack.pop();                     // condition
+        instr = opx_beginblock(instr, state);  // follow-by block
     }
-
-    // OPT: The pc must be the BEGINBLOCK (even in fallback case),
-    //      so we can execute it straight away.
-
-    state.stack.pop();
     return instr;
 }
 

--- a/test/unittests/evm_control_flow_test.cpp
+++ b/test/unittests/evm_control_flow_test.cpp
@@ -134,6 +134,12 @@ TEST_P(evm, jumpi_jumpdest)
     EXPECT_GAS_USED(EVMC_SUCCESS, 20);
 }
 
+TEST_P(evm, jumpi_followed_by_stack_underflow)
+{
+    execute(push(0) + OP_DUP1 + OP_JUMPI + OP_POP);
+    EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
+}
+
 TEST_P(evm, pc_sum)
 {
     const auto code = 4 * OP_PC + 3 * OP_ADD + ret_top();


### PR DESCRIPTION
Fix stack height check for the basic block following a JUMPI instruction.
Before the stack height was 1 too big because the implementation
incorrectly did not remove the JUMPI condition from the stack.

The bug was introduced in https://github.com/ethereum/evmone/pull/457.