### PR TITLE
cmake: Require CMake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.16...3.23)
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/evmc/.git)
     message(FATAL_ERROR "Git submodules not initialized, execute:\n  git submodule update --init")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,10 @@ if(CABLE_COMPILER_GNULIKE)
     add_compile_options(
         -Wmissing-declarations
         -Wno-attributes  # Allow using unknown attributes.
+        $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
     )
     cable_add_cxx_compiler_flag_if_supported(-Wduplicated-cond)
     cable_add_cxx_compiler_flag_if_supported(-Wduplicate-enum)
-    cable_add_cxx_compiler_flag_if_supported(-Wextra-semi)
     cable_add_cxx_compiler_flag_if_supported(-Wfinal-dtor-non-final-class)
     cable_add_cxx_compiler_flag_if_supported(-Wlogical-op)
     cable_add_cxx_compiler_flag_if_supported(-Wnewline-eof)

--- a/circle.yml
+++ b/circle.yml
@@ -47,6 +47,12 @@ executors:
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
+  linux-base:
+    docker:
+      - image: cimg/base:edge-22.04
+    resource_class: small
+    environment:
+      CMAKE_BUILD_PARALLEL_LEVEL: 2
   macos:
     macos:
       xcode: 13.4
@@ -54,6 +60,17 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
 
 commands:
+  install_cmake:
+    parameters:
+      version:
+        type: string
+    steps:
+      - run:
+          name: "Install CMake <<parameters.version>>"
+          working_directory: /usr/local
+          command: |
+            curl -L https://github.com/Kitware/CMake/releases/download/v<<parameters.version>>/cmake-<<parameters.version>>-linux-x86_64.tar.gz | sudo tar -xz --strip=1
+
   build_silkworm:
     parameters:
       branch:
@@ -438,6 +455,14 @@ jobs:
       - build
       - test
 
+  cmake-min:
+    executor: linux-base
+    steps:
+      - install_cmake:
+          version: 3.16.9
+      - build
+      - test
+
 workflows:
   version: 2
   evmone:
@@ -463,6 +488,7 @@ workflows:
             tags:
               only: /^v[0-9].*/
       - consensus-tests
+      - cmake-min
       - gcc-min
       - clang-min
       - gcc-latest-coverage

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ executors:
     resource_class: xlarge
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
-  fuzzing:
+  linux-clang-xlarge:
     docker:
       - image: ethereum/cpp-build-env:18-clang-14
     resource_class: xlarge
@@ -386,7 +386,7 @@ jobs:
       - test
 
   clang-latest-sanitizers:
-    executor: linux-clang-latest
+    executor: linux-clang-xlarge
     environment:
       CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=NO -DSANITIZE=address,undefined,shift-exponent,implicit-conversion,nullability -DCMAKE_CXX_CLANG_TIDY=clang-tidy
       UBSAN_OPTIONS: halt_on_error=1
@@ -423,7 +423,7 @@ jobs:
           destination: coverage
 
   fuzzing:
-    executor: fuzzing
+    executor: linux-clang-xlarge
     environment:
       CMAKE_OPTIONS: -DEVMONE_FUZZING=ON
     steps:


### PR DESCRIPTION
Bump the minimum required CMake version to 3.16. This is already fact
because required by ethash. Also specify max version 3.23 for policy
settings.