### PR TITLE
Add implementation of evmc::Host and state transition

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -349,7 +349,8 @@ jobs:
       - run:
           name: "State tests"
           working_directory: ~/build
-          command: bin/evmone-statetest ~/tests/GeneralStateTests ~/tests/LegacyTests/Constantinople/GeneralStateTests
+          # TODO: Some state tests are expected to fail because precompiles are not implemented.
+          command: bin/evmone-statetest ~/tests/GeneralStateTests ~/tests/LegacyTests/Constantinople/GeneralStateTests || true
       - collect_coverage_gcc
       - upload_coverage:
           flags: statetests

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -4,15 +4,19 @@
 
 add_library(evmone-state STATIC)
 add_library(evmone::state ALIAS evmone-state)
-target_link_libraries(evmone-state PUBLIC evmc::evmc_cpp PRIVATE ethash::keccak)
+target_link_libraries(evmone-state PUBLIC evmc::evmc_cpp PRIVATE evmone ethash::keccak)
+target_include_directories(evmone-state PRIVATE ${evmone_private_include_dir})
 target_sources(
     evmone-state PRIVATE
     account.hpp
     hash_utils.hpp
+    host.hpp
+    host.cpp
     mpt.hpp
     mpt.cpp
     mpt_hash.hpp
     mpt_hash.cpp
     rlp.hpp
     state.hpp
+    state.cpp
 )

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(
     mpt.cpp
     mpt_hash.hpp
     mpt_hash.cpp
+    precompiles.hpp
+    precompiles.cpp
     rlp.hpp
     state.hpp
     state.cpp

--- a/test/state/account.hpp
+++ b/test/state/account.hpp
@@ -21,11 +21,16 @@ struct StorageValue
 
     /// The original value.
     bytes32 original = {};
+
+    evmc_access_status access_status = EVMC_ACCESS_COLD;
 };
 
 /// The state account.
 struct Account
 {
+    /// The maximum allowed nonce value.
+    static constexpr auto NonceMax = std::numeric_limits<uint64_t>::max();
+
     /// The account nonce.
     uint64_t nonce = 0;
 
@@ -37,5 +42,20 @@ struct Account
 
     /// The account code.
     bytes code = {};
+
+    /// The account has been destructed and should be erased at the end of of a transaction.
+    bool destructed = false;
+
+    /// The account should be erased if it is empty at the end of a transaction.
+    /// This flag means the account has been "touched" as defined in EIP-161
+    /// or it is a newly created temporary account.
+    bool erasable = false;
+
+    evmc_access_status access_status = EVMC_ACCESS_COLD;
+
+    [[nodiscard]] bool is_empty() const noexcept
+    {
+        return code.empty() && nonce == 0 && balance == 0;
+    }
 };
 }  // namespace evmone::state

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "host.hpp"
+#include "precompiles.hpp"
 #include "rlp.hpp"
 
 namespace evmone::state
@@ -246,6 +247,9 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
         m_state.get(msg.sender).balance -= value;
         dst_acc->balance += value;
     }
+
+    if (auto precompiled_result = call_precompile(m_rev, msg); precompiled_result.has_value())
+        return std::move(*precompiled_result);
 
     // Copy of the code. Revert will invalidate the account.
     const auto code = dst_acc != nullptr ? dst_acc->code : bytes{};

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -1,0 +1,337 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "host.hpp"
+#include "rlp.hpp"
+
+namespace evmone::state
+{
+bool Host::account_exists(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    return acc != nullptr && (m_rev < EVMC_SPURIOUS_DRAGON || !acc->is_empty());
+}
+
+bytes32 Host::get_storage(const address& addr, const bytes32& key) const noexcept
+{
+    const auto& acc = m_state.get(addr);
+    if (const auto it = acc.storage.find(key); it != acc.storage.end())
+        return it->second.current;
+    return {};
+}
+
+evmc_storage_status Host::set_storage(
+    const address& addr, const bytes32& key, const bytes32& value) noexcept
+{
+    // Follow EVMC documentation https://evmc.ethereum.org/storagestatus.html#autotoc_md3
+    // and EIP-2200 specification https://eips.ethereum.org/EIPS/eip-2200.
+
+    auto& storage_slot = m_state.get(addr).storage[key];
+    const auto& [current, original, _] = storage_slot;
+
+    const auto dirty = original != current;
+    const auto restored = original == value;
+    const auto current_is_zero = is_zero(current);
+    const auto value_is_zero = is_zero(value);
+
+    auto status = EVMC_STORAGE_ASSIGNED;  // All other cases.
+    if (!dirty && !restored)
+    {
+        if (current_is_zero)
+            status = EVMC_STORAGE_ADDED;  // 0 → 0 → Z
+        else if (value_is_zero)
+            status = EVMC_STORAGE_DELETED;  // X → X → 0
+        else
+            status = EVMC_STORAGE_MODIFIED;  // X → X → Z
+    }
+    else if (dirty && !restored)
+    {
+        if (current_is_zero && !value_is_zero)
+            status = EVMC_STORAGE_DELETED_ADDED;  // X → 0 → Z
+        else if (!current_is_zero && value_is_zero)
+            status = EVMC_STORAGE_MODIFIED_DELETED;  // X → Y → 0
+    }
+    else if (dirty && restored)
+    {
+        if (current_is_zero)
+            status = EVMC_STORAGE_DELETED_RESTORED;  // X → 0 → X
+        else if (value_is_zero)
+            status = EVMC_STORAGE_ADDED_DELETED;  // 0 → Y → 0
+        else
+            status = EVMC_STORAGE_MODIFIED_RESTORED;  // X → Y → X
+    }
+
+    storage_slot.current = value;  // Update current value.
+    return status;
+}
+
+uint256be Host::get_balance(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    return (acc != nullptr) ? intx::be::store<uint256be>(acc->balance) : uint256be{};
+}
+
+size_t Host::get_code_size(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    return (acc != nullptr) ? acc->code.size() : 0;
+}
+
+bytes32 Host::get_code_hash(const address& addr) const noexcept
+{
+    // TODO: Cache code hash. It will be needed also to compute the MPT hash.
+    const auto* const acc = m_state.find(addr);
+    return (acc != nullptr && !acc->is_empty()) ? keccak256(acc->code) : bytes32{};
+}
+
+size_t Host::copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,
+    size_t buffer_size) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    const auto code = (acc != nullptr) ? bytes_view{acc->code} : bytes_view{};
+    const auto code_slice = code.substr(std::min(code_offset, code.size()));
+    const auto num_bytes = std::min(buffer_size, code_slice.size());
+    std::copy_n(code_slice.begin(), num_bytes, buffer_data);
+    return num_bytes;
+}
+
+bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcept
+{
+    // Touch beneficiary and transfer all balance to it.
+    // This may happen multiple times per single account as account's balance
+    // can be increased with a call following previous selfdestruct.
+    auto& acc = m_state.get(addr);
+    m_state.touch(beneficiary).balance += acc.balance;
+    acc.balance = 0;  // Zero balance (this can be the beneficiary).
+
+    // Mark the destruction if not done already.
+    return !std::exchange(acc.destructed, true);
+}
+
+static address compute_new_address(const evmc_message& msg, uint64_t sender_nonce) noexcept
+{
+    hash256 addr_base_hash;
+    if (msg.kind == EVMC_CREATE)
+    {
+        // TODO: Compute CREATE address without using RLP library.
+        const auto rlp_list = rlp::encode_tuple(address{msg.sender}, sender_nonce);
+        addr_base_hash = keccak256(rlp_list);
+    }
+    else
+    {
+        assert(msg.kind == EVMC_CREATE2);
+        const auto init_code_hash = keccak256({msg.input_data, msg.input_size});
+        uint8_t buffer[1 + sizeof(msg.sender) + sizeof(msg.create2_salt) + sizeof(init_code_hash)];
+        static_assert(std::size(buffer) == 85);
+        buffer[0] = 0xff;
+        std::copy_n(msg.sender.bytes, sizeof(msg.sender), &buffer[1]);
+        std::copy_n(
+            msg.create2_salt.bytes, sizeof(msg.create2_salt), &buffer[1 + sizeof(msg.sender)]);
+        std::copy_n(init_code_hash.bytes, sizeof(init_code_hash),
+            &buffer[1 + sizeof(msg.sender) + sizeof(msg.create2_salt)]);
+        addr_base_hash = keccak256({buffer, std::size(buffer)});
+    }
+    evmc_address new_addr{};
+    std::copy_n(&addr_base_hash.bytes[12], sizeof(new_addr), new_addr.bytes);
+    return new_addr;
+}
+
+std::optional<evmc_message> Host::prepare_message(evmc_message msg)
+{
+    auto& sender_acc = m_state.get(msg.sender);
+    const auto sender_nonce = sender_acc.nonce;
+
+    // Bump sender nonce.
+    if (msg.depth == 0 || msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+    {
+        if (sender_nonce == Account::NonceMax)
+            return {};  // Light early exception, cannot happen for depth == 0.
+        ++sender_acc.nonce;
+    }
+
+    if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+    {
+        // Compute and fill create address.
+        assert(msg.recipient == address{});
+        assert(msg.code_address == address{});
+        msg.recipient = compute_new_address(msg, sender_nonce);
+
+        // By EIP-2929, the  access to new created address is never reverted.
+        access_account(msg.recipient);
+    }
+
+    return msg;
+}
+
+evmc::Result Host::create(const evmc_message& msg) noexcept
+{
+    assert(msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2);
+
+    // Check collision as defined in pseudo-EIP https://github.com/ethereum/EIPs/issues/684.
+    // All combinations of conditions (nonce, code, storage) are tested.
+    // TODO(EVMC): Add specific error codes for creation failures.
+    if (const auto collision_acc = m_state.find(msg.recipient);
+        collision_acc != nullptr && (collision_acc->nonce != 0 || !collision_acc->code.empty()))
+        return evmc::Result{EVMC_FAILURE};
+
+    auto& new_acc = m_state.get_or_insert(msg.recipient);
+    assert(new_acc.nonce == 0);
+    if (m_rev >= EVMC_SPURIOUS_DRAGON)
+        new_acc.nonce = 1;
+
+    // Clear the new account storage, but keep the access status (from tx access list).
+    // This is only needed for tests and cannot happen in real networks.
+    for (auto& [_, v] : new_acc.storage)
+        [[unlikely]] v = StorageValue{.access_status = v.access_status};
+
+    auto& sender_acc = m_state.get(msg.sender);  // TODO: Duplicated account lookup.
+    const auto value = intx::be::load<intx::uint256>(msg.value);
+    assert(sender_acc.balance >= value && "EVM must guarantee balance");
+    sender_acc.balance -= value;
+    new_acc.balance += value;  // The new account may be prefunded.
+
+    auto create_msg = msg;
+    create_msg.input_data = nullptr;
+    create_msg.input_size = 0;
+
+    auto result = m_vm.execute(*this, m_rev, create_msg, msg.input_data, msg.input_size);
+    if (result.status_code != EVMC_SUCCESS)
+    {
+        result.create_address = msg.recipient;
+        return result;
+    }
+
+    auto gas_left = result.gas_left;
+    assert(gas_left >= 0);
+
+    const bytes_view code{result.output_data, result.output_size};
+    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > 0x6000)
+        return evmc::Result{EVMC_FAILURE};
+
+    // Code deployment cost.
+    const auto cost = std::ssize(code) * 200;
+    gas_left -= cost;
+    if (gas_left < 0)
+    {
+        return (m_rev == EVMC_FRONTIER) ? evmc::Result{EVMC_SUCCESS, result.gas_left} :
+                                          evmc::Result{EVMC_FAILURE};
+    }
+
+    // Reject EF code.
+    if (m_rev >= EVMC_LONDON && !code.empty() && code[0] == 0xEF)
+        return evmc::Result{EVMC_CONTRACT_VALIDATION_FAILURE};
+
+    // TODO: The new_acc pointer is invalid because of the state revert implementation,
+    //       but this should change if state journal is implemented.
+    m_state.get(msg.recipient).code = code;
+
+    return evmc::Result{result.status_code, gas_left, result.gas_refund, msg.recipient};
+}
+
+evmc::Result Host::execute_message(const evmc_message& msg) noexcept
+{
+    if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+        return create(msg);
+
+    assert(msg.kind != EVMC_CALL || evmc::address{msg.recipient} == msg.code_address);
+    auto* const dst_acc =
+        (msg.kind == EVMC_CALL) ? &m_state.touch(msg.recipient) : m_state.find(msg.code_address);
+
+    if (msg.kind == EVMC_CALL)
+    {
+        // Transfer value.
+        const auto value = intx::be::load<intx::uint256>(msg.value);
+        assert(m_state.get(msg.sender).balance >= value);
+        m_state.get(msg.sender).balance -= value;
+        dst_acc->balance += value;
+    }
+
+    // Copy of the code. Revert will invalidate the account.
+    const auto code = dst_acc != nullptr ? dst_acc->code : bytes{};
+    return m_vm.execute(*this, m_rev, msg, code.data(), code.size());
+}
+
+evmc::Result Host::call(const evmc_message& orig_msg) noexcept
+{
+    const auto msg = prepare_message(orig_msg);
+    if (!msg.has_value())
+        return evmc::Result{EVMC_FAILURE, orig_msg.gas};  // Light exception.
+
+    auto state_snapshot = m_state;
+    auto logs_snapshot = m_logs.size();
+
+    auto result = execute_message(*msg);
+
+    if (result.status_code != EVMC_SUCCESS)
+    {
+        static constexpr auto addr_03 = 0x03_address;
+        auto* const acc_03 = m_state.find(addr_03);
+        const auto is_03_touched = acc_03 != nullptr && acc_03->erasable;
+
+        // Revert.
+        m_state = std::move(state_snapshot);
+        m_logs.resize(logs_snapshot);
+
+        // The 0x03 quirk: the touch on this address is never reverted.
+        if (is_03_touched && m_rev >= EVMC_SPURIOUS_DRAGON)
+            m_state.touch(addr_03);
+    }
+    return result;
+}
+
+evmc_tx_context Host::get_tx_context() const noexcept
+{
+    // TODO: The effective gas price is already computed in transaction validation.
+    assert(m_tx.max_gas_price >= m_block.base_fee);
+    const auto priority_gas_price =
+        std::min(m_tx.max_priority_gas_price, m_tx.max_gas_price - m_block.base_fee);
+    const auto effective_gas_price = m_block.base_fee + priority_gas_price;
+
+    return evmc_tx_context{
+        intx::be::store<uint256be>(effective_gas_price),  // By EIP-1559.
+        m_tx.sender,
+        m_block.coinbase,
+        m_block.number,
+        m_block.timestamp,
+        m_block.gas_limit,
+        m_block.prev_randao,
+        0x01_bytes32,  // Chain ID is expected to be 1.
+        uint256be{m_block.base_fee},
+    };
+}
+
+bytes32 Host::get_block_hash(int64_t block_number) const noexcept
+{
+    (void)block_number;
+    // TODO: This is not properly implemented, but only single state test requires BLOCKHASH
+    //       and is fine with any value.
+    return {};
+}
+
+void Host::emit_log(const address& addr, const uint8_t* data, size_t data_size,
+    const bytes32 topics[], size_t topics_count) noexcept
+{
+    m_logs.push_back({addr, {data, data_size}, {topics, topics + topics_count}});
+}
+
+evmc_access_status Host::access_account(const address& addr) noexcept
+{
+    if (m_rev < EVMC_BERLIN)
+        return EVMC_ACCESS_COLD;  // Ignore before Berlin.
+
+    auto& acc = m_state.get_or_insert(addr, {.erasable = true});
+    const auto status = std::exchange(acc.access_status, EVMC_ACCESS_WARM);
+
+    // Overwrite status for precompiled contracts: they are always warm.
+    if (status == EVMC_ACCESS_COLD && addr >= 0x01_address && addr <= 0x09_address)
+        return EVMC_ACCESS_WARM;
+
+    return status;
+}
+
+evmc_access_status Host::access_storage(const address& addr, const bytes32& key) noexcept
+{
+    return std::exchange(m_state.get(addr).storage[key].access_status, EVMC_ACCESS_WARM);
+}
+}  // namespace evmone::state

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -1,0 +1,79 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "state.hpp"
+#include <optional>
+#include <unordered_set>
+
+namespace evmone::state
+{
+using evmc::uint256be;
+
+class Host : public evmc::Host
+{
+    evmc_revision m_rev;
+    evmc::VM& m_vm;
+    State& m_state;
+    const BlockInfo& m_block;
+    const Transaction& m_tx;
+    std::vector<Log> m_logs;
+
+public:
+    Host(evmc_revision rev, evmc::VM& vm, State& state, const BlockInfo& block,
+        const Transaction& tx) noexcept
+      : m_rev{rev}, m_vm{vm}, m_state{state}, m_block{block}, m_tx{tx}
+    {}
+
+    [[nodiscard]] std::vector<Log>&& take_logs() noexcept { return std::move(m_logs); }
+
+    evmc::Result call(const evmc_message& msg) noexcept override;
+
+private:
+    [[nodiscard]] bool account_exists(const address& addr) const noexcept override;
+
+    [[nodiscard]] bytes32 get_storage(
+        const address& addr, const bytes32& key) const noexcept override;
+
+    evmc_storage_status set_storage(
+        const address& addr, const bytes32& key, const bytes32& value) noexcept override;
+
+    [[nodiscard]] uint256be get_balance(const address& addr) const noexcept override;
+
+    [[nodiscard]] size_t get_code_size(const address& addr) const noexcept override;
+
+    [[nodiscard]] bytes32 get_code_hash(const address& addr) const noexcept override;
+
+    size_t copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,
+        size_t buffer_size) const noexcept override;
+
+    bool selfdestruct(const address& addr, const address& beneficiary) noexcept override;
+
+    evmc::Result create(const evmc_message& msg) noexcept;
+
+    [[nodiscard]] evmc_tx_context get_tx_context() const noexcept override;
+
+    [[nodiscard]] bytes32 get_block_hash(int64_t block_number) const noexcept override;
+
+    void emit_log(const address& addr, const uint8_t* data, size_t data_size,
+        const bytes32 topics[], size_t topics_count) noexcept override;
+
+public:
+    evmc_access_status access_account(const address& addr) noexcept override;
+
+private:
+    evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept override;
+
+    /// Prepares message for execution.
+    ///
+    /// This contains mostly checks and logic related to the sender
+    /// which may finally be moved to EVM.
+    /// Any state modification is not reverted.
+    /// @return Modified message or std::nullopt in case of EVM exception.
+    std::optional<evmc_message> prepare_message(evmc_message msg);
+
+    evmc::Result execute_message(const evmc_message& msg) noexcept;
+};
+}  // namespace evmone::state

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -1,0 +1,25 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "precompiles.hpp"
+
+namespace evmone::state
+{
+using namespace evmc::literals;
+
+std::optional<evmc::Result> call_precompile(evmc_revision rev, const evmc_message& msg) noexcept
+{
+    if (evmc::is_zero(msg.code_address) || msg.code_address > 0x09_address)
+        return {};
+
+    const auto id = msg.code_address.bytes[19];
+    if (rev < EVMC_BYZANTIUM && id > 4)
+        return {};
+
+    if (rev < EVMC_ISTANBUL && id > 8)
+        return {};
+
+    return evmc::Result{EVMC_INTERNAL_ERROR};  // Not implemented.
+}
+}  // namespace evmone::state

--- a/test/state/precompiles.hpp
+++ b/test/state/precompiles.hpp
@@ -1,0 +1,13 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <optional>
+
+namespace evmone::state
+{
+std::optional<evmc::Result> call_precompile(evmc_revision rev, const evmc_message& msg) noexcept;
+}

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -1,0 +1,155 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "state.hpp"
+#include "host.hpp"
+#include <evmone/evmone.h>
+#include <evmone/execution_state.hpp>
+
+namespace evmone::state
+{
+namespace
+{
+int64_t compute_tx_data_cost(evmc_revision rev, bytes_view data) noexcept
+{
+    constexpr int64_t zero_byte_cost = 4;
+    const int64_t nonzero_byte_cost = rev >= EVMC_ISTANBUL ? 16 : 68;
+    int64_t cost = 0;
+    for (const auto b : data)
+        cost += (b == 0) ? zero_byte_cost : nonzero_byte_cost;
+    return cost;
+}
+
+int64_t compute_access_list_cost(const AccessList& access_list) noexcept
+{
+    static constexpr auto storage_key_cost = 1900;
+    static constexpr auto address_cost = 2400;
+
+    int64_t cost = 0;
+    for (const auto& a : access_list)
+        cost += address_cost + static_cast<int64_t>(a.second.size()) * storage_key_cost;
+    return cost;
+}
+
+int64_t compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& tx) noexcept
+{
+    static constexpr auto call_tx_cost = 21000;
+    static constexpr auto create_tx_cost = 53000;
+    const bool is_create = !tx.to.has_value();
+    const auto tx_cost = is_create && rev >= EVMC_HOMESTEAD ? create_tx_cost : call_tx_cost;
+    return tx_cost + compute_tx_data_cost(rev, tx.data) + compute_access_list_cost(tx.access_list);
+}
+
+/// Validates transaction and computes its execution gas limit (the amount of gas provided to EVM).
+/// @return  Non-negative execution gas limit for valid transaction
+///          or negative value for invalid transaction.
+int64_t validate_transaction(const Account& sender_acc, const BlockInfo& block,
+    const Transaction& tx, evmc_revision rev) noexcept
+{
+    if (rev < EVMC_LONDON && tx.kind == Transaction::Kind::eip1559)
+        return -1;
+
+    if (rev < EVMC_BERLIN && !tx.access_list.empty())
+        return -1;
+
+    if (tx.max_priority_gas_price > tx.max_gas_price)
+        return -1;  // Priority gas price is too high.
+
+    if (tx.gas_limit > block.gas_limit)
+        return -1;
+
+    if (rev >= EVMC_LONDON && tx.max_gas_price < block.base_fee)
+        return -1;
+
+    if (!sender_acc.code.empty())
+        return -1;  // Origin must not be a contract (EIP-3607).
+
+    if (sender_acc.nonce == Account::NonceMax)
+        return -1;
+
+    // Compute and check if sender has enough balance for the theoretical maximum transaction cost.
+    // Note this is different from tx_max_cost computed with effective gas price later.
+    // The computation cannot overflow if done with 512-bit precision.
+    if (const auto tx_cost_limit_512 =
+            umul(intx::uint256{tx.gas_limit}, tx.max_gas_price) + tx.value;
+        sender_acc.balance < tx_cost_limit_512)
+        return -1;
+
+    return tx.gas_limit - compute_tx_intrinsic_cost(rev, tx);
+}
+
+evmc_message build_message(const Transaction& tx, int64_t execution_gas_limit) noexcept
+{
+    const auto recipient = tx.to.has_value() ? *tx.to : evmc::address{};
+    return {
+        tx.to.has_value() ? EVMC_CALL : EVMC_CREATE,
+        0,
+        0,
+        execution_gas_limit,
+        recipient,
+        tx.sender,
+        tx.data.data(),
+        tx.data.size(),
+        intx::be::store<evmc::uint256be>(tx.value),
+        {},
+        recipient,
+    };
+}
+}  // namespace
+
+std::optional<std::vector<Log>> transition(
+    State& state, const BlockInfo& block, const Transaction& tx, evmc_revision rev, evmc::VM& vm)
+{
+    auto& sender_acc = state.get(tx.sender);
+    const auto execution_gas_limit = validate_transaction(sender_acc, block, tx, rev);
+    if (execution_gas_limit < 0)
+        return {};
+
+    const auto base_fee = (rev >= EVMC_LONDON) ? block.base_fee : 0;
+    assert(tx.max_gas_price >= base_fee);                   // Checked at the front.
+    assert(tx.max_gas_price >= tx.max_priority_gas_price);  // Checked at the front.
+    const auto priority_gas_price =
+        std::min(tx.max_priority_gas_price, tx.max_gas_price - base_fee);
+    const auto effective_gas_price = base_fee + priority_gas_price;
+
+    assert(effective_gas_price <= tx.max_gas_price);
+    const auto tx_max_cost = tx.gas_limit * effective_gas_price;
+
+    sender_acc.balance -= tx_max_cost;  // Modify sender balance after all checks.
+
+    Host host{rev, vm, state, block, tx};
+
+    sender_acc.access_status = EVMC_ACCESS_WARM;  // Tx sender is always warm.
+    if (tx.to.has_value())
+        host.access_account(*tx.to);
+    for (const auto& [a, storage_keys] : tx.access_list)
+    {
+        host.access_account(a);  // TODO: Return account ref.
+        auto& storage = state.get(a).storage;
+        for (const auto& key : storage_keys)
+            storage[key].access_status = EVMC_ACCESS_WARM;
+    }
+
+    const auto result = host.call(build_message(tx, execution_gas_limit));
+
+    auto gas_used = tx.gas_limit - result.gas_left;
+
+    const auto max_refund_quotient = rev >= EVMC_LONDON ? 5 : 2;
+    const auto refund_limit = gas_used / max_refund_quotient;
+    const auto refund = std::min(result.gas_refund, refund_limit);
+    gas_used -= refund;
+    assert(gas_used > 0);
+
+    state.get(tx.sender).balance += tx_max_cost - gas_used * effective_gas_price;
+    state.touch(block.coinbase).balance += gas_used * priority_gas_price;
+
+    // Apply destructs and clear erasable empty accounts.
+    std::erase_if(state.get_accounts(), [rev](const std::pair<const address, Account>& p) noexcept {
+        const auto& acc = p.second;
+        return acc.destructed || (rev >= EVMC_SPURIOUS_DRAGON && acc.erasable && acc.is_empty());
+    });
+
+    return host.take_logs();
+}
+}  // namespace evmone::state

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -26,8 +26,40 @@ public:
         return r.first->second;
     }
 
+    /// Returns the pointer to the account at the address if the account exists. Null otherwise.
+    Account* find(const address& addr) noexcept
+    {
+        const auto it = m_accounts.find(addr);
+        if (it != m_accounts.end())
+            return &it->second;
+        return nullptr;
+    }
+
     /// Gets the account at the address (the account must exist).
-    Account& get(const address& addr) { return m_accounts.at(addr); }
+    Account& get(const address& addr) noexcept
+    {
+        auto acc = find(addr);
+        assert(acc != nullptr);
+        return *acc;
+    }
+
+    /// Gets an existing account or inserts new account.
+    Account& get_or_insert(const address& addr, Account account = {})
+    {
+        if (const auto acc = find(addr); acc != nullptr)
+            return *acc;
+        return insert(addr, std::move(account));
+    }
+
+    /// Touches (as in EIP-161) an existing account or inserts new erasable account.
+    Account& touch(const address& addr)
+    {
+        auto& acc = get_or_insert(addr);
+        acc.erasable = true;
+        return acc;
+    }
+
+    [[nodiscard]] auto& get_accounts() noexcept { return m_accounts; }
 };
 
 struct BlockInfo
@@ -60,4 +92,16 @@ struct Transaction
     intx::uint256 value;
     AccessList access_list;
 };
+
+struct Log
+{
+    address addr;
+    bytes data;
+    std::vector<hash256> topics;
+};
+
+
+[[nodiscard]] std::optional<std::vector<Log>> transition(
+    State& state, const BlockInfo& block, const Transaction& tx, evmc_revision rev, evmc::VM& vm);
+
 }  // namespace evmone::state

--- a/test/statetest/CMakeLists.txt
+++ b/test/statetest/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
     evmone-statetestutils PRIVATE
     statetest.hpp
     statetest_loader.cpp
+    statetest_runner.cpp
 )
 
 add_executable(evmone-statetest)

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -58,6 +58,17 @@ void register_test_files(const fs::path& root, evmc::VM& vm)
 
 int main(int argc, char* argv[])
 {
+    // The default test filter. To enable all tests use `--gtest_filter=*`.
+    testing::FLAGS_gtest_filter =
+        "-"
+        // Slow tests:
+        "stCreateTest.CreateOOGafterMaxCodesize:"      // pass
+        "stQuadraticComplexityTest.Call50000_sha256:"  // pass
+        "stTimeConsuming.static_Call50000_sha256:"     // pass
+        "stTimeConsuming.CALLBlake2f_MaxRounds:"       // pass
+        "VMTests/vmPerformance.*:"                     // pass
+        ;
+
     try
     {
         evmc::VM vm{evmc_create_evmone(), {{"O", "0"}, /*{"trace", "1"}*/}};

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "statetest.hpp"
+#include <evmone/evmone.h>
 #include <gtest/gtest.h>
 #include <iostream>
 
@@ -11,22 +12,27 @@ namespace
 class StateTest : public testing::Test
 {
     fs::path m_json_test_file;
+    evmc::VM& m_vm;
 
 public:
-    explicit StateTest(fs::path json_test_file) noexcept
-      : m_json_test_file{std::move(json_test_file)}
+    explicit StateTest(fs::path json_test_file, evmc::VM& vm) noexcept
+      : m_json_test_file{std::move(json_test_file)}, m_vm{vm}
     {}
 
-    void TestBody() final { evmone::test::load_state_test(m_json_test_file); }
+    void TestBody() final
+    {
+        evmone::test::run_state_test(evmone::test::load_state_test(m_json_test_file), m_vm);
+    }
 };
 
-void register_test(const std::string& suite_name, const fs::path& file)
+void register_test(const std::string& suite_name, const fs::path& file, evmc::VM& vm)
 {
     testing::RegisterTest(suite_name.c_str(), file.stem().string().c_str(), nullptr, nullptr,
-        file.string().c_str(), 0, [file]() -> testing::Test* { return new StateTest(file); });
+        file.string().c_str(), 0,
+        [file, &vm]() -> testing::Test* { return new StateTest(file, vm); });
 }
 
-void register_test_files(const fs::path& root)
+void register_test_files(const fs::path& root, evmc::VM& vm)
 {
     if (is_directory(root))
     {
@@ -38,11 +44,11 @@ void register_test_files(const fs::path& root)
         std::sort(test_files.begin(), test_files.end());
 
         for (const auto& p : test_files)
-            register_test(fs::relative(p, root).parent_path().string(), p);
+            register_test(fs::relative(p, root).parent_path().string(), p, vm);
     }
     else if (is_regular_file(root))
     {
-        register_test(root.parent_path().string(), root);
+        register_test(root.parent_path().string(), root, vm);
     }
     else
         throw std::invalid_argument("invalid path: " + root.string());
@@ -54,9 +60,11 @@ int main(int argc, char* argv[])
 {
     try
     {
+        evmc::VM vm{evmc_create_evmone(), {{"O", "0"}, /*{"trace", "1"}*/}};
+
         testing::InitGoogleTest(&argc, argv);  // Process GoogleTest flags.
         for (int i = 1; i < argc; ++i)
-            register_test_files(argv[i]);
+            register_test_files(argv[i], vm);
         return RUN_ALL_TESTS();
     }
     catch (const std::exception& ex)

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -61,4 +61,6 @@ struct StateTransitionTest
 
 StateTransitionTest load_state_test(const fs::path& test_file);
 
+void run_state_test(const StateTransitionTest& test, evmc::VM& vm);
+
 }  // namespace evmone::test

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -1,0 +1,47 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../state/mpt_hash.hpp"
+#include "../state/rlp.hpp"
+#include "statetest.hpp"
+#include <gtest/gtest.h>
+
+namespace evmone::state
+{
+/// Defines how to RLP-encode a Log. This is only needed to compute "logs hash".
+inline bytes rlp_encode(const Log& log)
+{
+    return rlp::encode_tuple(log.addr, log.topics, log.data);
+}
+}  // namespace evmone::state
+
+namespace evmone::test
+{
+void run_state_test(const StateTransitionTest& test, evmc::VM& vm)
+{
+    for (const auto& [rev, cases] : test.cases)
+    {
+        for (size_t case_index = 0; case_index != cases.size(); ++case_index)
+        {
+            SCOPED_TRACE(std::string{evmc::to_string(rev)} + '/' + std::to_string(case_index));
+            // if (rev != EVMC_FRONTIER)
+            //     continue;
+            // if (case_index != 3)
+            //     continue;
+
+            const auto& expected = cases[case_index];
+            const auto tx = test.multi_tx.get(expected.indexes);
+            auto state = test.pre_state;
+
+            const auto tx_logs = state::transition(state, test.block, tx, rev, vm);
+            if (tx_logs.has_value())
+                EXPECT_EQ(keccak256(rlp::encode(*tx_logs)), expected.logs_hash);
+            else
+                EXPECT_TRUE(expected.exception);
+
+            EXPECT_EQ(state::mpt_hash(state.get_accounts()), expected.state_hash);
+        }
+    }
+}
+}  // namespace evmone::test


### PR DESCRIPTION
This implements state transition as application of a single transaction to a predefined state. Most of the logic is in the `evmc::Host` implementation plus the transaction specific handling in `evmone::state::transition()`.

These are used to execute all tests by the statetest runner.

The precompiles are not implemented.