### PR TITLE
Implement gas refund

### DIFF
--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -19,10 +19,11 @@ evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& a
 
     const auto gas_left =
         (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
+    const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
 
     assert(state.output_size != 0 || state.output_offset == 0);
-    return evmc::make_result(
-        state.status, gas_left, 0, state.memory.data() + state.output_offset, state.output_size);
+    return evmc::make_result(state.status, gas_left, gas_refund,
+        state.memory.data() + state.output_offset, state.output_size);
 }
 
 evmc_result execute(evmc_vm* /*unused*/, const evmc_host_interface* host, evmc_host_context* ctx,

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -274,9 +274,10 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
 exit:
     const auto gas_left =
         (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? state.gas_left : 0;
+    const auto gas_refund = (state.status == EVMC_SUCCESS) ? state.gas_refund : 0;
 
     assert(state.output_size != 0 || state.output_offset == 0);
-    const auto result = evmc::make_result(state.status, gas_left, 0,
+    const auto result = evmc::make_result(state.status, gas_left, gas_refund,
         state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
 
     if constexpr (TracingEnabled)

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -126,6 +126,7 @@ class ExecutionState
 {
 public:
     int64_t gas_left = 0;
+    int64_t gas_refund = 0;
     Memory memory;
     const evmc_message* msg = nullptr;
     evmc::HostContext host;

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -892,7 +892,11 @@ inline StopToken selfdestruct(StackTop stack, ExecutionState& state) noexcept
         }
     }
 
-    state.host.selfdestruct(state.msg->recipient, beneficiary);
+    if (state.host.selfdestruct(state.msg->recipient, beneficiary))
+    {
+        if (state.rev < EVMC_LONDON)
+            state.gas_refund += 24000;
+    }
     return {EVMC_SUCCESS};
 }
 

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -99,6 +99,7 @@ evmc_status_code call_impl(StackTop stack, ExecutionState& state) noexcept
 
     const auto gas_used = msg.gas - result.gas_left;
     state.gas_left -= gas_used;
+    state.gas_refund += result.gas_refund;
     return EVMC_SUCCESS;
 }
 
@@ -161,6 +162,7 @@ evmc_status_code create_impl(StackTop stack, ExecutionState& state) noexcept
 
     const auto result = state.host.call(msg);
     state.gas_left -= msg.gas - result.gas_left;
+    state.gas_refund += result.gas_refund;
 
     state.return_data.assign(result.output_data, result.output_size);
     if (result.status_code == EVMC_SUCCESS)

--- a/lib/evmone/instructions_storage.cpp
+++ b/lib/evmone/instructions_storage.cpp
@@ -6,6 +6,91 @@
 
 namespace evmone::instr::core
 {
+namespace
+{
+/// The gas cost specification for storage instructions.
+struct StorageCostSpec
+{
+    bool net_cost;        ///< Is this net gas cost metering schedule?
+    int16_t warm_access;  ///< Storage warm access cost, YP: G_{warmaccess}
+    int16_t set;          ///< Storage addition cost, YP: G_{sset}
+    int16_t reset;        ///< Storage modification cost, YP: G_{sreset}
+    int16_t clear;        ///< Storage deletion refund, YP: R_{sclear}
+};
+
+/// Table of gas cost specification for storage instructions per EVM revision.
+/// TODO: This can be moved to instruction traits and be used in other places: e.g.
+///       SLOAD cost, replacement for warm_storage_read_cost.
+constexpr auto storage_cost_spec = []() noexcept {
+    std::array<StorageCostSpec, EVMC_MAX_REVISION + 1> tbl{};
+
+    // Legacy cost schedule.
+    for (auto rev : {EVMC_FRONTIER, EVMC_HOMESTEAD, EVMC_TANGERINE_WHISTLE, EVMC_SPURIOUS_DRAGON,
+             EVMC_BYZANTIUM, EVMC_PETERSBURG})
+        tbl[rev] = {false, 200, 20000, 5000, 15000};
+
+    // Net cost schedule.
+    tbl[EVMC_CONSTANTINOPLE] = {true, 200, 20000, 5000, 15000};
+    tbl[EVMC_ISTANBUL] = {true, 800, 20000, 5000, 15000};
+    tbl[EVMC_BERLIN] = {
+        true, instr::warm_storage_read_cost, 20000, 5000 - instr::cold_sload_cost, 15000};
+    tbl[EVMC_LONDON] = {
+        true, instr::warm_storage_read_cost, 20000, 5000 - instr::cold_sload_cost, 4800};
+    tbl[EVMC_PARIS] = tbl[EVMC_LONDON];
+    tbl[EVMC_SHANGHAI] = tbl[EVMC_LONDON];
+    tbl[EVMC_CANCUN] = tbl[EVMC_LONDON];
+    return tbl;
+}();
+
+
+struct StorageStoreCost
+{
+    int16_t gas_cost;
+    int16_t gas_refund;
+};
+
+// The lookup table of SSTORE costs by the storage update status.
+constexpr auto sstore_costs = []() noexcept {
+    std::array<std::array<StorageStoreCost, EVMC_STORAGE_MODIFIED_RESTORED + 1>,
+        EVMC_MAX_REVISION + 1>
+        tbl{};
+
+    for (size_t rev = EVMC_FRONTIER; rev <= EVMC_MAX_REVISION; ++rev)
+    {
+        auto& e = tbl[rev];
+        if (const auto c = storage_cost_spec[rev]; !c.net_cost)  // legacy
+        {
+            e[EVMC_STORAGE_ADDED] = {c.set, 0};
+            e[EVMC_STORAGE_DELETED] = {c.reset, c.clear};
+            e[EVMC_STORAGE_MODIFIED] = {c.reset, 0};
+            e[EVMC_STORAGE_ASSIGNED] = e[EVMC_STORAGE_MODIFIED];
+            e[EVMC_STORAGE_DELETED_ADDED] = e[EVMC_STORAGE_ADDED];
+            e[EVMC_STORAGE_MODIFIED_DELETED] = e[EVMC_STORAGE_DELETED];
+            e[EVMC_STORAGE_DELETED_RESTORED] = e[EVMC_STORAGE_ADDED];
+            e[EVMC_STORAGE_ADDED_DELETED] = e[EVMC_STORAGE_DELETED];
+            e[EVMC_STORAGE_MODIFIED_RESTORED] = e[EVMC_STORAGE_MODIFIED];
+        }
+        else  // net cost
+        {
+            e[EVMC_STORAGE_ASSIGNED] = {c.warm_access, 0};
+            e[EVMC_STORAGE_ADDED] = {c.set, 0};
+            e[EVMC_STORAGE_DELETED] = {c.reset, c.clear};
+            e[EVMC_STORAGE_MODIFIED] = {c.reset, 0};
+            e[EVMC_STORAGE_DELETED_ADDED] = {c.warm_access, static_cast<int16_t>(-c.clear)};
+            e[EVMC_STORAGE_MODIFIED_DELETED] = {c.warm_access, c.clear};
+            e[EVMC_STORAGE_DELETED_RESTORED] = {
+                c.warm_access, static_cast<int16_t>(c.reset - c.warm_access - c.clear)};
+            e[EVMC_STORAGE_ADDED_DELETED] = {
+                c.warm_access, static_cast<int16_t>(c.set - c.warm_access)};
+            e[EVMC_STORAGE_MODIFIED_RESTORED] = {
+                c.warm_access, static_cast<int16_t>(c.reset - c.warm_access)};
+        }
+    }
+
+    return tbl;
+}();
+}  // namespace
+
 evmc_status_code sload(StackTop stack, ExecutionState& state) noexcept
 {
     auto& x = stack.top();
@@ -38,63 +123,18 @@ evmc_status_code sstore(StackTop stack, ExecutionState& state) noexcept
     const auto key = intx::be::store<evmc::bytes32>(stack.pop());
     const auto value = intx::be::store<evmc::bytes32>(stack.pop());
 
-    int cost = 0;
-    if (state.rev >= EVMC_BERLIN &&
-        state.host.access_storage(state.msg->recipient, key) == EVMC_ACCESS_COLD)
-        cost = instr::cold_sload_cost;
-
+    const auto gas_cost_cold =
+        (state.rev >= EVMC_BERLIN &&
+            state.host.access_storage(state.msg->recipient, key) == EVMC_ACCESS_COLD) ?
+            instr::cold_sload_cost :
+            0;
     const auto status = state.host.set_storage(state.msg->recipient, key, value);
 
-    if (state.rev <= EVMC_BYZANTIUM || state.rev == EVMC_PETERSBURG)  // legacy
-    {
-        switch (status)
-        {
-        case EVMC_STORAGE_ASSIGNED:
-        case EVMC_STORAGE_MODIFIED_DELETED:
-        case EVMC_STORAGE_ADDED_DELETED:
-        case EVMC_STORAGE_MODIFIED_RESTORED:
-        case EVMC_STORAGE_MODIFIED:
-        case EVMC_STORAGE_DELETED:
-            cost = 5000;
-            break;
-        case EVMC_STORAGE_ADDED:
-        case EVMC_STORAGE_DELETED_ADDED:
-        case EVMC_STORAGE_DELETED_RESTORED:
-            cost = 20000;
-            break;
-        }
-    }
-    else  // net gas cost metering
-    {
-        switch (status)
-        {
-        case EVMC_STORAGE_ASSIGNED:
-        case EVMC_STORAGE_DELETED_ADDED:
-        case EVMC_STORAGE_DELETED_RESTORED:
-        case EVMC_STORAGE_MODIFIED_DELETED:
-        case EVMC_STORAGE_ADDED_DELETED:
-        case EVMC_STORAGE_MODIFIED_RESTORED:
-            if (state.rev >= EVMC_BERLIN)
-                cost += instr::warm_storage_read_cost;
-            else if (state.rev == EVMC_ISTANBUL)
-                cost = 800;
-            else
-                cost = 200;  // Constantinople
-            break;
-        case EVMC_STORAGE_MODIFIED:
-        case EVMC_STORAGE_DELETED:
-            if (state.rev >= EVMC_BERLIN)
-                cost += 5000 - instr::cold_sload_cost;
-            else
-                cost = 5000;
-            break;
-        case EVMC_STORAGE_ADDED:
-            cost += 20000;
-            break;
-        }
-    }
-    if ((state.gas_left -= cost) < 0)
+    const auto [gas_cost_warm, gas_refund] = sstore_costs[state.rev][status];
+    const auto gas_cost = gas_cost_warm + gas_cost_cold;
+    if ((state.gas_left -= gas_cost) < 0)
         return EVMC_OUT_OF_GAS;
+    state.gas_refund += gas_refund;
     return EVMC_SUCCESS;
 }
 }  // namespace evmone::instr::core

--- a/test/unittests/evm_storage_test.cpp
+++ b/test/unittests/evm_storage_test.cpp
@@ -5,6 +5,7 @@
 /// This file contains EVM unit tests that access or modify the contract storage.
 
 #include "evm_fixture.hpp"
+#include <array>
 
 using namespace evmc::literals;
 using evmone::test::evm;

--- a/test/unittests/evm_storage_test.cpp
+++ b/test/unittests/evm_storage_test.cpp
@@ -169,6 +169,120 @@ TEST_P(evm, sstore_cost)
     }
 }
 
+TEST_P(evm, sstore_cost_legacy)
+{
+    static constexpr auto O = 0x000000000000000000_bytes32;
+    static constexpr auto X = 0xfeffffffffffffffff_bytes32;
+    static constexpr auto Y = 0x011000000000000002_bytes32;
+    static constexpr auto Z = 0x800000000000000001_bytes32;
+    static constexpr auto key = 0xef_bytes32;
+
+    static constexpr int64_t b = 9;  // Cost of other instructions.
+
+    static constexpr struct
+    {
+        int64_t set = 20000;
+        int64_t reset = 5000;
+        int64_t clear = 15000;
+    } c;
+
+    const auto test = [this](const evmc::bytes32& original, const evmc::bytes32& current,
+                          const evmc::bytes32& value, int64_t expected_gas_used,
+                          int64_t expected_gas_refund) {
+        auto& storage_entry = host.accounts[msg.recipient].storage[key];
+        storage_entry = {current, original};
+        execute(sstore(key, calldataload(0)), value);
+        EXPECT_EQ(storage_entry.current, value);
+        EXPECT_GAS_USED(EVMC_SUCCESS, expected_gas_used);
+        EXPECT_EQ(result.gas_refund, expected_gas_refund);
+    };
+
+    for (const auto r : {EVMC_FRONTIER, EVMC_BYZANTIUM, EVMC_PETERSBURG})
+    {
+        rev = r;
+
+        test(O, O, O, b + c.reset, 0);  // assigned
+        test(X, O, O, b + c.reset, 0);
+        test(O, Y, Y, b + c.reset, 0);
+        test(X, Y, Y, b + c.reset, 0);
+        test(Y, Y, Y, b + c.reset, 0);
+        test(O, Y, Z, b + c.reset, 0);
+        test(X, Y, Z, b + c.reset, 0);
+
+        test(O, O, Z, b + c.set, 0);          // added
+        test(X, X, O, b + c.reset, c.clear);  // deleted
+        test(X, X, Z, b + c.reset, 0);        // modified
+        test(X, O, Z, b + c.set, 0);          // deleted added
+        test(X, Y, O, b + c.reset, c.clear);  // modified deleted
+        test(X, O, X, b + c.set, 0);          // deleted restored
+        test(O, Y, O, b + c.reset, c.clear);  // added deleted
+        test(X, Y, X, b + c.reset, 0);        // modified restored
+    }
+}
+
+TEST_P(evm, sstore_cost_net_gas_metering)
+{
+    // Follow the table on https://evmc.ethereum.org/storagestatus.html
+
+    static constexpr auto O = 0x000000000000000000_bytes32;
+    static constexpr auto X = 0x00ffffffffffffffff_bytes32;
+    static constexpr auto Y = 0x010000000000000000_bytes32;
+    static constexpr auto Z = 0x010000000000000001_bytes32;
+    static constexpr auto key = 0xde_bytes32;
+
+    static constexpr int64_t b = 6;  // Cost of other instructions.
+
+    struct CostConstants
+    {
+        int64_t warm_access = -1;
+        int64_t set = -1;
+        int64_t reset = -1;
+        int64_t clear = -1;
+    };
+
+    const auto test = [this](const evmc::bytes32& original, const evmc::bytes32& current,
+                          const evmc::bytes32& value, int64_t expected_gas_used,
+                          int64_t expected_gas_refund) {
+        auto& storage_entry = host.accounts[msg.recipient].storage[key];
+        storage_entry.original = original;
+        storage_entry.current = current;
+        storage_entry.access_status = EVMC_ACCESS_WARM;
+        execute(sstore(key, value));
+        EXPECT_EQ(storage_entry.current, value);
+        EXPECT_GAS_USED(EVMC_SUCCESS, expected_gas_used);
+        EXPECT_EQ(result.gas_refund, expected_gas_refund);
+    };
+
+    std::array<CostConstants, EVMC_MAX_REVISION + 1> cost_constants{};
+    cost_constants[EVMC_CONSTANTINOPLE] = {200, 20000, 5000, 15000};
+    cost_constants[EVMC_ISTANBUL] = {800, 20000, 5000, 15000};
+    cost_constants[EVMC_BERLIN] = {100, 20000, 2900, 15000};
+    cost_constants[EVMC_LONDON] = {100, 20000, 2900, 4800};
+
+    for (const auto r : {EVMC_CONSTANTINOPLE, EVMC_ISTANBUL, EVMC_BERLIN, EVMC_LONDON})
+    {
+        rev = r;
+        const auto& c = cost_constants.at(static_cast<size_t>(r));
+
+        test(O, O, O, b + c.warm_access, 0);  // assigned
+        test(X, O, O, b + c.warm_access, 0);
+        test(O, Y, Y, b + c.warm_access, 0);
+        test(X, Y, Y, b + c.warm_access, 0);
+        test(Y, Y, Y, b + c.warm_access, 0);
+        test(O, Y, Z, b + c.warm_access, 0);
+        test(X, Y, Z, b + c.warm_access, 0);
+
+        test(O, O, Z, b + c.set, 0);                                          // added
+        test(X, X, O, b + c.reset, c.clear);                                  // deleted
+        test(X, X, Z, b + c.reset, 0);                                        // modified
+        test(X, O, Z, b + c.warm_access, -c.clear);                           // deleted added
+        test(X, Y, O, b + c.warm_access, c.clear);                            // modified deleted
+        test(X, O, X, b + c.warm_access, c.reset - c.warm_access - c.clear);  // deleted restored
+        test(O, Y, O, b + c.warm_access, c.set - c.warm_access);              // added deleted
+        test(X, Y, X, b + c.warm_access, c.reset - c.warm_access);            // modified restored
+    }
+}
+
 TEST_P(evm, sstore_below_stipend)
 {
     const auto code = sstore(0, 0);

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -15,6 +15,7 @@ struct bytecode;
 
 inline bytecode push(uint64_t n);
 inline bytecode push(evmc::address addr);
+inline bytecode push(evmc::bytes32 bs);
 
 struct bytecode : bytes
 {
@@ -34,6 +35,8 @@ struct bytecode : bytes
     bytecode(uint64_t n) : bytes{push(n)} {}
 
     bytecode(evmc::address addr) : bytes{push(addr)} {}
+
+    bytecode(evmc::bytes32 bs) : bytes{push(bs)} {}
 
     operator bytes_view() const noexcept { return {data(), size()}; }
 };


### PR DESCRIPTION
Calculate, aggregate and report the gas refund. This requires changes to `SSTORE`, `SELFDESTRUCT` and calls (propagate gas refund).