### PR TITLE
Baseline threaded code (computed goto)

### DIFF
--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -222,9 +222,9 @@ constexpr std::array<instruction_exec_fn, 256> instruction_implementations = [](
     std::array<instruction_exec_fn, 256> table{};
 
     // Init table with wrapped generic implementations.
-#define X(OPCODE, IGNORED) table[OPCODE] = op<instr::impl<(OPCODE)>>;
-    MAP_OPCODE_TO_IDENTIFIER
-#undef X
+#define ON_OPCODE(OPCODE) table[OPCODE] = op<instr::impl<(OPCODE)>>;
+    MAP_OPCODES
+#undef ON_OPCODE
 
     // Overwrite with Advanced-specific implementations.
     table[OP_SSTORE] = op_sstore;

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -233,7 +233,7 @@ void dispatch(const CostTable& cost_table, ExecutionState& state, Tracer* tracer
         const auto op = *position.code_it;
         switch (op)
         {
-#define X(OPCODE, IGNORED)                                                               \
+#define ON_OPCODE(OPCODE)                                                                \
     case OPCODE:                                                                         \
         ASM_COMMENT(OPCODE);                                                             \
         if (const auto next = invoke<OPCODE>(cost_table, stack_bottom, position, state); \
@@ -249,8 +249,8 @@ void dispatch(const CostTable& cost_table, ExecutionState& state, Tracer* tracer
         }                                                                                \
         break;
 
-            MAP_OPCODE_TO_IDENTIFIER
-#undef X
+            MAP_OPCODES
+#undef ON_OPCODE
 
         default:
             state.status = EVMC_UNDEFINED_INSTRUCTION;

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -325,10 +325,11 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
     else
     {
 #if EVMONE_CGOTO_SUPPORTED
-        dispatch_cgoto(cost_table, state);
-#else
-        dispatch<false>(cost_table, state);
+        if (vm.cgoto)
+            dispatch_cgoto(cost_table, state);
+        else
 #endif
+            dispatch<false>(cost_table, state);
     }
 
     const auto gas_left =

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -910,10 +910,12 @@ inline StopToken selfdestruct(StackTop stack, ExecutionState& state) noexcept
 template <evmc_opcode Op>
 inline constexpr auto impl = nullptr;
 
-#define X(OPCODE, IDENTIFIER) \
-    template <>               \
+#undef ON_OPCODE_IDENTIFIER
+#define ON_OPCODE_IDENTIFIER(OPCODE, IDENTIFIER) \
+    template <>                                  \
     inline constexpr auto impl<OPCODE> = IDENTIFIER;  // opcode -> implementation
-MAP_OPCODE_TO_IDENTIFIER
-#undef X
+MAP_OPCODES
+#undef ON_OPCODE_IDENTIFIER
+#define ON_OPCODE_IDENTIFIER ON_OPCODE_IDENTIFIER_DEFAULT
 }  // namespace instr::core
 }  // namespace evmone

--- a/lib/evmone/instructions_xmacro.hpp
+++ b/lib/evmone/instructions_xmacro.hpp
@@ -3,148 +3,303 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#define MAP_OPCODE_TO_IDENTIFIER         \
-    X(OP_STOP, stop)                     \
-    X(OP_ADD, add)                       \
-    X(OP_MUL, mul)                       \
-    X(OP_SUB, sub)                       \
-    X(OP_DIV, div)                       \
-    X(OP_SDIV, sdiv)                     \
-    X(OP_MOD, mod)                       \
-    X(OP_SMOD, smod)                     \
-    X(OP_ADDMOD, addmod)                 \
-    X(OP_MULMOD, mulmod)                 \
-    X(OP_EXP, exp)                       \
-    X(OP_SIGNEXTEND, signextend)         \
-    X(OP_LT, lt)                         \
-    X(OP_GT, gt)                         \
-    X(OP_SLT, slt)                       \
-    X(OP_SGT, sgt)                       \
-    X(OP_EQ, eq)                         \
-    X(OP_ISZERO, iszero)                 \
-    X(OP_AND, and_)                      \
-    X(OP_OR, or_)                        \
-    X(OP_XOR, xor_)                      \
-    X(OP_NOT, not_)                      \
-    X(OP_BYTE, byte)                     \
-    X(OP_SHL, shl)                       \
-    X(OP_SHR, shr)                       \
-    X(OP_SAR, sar)                       \
-    X(OP_KECCAK256, keccak256)           \
-    X(OP_ADDRESS, address)               \
-    X(OP_BALANCE, balance)               \
-    X(OP_ORIGIN, origin)                 \
-    X(OP_CALLER, caller)                 \
-    X(OP_CALLVALUE, callvalue)           \
-    X(OP_CALLDATALOAD, calldataload)     \
-    X(OP_CALLDATASIZE, calldatasize)     \
-    X(OP_CALLDATACOPY, calldatacopy)     \
-    X(OP_CODESIZE, codesize)             \
-    X(OP_CODECOPY, codecopy)             \
-    X(OP_GASPRICE, gasprice)             \
-    X(OP_EXTCODESIZE, extcodesize)       \
-    X(OP_EXTCODECOPY, extcodecopy)       \
-    X(OP_RETURNDATASIZE, returndatasize) \
-    X(OP_RETURNDATACOPY, returndatacopy) \
-    X(OP_EXTCODEHASH, extcodehash)       \
-    X(OP_BLOCKHASH, blockhash)           \
-    X(OP_COINBASE, coinbase)             \
-    X(OP_TIMESTAMP, timestamp)           \
-    X(OP_NUMBER, number)                 \
-    X(OP_PREVRANDAO, prevrandao)         \
-    X(OP_GASLIMIT, gaslimit)             \
-    X(OP_CHAINID, chainid)               \
-    X(OP_SELFBALANCE, selfbalance)       \
-    X(OP_BASEFEE, basefee)               \
-    X(OP_POP, pop)                       \
-    X(OP_MLOAD, mload)                   \
-    X(OP_MSTORE, mstore)                 \
-    X(OP_MSTORE8, mstore8)               \
-    X(OP_SLOAD, sload)                   \
-    X(OP_SSTORE, sstore)                 \
-    X(OP_JUMP, jump)                     \
-    X(OP_JUMPI, jumpi)                   \
-    X(OP_PC, pc)                         \
-    X(OP_MSIZE, msize)                   \
-    X(OP_GAS, gas)                       \
-    X(OP_JUMPDEST, jumpdest)             \
-    X(OP_PUSH0, push0)                   \
-    X(OP_PUSH1, push<1>)                 \
-    X(OP_PUSH2, push<2>)                 \
-    X(OP_PUSH3, push<3>)                 \
-    X(OP_PUSH4, push<4>)                 \
-    X(OP_PUSH5, push<5>)                 \
-    X(OP_PUSH6, push<6>)                 \
-    X(OP_PUSH7, push<7>)                 \
-    X(OP_PUSH8, push<8>)                 \
-    X(OP_PUSH9, push<9>)                 \
-    X(OP_PUSH10, push<10>)               \
-    X(OP_PUSH11, push<11>)               \
-    X(OP_PUSH12, push<12>)               \
-    X(OP_PUSH13, push<13>)               \
-    X(OP_PUSH14, push<14>)               \
-    X(OP_PUSH15, push<15>)               \
-    X(OP_PUSH16, push<16>)               \
-    X(OP_PUSH17, push<17>)               \
-    X(OP_PUSH18, push<18>)               \
-    X(OP_PUSH19, push<19>)               \
-    X(OP_PUSH20, push<20>)               \
-    X(OP_PUSH21, push<21>)               \
-    X(OP_PUSH22, push<22>)               \
-    X(OP_PUSH23, push<23>)               \
-    X(OP_PUSH24, push<24>)               \
-    X(OP_PUSH25, push<25>)               \
-    X(OP_PUSH26, push<26>)               \
-    X(OP_PUSH27, push<27>)               \
-    X(OP_PUSH28, push<28>)               \
-    X(OP_PUSH29, push<29>)               \
-    X(OP_PUSH30, push<30>)               \
-    X(OP_PUSH31, push<31>)               \
-    X(OP_PUSH32, push<32>)               \
-    X(OP_DUP1, dup<1>)                   \
-    X(OP_DUP2, dup<2>)                   \
-    X(OP_DUP3, dup<3>)                   \
-    X(OP_DUP4, dup<4>)                   \
-    X(OP_DUP5, dup<5>)                   \
-    X(OP_DUP6, dup<6>)                   \
-    X(OP_DUP7, dup<7>)                   \
-    X(OP_DUP8, dup<8>)                   \
-    X(OP_DUP9, dup<9>)                   \
-    X(OP_DUP10, dup<10>)                 \
-    X(OP_DUP11, dup<11>)                 \
-    X(OP_DUP12, dup<12>)                 \
-    X(OP_DUP13, dup<13>)                 \
-    X(OP_DUP14, dup<14>)                 \
-    X(OP_DUP15, dup<15>)                 \
-    X(OP_DUP16, dup<16>)                 \
-    X(OP_SWAP1, swap<1>)                 \
-    X(OP_SWAP2, swap<2>)                 \
-    X(OP_SWAP3, swap<3>)                 \
-    X(OP_SWAP4, swap<4>)                 \
-    X(OP_SWAP5, swap<5>)                 \
-    X(OP_SWAP6, swap<6>)                 \
-    X(OP_SWAP7, swap<7>)                 \
-    X(OP_SWAP8, swap<8>)                 \
-    X(OP_SWAP9, swap<9>)                 \
-    X(OP_SWAP10, swap<10>)               \
-    X(OP_SWAP11, swap<11>)               \
-    X(OP_SWAP12, swap<12>)               \
-    X(OP_SWAP13, swap<13>)               \
-    X(OP_SWAP14, swap<14>)               \
-    X(OP_SWAP15, swap<15>)               \
-    X(OP_SWAP16, swap<16>)               \
-    X(OP_LOG0, log<0>)                   \
-    X(OP_LOG1, log<1>)                   \
-    X(OP_LOG2, log<2>)                   \
-    X(OP_LOG3, log<3>)                   \
-    X(OP_LOG4, log<4>)                   \
-    X(OP_CREATE, create)                 \
-    X(OP_CALL, call)                     \
-    X(OP_CALLCODE, callcode)             \
-    X(OP_RETURN, return_)                \
-    X(OP_DELEGATECALL, delegatecall)     \
-    X(OP_CREATE2, create2)               \
-    X(OP_STATICCALL, staticcall)         \
-    X(OP_INVALID, invalid)               \
-    X(OP_REVERT, revert)                 \
-    X(OP_SELFDESTRUCT, selfdestruct)
+/// The default macro for ON_OPCODE_IDENTIFIER. It redirects to ON_OPCODE.
+#define ON_OPCODE_IDENTIFIER_DEFAULT(OPCODE, NAME) ON_OPCODE(OPCODE)
+
+/// The default macro for ON_OPCODE_UNDEFINED. Empty implementation to ignore undefined opcodes.
+#define ON_OPCODE_UNDEFINED_DEFAULT(OPCODE)
+
+
+#define ON_OPCODE_IDENTIFIER ON_OPCODE_IDENTIFIER_DEFAULT
+#define ON_OPCODE_UNDEFINED ON_OPCODE_UNDEFINED_DEFAULT
+
+
+/// The "X Macro" for opcodes and their matching identifiers.
+///
+/// The MAP_OPCODES is an extended variant of X Macro idiom.
+/// It has 3 knobs for users.
+///
+/// 1. The ON_OPCODE(OPCODE) macro must be defined. It will receive all defined opcodes from
+///    the evmc_opcode enum.
+/// 2. The ON_OPCODE_UNDEFINED(OPCODE) macro may be defined to receive
+///    the values of all undefined opcodes.
+///    This macro is by default alias to ON_OPCODE_UNDEFINED_DEFAULT therefore users must first
+///    undef it and restore the alias after usage.
+/// 3. The ON_OPCODE_IDENTIFIER(OPCODE, IDENTIFIER) macro may be defined to receive
+///    the pairs of all defined opcodes and their matching identifiers.
+///    This macro is by default alias to ON_OPCODE_IDENTIFIER_DEFAULT therefore users must first
+///    undef it and restore the alias after usage.
+///
+/// See for more about X Macros: https://en.wikipedia.org/wiki/X_Macro.
+#define MAP_OPCODES                                         \
+    ON_OPCODE_IDENTIFIER(OP_STOP, stop)                     \
+    ON_OPCODE_IDENTIFIER(OP_ADD, add)                       \
+    ON_OPCODE_IDENTIFIER(OP_MUL, mul)                       \
+    ON_OPCODE_IDENTIFIER(OP_SUB, sub)                       \
+    ON_OPCODE_IDENTIFIER(OP_DIV, div)                       \
+    ON_OPCODE_IDENTIFIER(OP_SDIV, sdiv)                     \
+    ON_OPCODE_IDENTIFIER(OP_MOD, mod)                       \
+    ON_OPCODE_IDENTIFIER(OP_SMOD, smod)                     \
+    ON_OPCODE_IDENTIFIER(OP_ADDMOD, addmod)                 \
+    ON_OPCODE_IDENTIFIER(OP_MULMOD, mulmod)                 \
+    ON_OPCODE_IDENTIFIER(OP_EXP, exp)                       \
+    ON_OPCODE_IDENTIFIER(OP_SIGNEXTEND, signextend)         \
+    ON_OPCODE_UNDEFINED(0x0c)                               \
+    ON_OPCODE_UNDEFINED(0x0d)                               \
+    ON_OPCODE_UNDEFINED(0x0e)                               \
+    ON_OPCODE_UNDEFINED(0x0f)                               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_LT, lt)                         \
+    ON_OPCODE_IDENTIFIER(OP_GT, gt)                         \
+    ON_OPCODE_IDENTIFIER(OP_SLT, slt)                       \
+    ON_OPCODE_IDENTIFIER(OP_SGT, sgt)                       \
+    ON_OPCODE_IDENTIFIER(OP_EQ, eq)                         \
+    ON_OPCODE_IDENTIFIER(OP_ISZERO, iszero)                 \
+    ON_OPCODE_IDENTIFIER(OP_AND, and_)                      \
+    ON_OPCODE_IDENTIFIER(OP_OR, or_)                        \
+    ON_OPCODE_IDENTIFIER(OP_XOR, xor_)                      \
+    ON_OPCODE_IDENTIFIER(OP_NOT, not_)                      \
+    ON_OPCODE_IDENTIFIER(OP_BYTE, byte)                     \
+    ON_OPCODE_IDENTIFIER(OP_SHL, shl)                       \
+    ON_OPCODE_IDENTIFIER(OP_SHR, shr)                       \
+    ON_OPCODE_IDENTIFIER(OP_SAR, sar)                       \
+    ON_OPCODE_UNDEFINED(0x1e)                               \
+    ON_OPCODE_UNDEFINED(0x1f)                               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_KECCAK256, keccak256)           \
+    ON_OPCODE_UNDEFINED(0x21)                               \
+    ON_OPCODE_UNDEFINED(0x22)                               \
+    ON_OPCODE_UNDEFINED(0x23)                               \
+    ON_OPCODE_UNDEFINED(0x24)                               \
+    ON_OPCODE_UNDEFINED(0x25)                               \
+    ON_OPCODE_UNDEFINED(0x26)                               \
+    ON_OPCODE_UNDEFINED(0x27)                               \
+    ON_OPCODE_UNDEFINED(0x28)                               \
+    ON_OPCODE_UNDEFINED(0x29)                               \
+    ON_OPCODE_UNDEFINED(0x2a)                               \
+    ON_OPCODE_UNDEFINED(0x2b)                               \
+    ON_OPCODE_UNDEFINED(0x2c)                               \
+    ON_OPCODE_UNDEFINED(0x2d)                               \
+    ON_OPCODE_UNDEFINED(0x2e)                               \
+    ON_OPCODE_UNDEFINED(0x2f)                               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_ADDRESS, address)               \
+    ON_OPCODE_IDENTIFIER(OP_BALANCE, balance)               \
+    ON_OPCODE_IDENTIFIER(OP_ORIGIN, origin)                 \
+    ON_OPCODE_IDENTIFIER(OP_CALLER, caller)                 \
+    ON_OPCODE_IDENTIFIER(OP_CALLVALUE, callvalue)           \
+    ON_OPCODE_IDENTIFIER(OP_CALLDATALOAD, calldataload)     \
+    ON_OPCODE_IDENTIFIER(OP_CALLDATASIZE, calldatasize)     \
+    ON_OPCODE_IDENTIFIER(OP_CALLDATACOPY, calldatacopy)     \
+    ON_OPCODE_IDENTIFIER(OP_CODESIZE, codesize)             \
+    ON_OPCODE_IDENTIFIER(OP_CODECOPY, codecopy)             \
+    ON_OPCODE_IDENTIFIER(OP_GASPRICE, gasprice)             \
+    ON_OPCODE_IDENTIFIER(OP_EXTCODESIZE, extcodesize)       \
+    ON_OPCODE_IDENTIFIER(OP_EXTCODECOPY, extcodecopy)       \
+    ON_OPCODE_IDENTIFIER(OP_RETURNDATASIZE, returndatasize) \
+    ON_OPCODE_IDENTIFIER(OP_RETURNDATACOPY, returndatacopy) \
+    ON_OPCODE_IDENTIFIER(OP_EXTCODEHASH, extcodehash)       \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_BLOCKHASH, blockhash)           \
+    ON_OPCODE_IDENTIFIER(OP_COINBASE, coinbase)             \
+    ON_OPCODE_IDENTIFIER(OP_TIMESTAMP, timestamp)           \
+    ON_OPCODE_IDENTIFIER(OP_NUMBER, number)                 \
+    ON_OPCODE_IDENTIFIER(OP_PREVRANDAO, prevrandao)         \
+    ON_OPCODE_IDENTIFIER(OP_GASLIMIT, gaslimit)             \
+    ON_OPCODE_IDENTIFIER(OP_CHAINID, chainid)               \
+    ON_OPCODE_IDENTIFIER(OP_SELFBALANCE, selfbalance)       \
+    ON_OPCODE_IDENTIFIER(OP_BASEFEE, basefee)               \
+    ON_OPCODE_UNDEFINED(0x49)                               \
+    ON_OPCODE_UNDEFINED(0x4a)                               \
+    ON_OPCODE_UNDEFINED(0x4b)                               \
+    ON_OPCODE_UNDEFINED(0x4c)                               \
+    ON_OPCODE_UNDEFINED(0x4d)                               \
+    ON_OPCODE_UNDEFINED(0x4e)                               \
+    ON_OPCODE_UNDEFINED(0x4f)                               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_POP, pop)                       \
+    ON_OPCODE_IDENTIFIER(OP_MLOAD, mload)                   \
+    ON_OPCODE_IDENTIFIER(OP_MSTORE, mstore)                 \
+    ON_OPCODE_IDENTIFIER(OP_MSTORE8, mstore8)               \
+    ON_OPCODE_IDENTIFIER(OP_SLOAD, sload)                   \
+    ON_OPCODE_IDENTIFIER(OP_SSTORE, sstore)                 \
+    ON_OPCODE_IDENTIFIER(OP_JUMP, jump)                     \
+    ON_OPCODE_IDENTIFIER(OP_JUMPI, jumpi)                   \
+    ON_OPCODE_IDENTIFIER(OP_PC, pc)                         \
+    ON_OPCODE_IDENTIFIER(OP_MSIZE, msize)                   \
+    ON_OPCODE_IDENTIFIER(OP_GAS, gas)                       \
+    ON_OPCODE_IDENTIFIER(OP_JUMPDEST, jumpdest)             \
+    ON_OPCODE_UNDEFINED(0x5c)                               \
+    ON_OPCODE_UNDEFINED(0x5d)                               \
+    ON_OPCODE_UNDEFINED(0x5e)                               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH0, push0)                   \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_PUSH1, push<1>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH2, push<2>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH3, push<3>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH4, push<4>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH5, push<5>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH6, push<6>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH7, push<7>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH8, push<8>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH9, push<9>)                 \
+    ON_OPCODE_IDENTIFIER(OP_PUSH10, push<10>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH11, push<11>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH12, push<12>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH13, push<13>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH14, push<14>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH15, push<15>)               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_PUSH16, push<16>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH17, push<17>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH18, push<18>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH19, push<19>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH20, push<20>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH21, push<21>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH22, push<22>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH23, push<23>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH24, push<24>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH25, push<25>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH26, push<26>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH27, push<27>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH28, push<28>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH29, push<29>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH30, push<30>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH31, push<31>)               \
+    ON_OPCODE_IDENTIFIER(OP_PUSH32, push<32>)               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_DUP1, dup<1>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP2, dup<2>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP3, dup<3>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP4, dup<4>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP5, dup<5>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP6, dup<6>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP7, dup<7>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP8, dup<8>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP9, dup<9>)                   \
+    ON_OPCODE_IDENTIFIER(OP_DUP10, dup<10>)                 \
+    ON_OPCODE_IDENTIFIER(OP_DUP11, dup<11>)                 \
+    ON_OPCODE_IDENTIFIER(OP_DUP12, dup<12>)                 \
+    ON_OPCODE_IDENTIFIER(OP_DUP13, dup<13>)                 \
+    ON_OPCODE_IDENTIFIER(OP_DUP14, dup<14>)                 \
+    ON_OPCODE_IDENTIFIER(OP_DUP15, dup<15>)                 \
+    ON_OPCODE_IDENTIFIER(OP_DUP16, dup<16>)                 \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_SWAP1, swap<1>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP2, swap<2>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP3, swap<3>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP4, swap<4>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP5, swap<5>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP6, swap<6>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP7, swap<7>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP8, swap<8>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP9, swap<9>)                 \
+    ON_OPCODE_IDENTIFIER(OP_SWAP10, swap<10>)               \
+    ON_OPCODE_IDENTIFIER(OP_SWAP11, swap<11>)               \
+    ON_OPCODE_IDENTIFIER(OP_SWAP12, swap<12>)               \
+    ON_OPCODE_IDENTIFIER(OP_SWAP13, swap<13>)               \
+    ON_OPCODE_IDENTIFIER(OP_SWAP14, swap<14>)               \
+    ON_OPCODE_IDENTIFIER(OP_SWAP15, swap<15>)               \
+    ON_OPCODE_IDENTIFIER(OP_SWAP16, swap<16>)               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_LOG0, log<0>)                   \
+    ON_OPCODE_IDENTIFIER(OP_LOG1, log<1>)                   \
+    ON_OPCODE_IDENTIFIER(OP_LOG2, log<2>)                   \
+    ON_OPCODE_IDENTIFIER(OP_LOG3, log<3>)                   \
+    ON_OPCODE_IDENTIFIER(OP_LOG4, log<4>)                   \
+    ON_OPCODE_UNDEFINED(0xa5)                               \
+    ON_OPCODE_UNDEFINED(0xa6)                               \
+    ON_OPCODE_UNDEFINED(0xa7)                               \
+    ON_OPCODE_UNDEFINED(0xa8)                               \
+    ON_OPCODE_UNDEFINED(0xa9)                               \
+    ON_OPCODE_UNDEFINED(0xaa)                               \
+    ON_OPCODE_UNDEFINED(0xab)                               \
+    ON_OPCODE_UNDEFINED(0xac)                               \
+    ON_OPCODE_UNDEFINED(0xad)                               \
+    ON_OPCODE_UNDEFINED(0xae)                               \
+    ON_OPCODE_UNDEFINED(0xaf)                               \
+                                                            \
+    ON_OPCODE_UNDEFINED(0xb0)                               \
+    ON_OPCODE_UNDEFINED(0xb1)                               \
+    ON_OPCODE_UNDEFINED(0xb2)                               \
+    ON_OPCODE_UNDEFINED(0xb3)                               \
+    ON_OPCODE_UNDEFINED(0xb4)                               \
+    ON_OPCODE_UNDEFINED(0xb5)                               \
+    ON_OPCODE_UNDEFINED(0xb6)                               \
+    ON_OPCODE_UNDEFINED(0xb7)                               \
+    ON_OPCODE_UNDEFINED(0xb8)                               \
+    ON_OPCODE_UNDEFINED(0xb9)                               \
+    ON_OPCODE_UNDEFINED(0xba)                               \
+    ON_OPCODE_UNDEFINED(0xbb)                               \
+    ON_OPCODE_UNDEFINED(0xbc)                               \
+    ON_OPCODE_UNDEFINED(0xbd)                               \
+    ON_OPCODE_UNDEFINED(0xbe)                               \
+    ON_OPCODE_UNDEFINED(0xbf)                               \
+                                                            \
+    ON_OPCODE_UNDEFINED(0xc0)                               \
+    ON_OPCODE_UNDEFINED(0xc1)                               \
+    ON_OPCODE_UNDEFINED(0xc2)                               \
+    ON_OPCODE_UNDEFINED(0xc3)                               \
+    ON_OPCODE_UNDEFINED(0xc4)                               \
+    ON_OPCODE_UNDEFINED(0xc5)                               \
+    ON_OPCODE_UNDEFINED(0xc6)                               \
+    ON_OPCODE_UNDEFINED(0xc7)                               \
+    ON_OPCODE_UNDEFINED(0xc8)                               \
+    ON_OPCODE_UNDEFINED(0xc9)                               \
+    ON_OPCODE_UNDEFINED(0xca)                               \
+    ON_OPCODE_UNDEFINED(0xcb)                               \
+    ON_OPCODE_UNDEFINED(0xcc)                               \
+    ON_OPCODE_UNDEFINED(0xcd)                               \
+    ON_OPCODE_UNDEFINED(0xce)                               \
+    ON_OPCODE_UNDEFINED(0xcf)                               \
+                                                            \
+    ON_OPCODE_UNDEFINED(0xd0)                               \
+    ON_OPCODE_UNDEFINED(0xd1)                               \
+    ON_OPCODE_UNDEFINED(0xd2)                               \
+    ON_OPCODE_UNDEFINED(0xd3)                               \
+    ON_OPCODE_UNDEFINED(0xd4)                               \
+    ON_OPCODE_UNDEFINED(0xd5)                               \
+    ON_OPCODE_UNDEFINED(0xd6)                               \
+    ON_OPCODE_UNDEFINED(0xd7)                               \
+    ON_OPCODE_UNDEFINED(0xd8)                               \
+    ON_OPCODE_UNDEFINED(0xd9)                               \
+    ON_OPCODE_UNDEFINED(0xda)                               \
+    ON_OPCODE_UNDEFINED(0xdb)                               \
+    ON_OPCODE_UNDEFINED(0xdc)                               \
+    ON_OPCODE_UNDEFINED(0xdd)                               \
+    ON_OPCODE_UNDEFINED(0xde)                               \
+    ON_OPCODE_UNDEFINED(0xdf)                               \
+                                                            \
+    ON_OPCODE_UNDEFINED(0xe0)                               \
+    ON_OPCODE_UNDEFINED(0xe1)                               \
+    ON_OPCODE_UNDEFINED(0xe2)                               \
+    ON_OPCODE_UNDEFINED(0xe3)                               \
+    ON_OPCODE_UNDEFINED(0xe4)                               \
+    ON_OPCODE_UNDEFINED(0xe5)                               \
+    ON_OPCODE_UNDEFINED(0xe6)                               \
+    ON_OPCODE_UNDEFINED(0xe7)                               \
+    ON_OPCODE_UNDEFINED(0xe8)                               \
+    ON_OPCODE_UNDEFINED(0xe9)                               \
+    ON_OPCODE_UNDEFINED(0xea)                               \
+    ON_OPCODE_UNDEFINED(0xeb)                               \
+    ON_OPCODE_UNDEFINED(0xec)                               \
+    ON_OPCODE_UNDEFINED(0xed)                               \
+    ON_OPCODE_UNDEFINED(0xee)                               \
+    ON_OPCODE_UNDEFINED(0xef)                               \
+                                                            \
+    ON_OPCODE_IDENTIFIER(OP_CREATE, create)                 \
+    ON_OPCODE_IDENTIFIER(OP_CALL, call)                     \
+    ON_OPCODE_IDENTIFIER(OP_CALLCODE, callcode)             \
+    ON_OPCODE_IDENTIFIER(OP_RETURN, return_)                \
+    ON_OPCODE_IDENTIFIER(OP_DELEGATECALL, delegatecall)     \
+    ON_OPCODE_IDENTIFIER(OP_CREATE2, create2)               \
+    ON_OPCODE_UNDEFINED(0xf6)                               \
+    ON_OPCODE_UNDEFINED(0xf7)                               \
+    ON_OPCODE_UNDEFINED(0xf8)                               \
+    ON_OPCODE_UNDEFINED(0xf9)                               \
+    ON_OPCODE_IDENTIFIER(OP_STATICCALL, staticcall)         \
+    ON_OPCODE_UNDEFINED(0xfb)                               \
+    ON_OPCODE_UNDEFINED(0xfc)                               \
+    ON_OPCODE_IDENTIFIER(OP_REVERT, revert)                 \
+    ON_OPCODE_IDENTIFIER(OP_INVALID, invalid)               \
+    ON_OPCODE_IDENTIFIER(OP_SELFDESTRUCT, selfdestruct)

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -47,6 +47,19 @@ evmc_set_option_result set_option(evmc_vm* c_vm, char const* c_name, char const*
         }
         return EVMC_SET_OPTION_INVALID_VALUE;
     }
+    else if (name == "cgoto")
+    {
+#if EVMONE_CGOTO_SUPPORTED
+        if (value == "no")
+        {
+            vm.cgoto = false;
+            return EVMC_SET_OPTION_SUCCESS;
+        }
+        return EVMC_SET_OPTION_INVALID_VALUE;
+#else
+        return EVMC_SET_OPTION_INVALID_NAME;
+#endif
+    }
     else if (name == "trace")
     {
         vm.add_tracer(create_instruction_tracer(std::cerr));

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -6,6 +6,12 @@
 #include "tracing.hpp"
 #include <evmc/evmc.h>
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#define EVMONE_CGOTO_SUPPORTED 0
+#else
+#define EVMONE_CGOTO_SUPPORTED 1
+#endif
+
 namespace evmone
 {
 /// The evmone EVMC instance.

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -17,6 +17,10 @@ namespace evmone
 /// The evmone EVMC instance.
 class VM : public evmc_vm
 {
+public:
+    bool cgoto = EVMONE_CGOTO_SUPPORTED;
+
+private:
     std::unique_ptr<Tracer> m_first_tracer;
 
 public:

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -150,10 +150,13 @@ void register_benchmarks(const std::vector<BenchmarkCase>& benchmark_cases)
 {
     evmc::VM* advanced_vm = nullptr;
     evmc::VM* baseline_vm = nullptr;
+    evmc::VM* basel_cg_vm = nullptr;
     if (const auto it = registered_vms.find("advanced"); it != registered_vms.end())
         advanced_vm = &it->second;
     if (const auto it = registered_vms.find("baseline"); it != registered_vms.end())
         baseline_vm = &it->second;
+    if (const auto it = registered_vms.find("bnocgoto"); it != registered_vms.end())
+        basel_cg_vm = &it->second;
 
     for (const auto& b : benchmark_cases)
     {
@@ -189,6 +192,14 @@ void register_benchmarks(const std::vector<BenchmarkCase>& benchmark_cases)
             {
                 const auto name = "baseline/execute/" + case_name;
                 RegisterBenchmark(name.c_str(), [&vm = *baseline_vm, &b, &input](State& state) {
+                    bench_baseline_execute(state, vm, b.code, input.input, input.expected_output);
+                })->Unit(kMicrosecond);
+            }
+
+            if (basel_cg_vm != nullptr)
+            {
+                const auto name = "bnocgoto/execute/" + case_name;
+                RegisterBenchmark(name.c_str(), [&vm = *basel_cg_vm, &b, &input](State& state) {
                     bench_baseline_execute(state, vm, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }
@@ -308,6 +319,7 @@ int main(int argc, char** argv)
 
         registered_vms["advanced"] = evmc::VM{evmc_create_evmone(), {{"O", "2"}}};
         registered_vms["baseline"] = evmc::VM{evmc_create_evmone(), {{"O", "0"}}};
+        registered_vms["bnocgoto"] = evmc::VM{evmc_create_evmone(), {{"O", "0"}, {"cgoto", "no"}}};
         register_benchmarks(benchmark_cases);
         register_synthetic_benchmarks();
         RunSpecifiedBenchmarks();

--- a/test/unittests/evm_fixture.cpp
+++ b/test/unittests/evm_fixture.cpp
@@ -11,6 +11,7 @@ namespace
 {
 evmc::VM advanced_vm{evmc_create_evmone(), {{"O", "2"}}};
 evmc::VM baseline_vm{evmc_create_evmone(), {{"O", "0"}}};
+evmc::VM bnocgoto_vm{evmc_create_evmone(), {{"O", "0"}, {"cgoto", "no"}}};
 
 const char* print_vm_name(const testing::TestParamInfo<evmc::VM*>& info) noexcept
 {
@@ -18,9 +19,12 @@ const char* print_vm_name(const testing::TestParamInfo<evmc::VM*>& info) noexcep
         return "advanced";
     if (info.param == &baseline_vm)
         return "baseline";
+    if (info.param == &bnocgoto_vm)
+        return "bnocgoto";
     return "unknown";
 }
 }  // namespace
 
-INSTANTIATE_TEST_SUITE_P(evmone, evm, testing::Values(&advanced_vm, &baseline_vm), print_vm_name);
+INSTANTIATE_TEST_SUITE_P(
+    evmone, evm, testing::Values(&advanced_vm, &baseline_vm, &bnocgoto_vm), print_vm_name);
 }  // namespace evmone::test

--- a/test/unittests/evmone_test.cpp
+++ b/test/unittests/evmone_test.cpp
@@ -4,6 +4,7 @@
 
 #include <evmc/evmc.hpp>
 #include <evmone/evmone.h>
+#include <evmone/vm.hpp>
 #include <gtest/gtest.h>
 
 TEST(evmone, info)
@@ -43,4 +44,17 @@ TEST(evmone, set_option_optimization_level)
     EXPECT_EQ(vm.set_option("O", "20"), EVMC_SET_OPTION_INVALID_VALUE);
     EXPECT_EQ(vm.set_option("O", "21"), EVMC_SET_OPTION_INVALID_VALUE);
     EXPECT_EQ(vm.set_option("O", "22"), EVMC_SET_OPTION_INVALID_VALUE);
+}
+
+TEST(evmone, set_option_cgoto)
+{
+    evmc::VM vm{evmc_create_evmone()};
+
+#if EVMONE_CGOTO_SUPPORTED
+    EXPECT_EQ(vm.set_option("cgoto", ""), EVMC_SET_OPTION_INVALID_VALUE);
+    EXPECT_EQ(vm.set_option("cgoto", "yes"), EVMC_SET_OPTION_INVALID_VALUE);
+    EXPECT_EQ(vm.set_option("cgoto", "no"), EVMC_SET_OPTION_SUCCESS);
+#else
+    EXPECT_EQ(vm.set_option("cgoto", "no"), EVMC_SET_OPTION_INVALID_NAME);
+#endif
 }


### PR DESCRIPTION
This finally adds "computed goto" dispatch loop implementation. This is enabled by default for Baseline if a compiler supports the [Labels as Values](https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html) extension.