### PR TITLE
cmake: Require C++20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Documentation of all notable changes to the **evmone** project.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [0.10.0] — unreleased
+
+### Changed
+
+- C++20 is now required to build evmone.
+  [#502](https://github.com/ethereum/evmone/pull/502)
+
 ## [0.9.1] — 2022-09-07
 
 ### Fixed
@@ -354,6 +361,7 @@ It delivers fully-compatible and high-speed EVM implementation.
 - The [intx 0.2.0](https://github.com/chfast/intx/releases/tag/v0.2.0) library is used for 256-bit precision arithmetic. 
 
 
+[0.10.0]: https://github.com/ethereum/evmone/compare/v0.9.1..master
 [0.9.1]: https://github.com/ethereum/evmone/releases/tag/v0.9.1
 [0.9.0]: https://github.com/ethereum/evmone/releases/tag/v0.9.0
 [0.8.2]: https://github.com/ethereum/evmone/releases/tag/v0.8.2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The codebase of _evmone_ is optimized to provide fast and efficient execution of
 ### Characteristic of evmone
 
 1. Exposes the [EVMC] API.
-2. Requires C++17 standard.
+2. Requires C++20 standard.
 3. The [intx] library is used to provide 256-bit integer precision.
 4. The [ethash] library is used to provide Keccak hash function implementation
    needed for the special `KECCAK256` instruction.
@@ -73,7 +73,6 @@ To build the evmone EVMC module (shared library), test, and benchmark:
    ```
 
    ##### Windows
-   *Note: >= Visual Studio 2019 is required since evmone makes heavy use of C++17*
    ```
    cmake -S . -B build -DEVMONE_TESTING=ON -G "Visual Studio 16 2019" -A x64
    ```

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
   linux-gcc-min:
     docker:
-      - image: ethereum/cpp-build-env:15-gcc-8
+      - image: ethereum/cpp-build-env:15-gcc-10
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/circle.yml
+++ b/circle.yml
@@ -43,7 +43,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
   linux-clang-min:
     docker:
-      - image: ethereum/cpp-build-env:15-clang-9
+      - image: ethereum/cpp-build-env:16-clang-11
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(evmone
     vm.cpp
     vm.hpp
 )
+target_compile_features(evmone PUBLIC cxx_std_20)
 target_link_libraries(evmone PUBLIC evmc::evmc intx::intx PRIVATE evmc::instructions ethash::keccak)
 target_include_directories(evmone PUBLIC
     $<BUILD_INTERFACE:${include_dir}>$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -12,8 +12,7 @@
 #include <memory>
 
 #ifdef NDEBUG
-// TODO: msvc::forceinline can be used in C++20.
-#define release_inline gnu::always_inline
+#define release_inline gnu::always_inline, msvc::forceinline
 #else
 #define release_inline
 #endif

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -2,11 +2,9 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-include(CheckIncludeFileCXX)
-
 add_executable(evmone-bench)
 target_include_directories(evmone-bench PRIVATE ${evmone_private_include_dir})
-target_link_libraries(evmone-bench PRIVATE evmone testutils evmc::loader benchmark::benchmark $<$<CXX_COMPILER_ID:GNU>:stdc++fs>)
+target_link_libraries(evmone-bench PRIVATE evmone testutils evmc::loader benchmark::benchmark)
 target_sources(
     evmone-bench PRIVATE
     bench.cpp

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -11,6 +11,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <span>
 
 namespace fs = std::filesystem;
 
@@ -146,7 +147,7 @@ std::vector<BenchmarkCase> load_benchmarks_from_dir(  // NOLINT(misc-no-recursio
     return benchmark_cases;
 }
 
-void register_benchmarks(const std::vector<BenchmarkCase>& benchmark_cases)
+void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
 {
     evmc::VM* advanced_vm = nullptr;
     evmc::VM* baseline_vm = nullptr;

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -50,8 +50,7 @@ template <>
 intx::uint256 from_json<intx::uint256>(const json::json& j)
 {
     const auto s = j.get<std::string>();
-    static constexpr std::string_view bigint_marker{"0x:bigint "};
-    if (std::string_view{s}.substr(0, bigint_marker.size()) == bigint_marker)
+    if (s.starts_with("0x:bigint "))
         return std::numeric_limits<intx::uint256>::max();  // Fake it
     return intx::from_string<intx::uint256>(s);
 }


### PR DESCRIPTION
Bump the required C++ standard from C++17 to C++20. Use some example C++20 features to adjust the minimal supported compiler versions.