### PR TITLE
Do not pad code for EOF

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -71,9 +71,8 @@ CodeAnalysis analyze_legacy(bytes_view code)
 
 CodeAnalysis analyze_eof1(bytes_view eof_container, const EOF1Header& header)
 {
-    // TODO: Padding code for EOF is not needed.
-    const auto code = eof_container.substr(header.code_begin(), header.code_size);
-    return {pad_code(code), analyze_jumpdests(code)};
+    const auto executable_code = eof_container.substr(header.code_begin(), header.code_size);
+    return {executable_code.data(), analyze_jumpdests(executable_code)};
 }
 }  // namespace
 

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -311,8 +311,7 @@ evmc_result execute(const VM& vm, ExecutionState& state, const CodeAnalysis& ana
 {
     state.analysis.baseline = &analysis;  // Assign code analysis for instruction implementations.
 
-    // Use padded code.
-    state.code = {analysis.padded_code.get(), state.code.size()};
+    state.code = {analysis.executable_code, state.code.size()};
 
     const auto& cost_table = get_baseline_cost_table(state.rev);
 

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -37,6 +37,10 @@ public:
         jumpdest_map{std::move(map)},
         m_padded_code{std::move(padded_code)}
     {}
+
+    CodeAnalysis(const uint8_t* code, JumpdestMap map)
+      : executable_code{code}, jumpdest_map{std::move(map)}
+    {}
 };
 static_assert(std::is_move_constructible_v<CodeAnalysis>);
 static_assert(std::is_move_assignable_v<CodeAnalysis>);

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -18,12 +18,25 @@ class VM;
 
 namespace baseline
 {
-struct CodeAnalysis
+class CodeAnalysis
 {
+public:
     using JumpdestMap = std::vector<bool>;
 
-    std::unique_ptr<uint8_t[]> padded_code;
-    JumpdestMap jumpdest_map;
+    const uint8_t* executable_code;  ///< Pointer to the beginning of executable code section.
+    JumpdestMap jumpdest_map;        ///< Map of valid jump destinations.
+
+private:
+    /// Padded code for faster legacy code execution.
+    /// If not nullptr the executable_code must point to it.
+    std::unique_ptr<uint8_t[]> m_padded_code;
+
+public:
+    CodeAnalysis(std::unique_ptr<uint8_t[]> padded_code, JumpdestMap map)
+      : executable_code{padded_code.get()},
+        jumpdest_map{std::move(map)},
+        m_padded_code{std::move(padded_code)}
+    {}
 };
 static_assert(std::is_move_constructible_v<CodeAnalysis>);
 static_assert(std::is_move_assignable_v<CodeAnalysis>);

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -16,7 +16,7 @@ struct AdvancedCodeAnalysis;
 }
 namespace baseline
 {
-struct CodeAnalysis;
+class CodeAnalysis;
 }
 
 using uint256 = intx::uint256;

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -133,11 +133,6 @@ public:
     evmc_revision rev = {};
     bytes return_data;
 
-    /// Reference to original EVM code section.
-    /// For legacy code this is a reference to entire original code.
-    /// For EOF-formatted code this is a reference to code section only.
-    /// TODO: Code should be accessed via code analysis only and this should be removed.
-    bytes_view code;
     /// Reference to original EVM code container.
     /// For legacy code this is a reference to entire original code.
     /// For EOF-formatted code this is a reference to entire container.
@@ -173,7 +168,6 @@ public:
         msg{&message},
         host{host_interface, host_ctx},
         rev{revision},
-        code{_code},
         original_code{_code}
     {}
 
@@ -189,7 +183,6 @@ public:
         host = {host_interface, host_ctx};
         rev = revision;
         return_data.clear();
-        code = _code;
         original_code = _code;
         status = EVMC_SUCCESS;
         output_offset = 0;

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -684,7 +684,7 @@ inline code_iterator jump_impl(ExecutionState& state, const uint256& dst) noexce
         return nullptr;
     }
 
-    return state.code.data() + static_cast<size_t>(dst);
+    return state.analysis.baseline->executable_code + static_cast<size_t>(dst);
 }
 
 /// JUMP instruction implementation using baseline::CodeAnalysis.
@@ -703,7 +703,7 @@ inline code_iterator jumpi(StackTop stack, ExecutionState& state, code_iterator 
 
 inline code_iterator pc(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
 {
-    stack.push(static_cast<uint64_t>(pos - state.code.data()));
+    stack.push(static_cast<uint64_t>(pos - state.analysis.baseline->executable_code));
     return pos + 1;
 }
 

--- a/test/unittests/execution_state_test.cpp
+++ b/test/unittests/execution_state_test.cpp
@@ -33,8 +33,6 @@ TEST(execution_state, construct)
     EXPECT_EQ(st.msg, &msg);
     EXPECT_EQ(st.rev, EVMC_MAX_REVISION);
     EXPECT_EQ(st.return_data.size(), 0);
-    EXPECT_EQ(st.code.data(), &code[0]);
-    EXPECT_EQ(st.code.size(), std::size(code));
     EXPECT_EQ(st.status, EVMC_SUCCESS);
     EXPECT_EQ(st.output_offset, 0);
     EXPECT_EQ(st.output_size, 0);
@@ -49,8 +47,6 @@ TEST(execution_state, default_construct)
     EXPECT_EQ(st.msg, nullptr);
     EXPECT_EQ(st.rev, EVMC_FRONTIER);
     EXPECT_EQ(st.return_data.size(), 0);
-    EXPECT_EQ(st.code.data(), nullptr);
-    EXPECT_EQ(st.code.size(), 0);
     EXPECT_EQ(st.status, EVMC_SUCCESS);
     EXPECT_EQ(st.output_offset, 0);
     EXPECT_EQ(st.output_size, 0);
@@ -66,8 +62,6 @@ TEST(execution_state, default_construct_advanced)
     EXPECT_EQ(st.msg, nullptr);
     EXPECT_EQ(st.rev, EVMC_FRONTIER);
     EXPECT_EQ(st.return_data.size(), 0);
-    EXPECT_EQ(st.code.data(), nullptr);
-    EXPECT_EQ(st.code.size(), 0);
     EXPECT_EQ(st.status, EVMC_SUCCESS);
     EXPECT_EQ(st.output_offset, 0);
     EXPECT_EQ(st.output_size, 0);
@@ -79,7 +73,6 @@ TEST(execution_state, default_construct_advanced)
 TEST(execution_state, reset_advanced)
 {
     const evmc_message msg{};
-    const uint8_t code[]{0xff};
     evmone::advanced::AdvancedCodeAnalysis analysis;
 
     evmone::advanced::AdvancedExecutionState st;
@@ -90,7 +83,6 @@ TEST(execution_state, reset_advanced)
     st.msg = &msg;
     st.rev = EVMC_BYZANTIUM;
     st.return_data.push_back('0');
-    st.code = {code, std::size(code)};
     st.status = EVMC_FAILURE;
     st.output_offset = 3;
     st.output_size = 4;
@@ -104,8 +96,6 @@ TEST(execution_state, reset_advanced)
     EXPECT_EQ(st.msg, &msg);
     EXPECT_EQ(st.rev, EVMC_BYZANTIUM);
     EXPECT_EQ(st.return_data.size(), 1);
-    EXPECT_EQ(st.code.data(), &code[0]);
-    EXPECT_EQ(st.code.size(), 1);
     EXPECT_EQ(st.status, EVMC_FAILURE);
     EXPECT_EQ(st.output_offset, 3);
     EXPECT_EQ(st.output_size, 4u);
@@ -129,8 +119,6 @@ TEST(execution_state, reset_advanced)
         EXPECT_EQ(st.msg, &msg2);
         EXPECT_EQ(st.rev, EVMC_HOMESTEAD);
         EXPECT_EQ(st.return_data.size(), 0);
-        EXPECT_EQ(st.code.data(), &code2[0]);
-        EXPECT_EQ(st.code.size(), 2);
         EXPECT_EQ(st.status, EVMC_SUCCESS);
         EXPECT_EQ(st.output_offset, 0);
         EXPECT_EQ(st.output_size, 0);


### PR DESCRIPTION
EOF does not require code padding for execution as executable code must end with terminating instruction.
This also refactors code analysis and execution state.