### PR TITLE
Bump minimum required GCC version to 10

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
   linux-gcc-min:
     docker:
-      - image: ethereum/cpp-build-env:15-gcc-8
+      - image: ethereum/cpp-build-env:15-gcc-10
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -2,11 +2,9 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-include(CheckIncludeFileCXX)
-
 add_executable(evmone-bench)
 target_include_directories(evmone-bench PRIVATE ${evmone_private_include_dir})
-target_link_libraries(evmone-bench PRIVATE evmone testutils evmc::loader benchmark::benchmark $<$<CXX_COMPILER_ID:GNU>:stdc++fs>)
+target_link_libraries(evmone-bench PRIVATE evmone testutils evmc::loader benchmark::benchmark)
 target_sources(
     evmone-bench PRIVATE
     bench.cpp


### PR DESCRIPTION
This removes the need to link stdc++fs in case <filesystem> is used.
This also allows using of std::span once C++20 is enabled.