### PR TITLE
baseline: Refactor code padding

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -53,8 +53,7 @@ std::unique_ptr<uint8_t[]> pad_code(bytes_view code)
     // instruction at the code end.
     constexpr auto padding = 32 + 1;
 
-    // Using "raw" new operator instead of std::make_unique() to get uninitialized array.
-    std::unique_ptr<uint8_t[]> padded_code{new uint8_t[code.size() + padding]};
+    auto padded_code = std::make_unique_for_overwrite<uint8_t[]>(code.size() + padding);
     std::copy(std::begin(code), std::end(code), padded_code.get());
     std::fill_n(&padded_code[code.size()], padding, uint8_t{OP_STOP});
     return padded_code;


### PR DESCRIPTION
Use `std::make_unique_for_overwrite` to create padded code.