### PR TITLE
baseline: Better stack overflow/underflow checks

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -104,7 +104,7 @@ inline evmc_status_code check_requirements(
     const CostTable& cost_table, int64_t& gas_left, ptrdiff_t stack_size) noexcept
 {
     static_assert(
-        !(instr::has_const_gas_cost(Op) && instr::gas_costs[EVMC_FRONTIER][Op] == instr::undefined),
+        !instr::has_const_gas_cost(Op) || instr::gas_costs[EVMC_FRONTIER][Op] != instr::undefined,
         "undefined instructions must not be handled by check_requirements()");
 
     auto gas_cost = instr::gas_costs[EVMC_FRONTIER][Op];  // Init assuming const cost.


### PR DESCRIPTION
Change stack overflow/underflow checks to stack pointers comparisons.
This gives better compiler optimizations. This gives around ~2% performance improvements.