### PR TITLE
Optimize SWAP

### DIFF
--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -802,7 +802,22 @@ template <int N>
 inline void swap(StackTop stack) noexcept
 {
     static_assert(N >= 1 && N <= 16);
-    std::swap(stack.top(), stack[N]);
+
+    // The simple std::swap(stack.top(), stack[N]) is not used to workaround
+    // clang missed optimization: https://github.com/llvm/llvm-project/issues/59116
+    // TODO(clang): Check if #59116 bug fix has been released.
+
+    auto& a = stack[N];
+    auto& t = stack.top();
+    auto t0 = t[0];
+    auto t1 = t[1];
+    auto t2 = t[2];
+    auto t3 = t[3];
+    t = a;
+    a[0] = t0;
+    a[1] = t1;
+    a[2] = t2;
+    a[3] = t3;
 }
 
 template <size_t NumTopics>


### PR DESCRIPTION
Clang compiler generates suboptimal code if the temporary struct is used in SWAP implementation. Workaround it by using 4x uint64_t temporaries.

https://github.com/llvm/llvm-project/issues/59116