### PR TITLE
Fix instruction tracing of EOF code

### DIFF
--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -23,8 +23,8 @@ class CodeAnalysis
 public:
     using JumpdestMap = std::vector<bool>;
 
-    const uint8_t* executable_code;  ///< Pointer to the beginning of executable code section.
-    JumpdestMap jumpdest_map;        ///< Map of valid jump destinations.
+    bytes_view executable_code;  ///< Executable code section.
+    JumpdestMap jumpdest_map;    ///< Map of valid jump destinations.
 
 private:
     /// Padded code for faster legacy code execution.
@@ -32,13 +32,13 @@ private:
     std::unique_ptr<uint8_t[]> m_padded_code;
 
 public:
-    CodeAnalysis(std::unique_ptr<uint8_t[]> padded_code, JumpdestMap map)
-      : executable_code{padded_code.get()},
+    CodeAnalysis(std::unique_ptr<uint8_t[]> padded_code, size_t code_size, JumpdestMap map)
+      : executable_code{padded_code.get(), code_size},
         jumpdest_map{std::move(map)},
         m_padded_code{std::move(padded_code)}
     {}
 
-    CodeAnalysis(const uint8_t* code, JumpdestMap map)
+    CodeAnalysis(bytes_view code, JumpdestMap map)
       : executable_code{code}, jumpdest_map{std::move(map)}
     {}
 };

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -684,7 +684,7 @@ inline code_iterator jump_impl(ExecutionState& state, const uint256& dst) noexce
         return nullptr;
     }
 
-    return state.analysis.baseline->executable_code + static_cast<size_t>(dst);
+    return &state.analysis.baseline->executable_code[static_cast<size_t>(dst)];
 }
 
 /// JUMP instruction implementation using baseline::CodeAnalysis.
@@ -703,7 +703,7 @@ inline code_iterator jumpi(StackTop stack, ExecutionState& state, code_iterator 
 
 inline code_iterator pc(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
 {
-    stack.push(static_cast<uint64_t>(pos - state.analysis.baseline->executable_code));
+    stack.push(static_cast<uint64_t>(pos - state.analysis.baseline->executable_code.data()));
     return pos + 1;
 }
 


### PR DESCRIPTION
After #531 tracer gets `state.original_code` and then uses PC value to get an opcode from this code, which is incorrect for EOF.

I don't have a fix yet, but wrote a test.