### PR TITLE
Refactor CALL/CREATE instructions

### DIFF
--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -16,10 +16,10 @@ evmc_status_code call_impl(StackTop stack, ExecutionState& state) noexcept
     const auto dst = intx::be::trunc<evmc::address>(stack.pop());
     const auto value = (Op == OP_STATICCALL || Op == OP_DELEGATECALL) ? 0 : stack.pop();
     const auto has_value = value != 0;
-    const auto input_offset = stack.pop();
-    const auto input_size = stack.pop();
-    const auto output_offset = stack.pop();
-    const auto output_size = stack.pop();
+    const auto input_offset_u256 = stack.pop();
+    const auto input_size_u256 = stack.pop();
+    const auto output_offset_u256 = stack.pop();
+    const auto output_size_u256 = stack.pop();
 
     stack.push(0);  // Assume failure.
 
@@ -29,11 +29,16 @@ evmc_status_code call_impl(StackTop stack, ExecutionState& state) noexcept
             return EVMC_OUT_OF_GAS;
     }
 
-    if (!check_memory(state, input_offset, input_size))
+    if (!check_memory(state, input_offset_u256, input_size_u256))
         return EVMC_OUT_OF_GAS;
 
-    if (!check_memory(state, output_offset, output_size))
+    if (!check_memory(state, output_offset_u256, output_size_u256))
         return EVMC_OUT_OF_GAS;
+
+    const auto input_offset = static_cast<size_t>(input_offset_u256);
+    const auto input_size = static_cast<size_t>(input_size_u256);
+    const auto output_offset = static_cast<size_t>(output_offset_u256);
+    const auto output_size = static_cast<size_t>(output_size_u256);
 
     auto msg = evmc_message{};
     msg.kind = (Op == OP_DELEGATECALL) ? EVMC_DELEGATECALL :
@@ -47,10 +52,11 @@ evmc_status_code call_impl(StackTop stack, ExecutionState& state) noexcept
     msg.value =
         (Op == OP_DELEGATECALL) ? state.msg->value : intx::be::store<evmc::uint256be>(value);
 
-    if (size_t(input_size) > 0)
+    if (input_size > 0)
     {
-        msg.input_data = &state.memory[size_t(input_offset)];
-        msg.input_size = size_t(input_size);
+        // input_offset may be garbage if input_size == 0.
+        msg.input_data = &state.memory[input_offset];
+        msg.input_size = input_size;
     }
 
     auto cost = has_value ? 9000 : 0;
@@ -94,8 +100,8 @@ evmc_status_code call_impl(StackTop stack, ExecutionState& state) noexcept
     state.return_data.assign(result.output_data, result.output_size);
     stack.top() = result.status_code == EVMC_SUCCESS;
 
-    if (const auto copy_size = std::min(size_t(output_size), result.output_size); copy_size > 0)
-        std::memcpy(&state.memory[size_t(output_offset)], result.output_data, copy_size);
+    if (const auto copy_size = std::min(output_size, result.output_size); copy_size > 0)
+        std::memcpy(&state.memory[output_offset], result.output_data, copy_size);
 
     const auto gas_used = msg.gas - result.gas_left;
     state.gas_left -= gas_used;
@@ -119,17 +125,20 @@ evmc_status_code create_impl(StackTop stack, ExecutionState& state) noexcept
         return EVMC_STATIC_MODE_VIOLATION;
 
     const auto endowment = stack.pop();
-    const auto init_code_offset = stack.pop();
-    const auto init_code_size = stack.pop();
+    const auto init_code_offset_u256 = stack.pop();
+    const auto init_code_size_u256 = stack.pop();
 
-    if (!check_memory(state, init_code_offset, init_code_size))
+    if (!check_memory(state, init_code_offset_u256, init_code_size_u256))
         return EVMC_OUT_OF_GAS;
+
+    const auto init_code_offset = static_cast<size_t>(init_code_offset_u256);
+    const auto init_code_size = static_cast<size_t>(init_code_size_u256);
 
     auto salt = uint256{};
     if constexpr (Op == OP_CREATE2)
     {
         salt = stack.pop();
-        auto salt_cost = num_words(static_cast<size_t>(init_code_size)) * 6;
+        const auto salt_cost = num_words(init_code_size) * 6;
         if ((state.gas_left -= salt_cost) < 0)
             return EVMC_OUT_OF_GAS;
     }
@@ -150,10 +159,11 @@ evmc_status_code create_impl(StackTop stack, ExecutionState& state) noexcept
         msg.gas = msg.gas - msg.gas / 64;
 
     msg.kind = (Op == OP_CREATE) ? EVMC_CREATE : EVMC_CREATE2;
-    if (size_t(init_code_size) > 0)
+    if (init_code_size > 0)
     {
-        msg.input_data = &state.memory[size_t(init_code_offset)];
-        msg.input_size = size_t(init_code_size);
+        // init_code_offset may be garbage if init_code_size == 0.
+        msg.input_data = &state.memory[init_code_offset];
+        msg.input_size = init_code_size;
     }
     msg.sender = state.msg->recipient;
     msg.depth = state.msg->depth + 1;


### PR DESCRIPTION
- Perform uint256 → size_t casts of memory offsets and sizes in single
place when it is safe to do so.
- Assume failure of CALL/CREATE by setting result to 0 and clearing
the return buffer before performing any checks.