### PR TITLE
Make JSON Test Loader unit-testable

### DIFF
--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -60,7 +60,8 @@ std::vector<BenchmarkCase::Input> load_inputs(const StateTransitionTest& state_t
 /// Loads a benchmark case from a file at `path` and all its inputs from the matching inputs file.
 BenchmarkCase load_benchmark(const fs::path& path, const std::string& name_prefix)
 {
-    auto state_test = evmone::test::load_state_test(path);
+    std::ifstream f{path};
+    auto state_test = evmone::test::load_state_test(f);
 
     const auto name = name_prefix + path.stem().string();
     const auto code = state_test.pre_state.get(state_test.multi_tx.to.value()).code;

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -62,6 +62,8 @@ public:
     }
 
     [[nodiscard]] auto& get_accounts() noexcept { return m_accounts; }
+
+    [[nodiscard]] const auto& get_accounts() const noexcept { return m_accounts; }
 };
 
 struct BlockInfo

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -22,7 +22,8 @@ public:
 
     void TestBody() final
     {
-        evmone::test::run_state_test(evmone::test::load_state_test(m_json_test_file), m_vm);
+        std::ifstream f{m_json_test_file};
+        evmone::test::run_state_test(evmone::test::load_state_test(f), m_vm);
     }
 };
 

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -77,7 +77,7 @@ state::State from_json<state::State>(const json::json& j);
 template <>
 state::Transaction from_json<state::Transaction>(const json::json& j);
 
-StateTransitionTest load_state_test(const fs::path& test_file);
+StateTransitionTest load_state_test(std::istream& input);
 
 void run_state_test(const StateTransitionTest& test, evmc::VM& vm);
 

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -279,6 +279,9 @@ static void from_json(const json::json& j, StateTransitionTest::Case::Expectatio
 
 static void from_json(const json::json& j, StateTransitionTest& o)
 {
+    if (!j.is_object() || j.empty())
+        throw std::invalid_argument{"JSON test must be an object with single key of the test name"};
+
     const auto& j_t = j.begin().value();  // Content is in a dict with the test name.
 
     o.pre_state = from_json<state::State>(j_t.at("pre"));

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -4,7 +4,6 @@
 
 #include "statetest.hpp"
 #include <nlohmann/json.hpp>
-#include <fstream>
 
 namespace evmone::test
 {
@@ -302,8 +301,8 @@ static void from_json(const json::json& j, StateTransitionTest& o)
     }
 }
 
-StateTransitionTest load_state_test(const fs::path& test_file)
+StateTransitionTest load_state_test(std::istream& input)
 {
-    return json::json::parse(std::ifstream{test_file}).get<StateTransitionTest>();
+    return json::json::parse(input).get<StateTransitionTest>();
 }
 }  // namespace evmone::test

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(evmone-unittests
     state_mpt_hash_test.cpp
     state_mpt_test.cpp
     state_rlp_test.cpp
+    statetest_loader_test.cpp
     statetest_loader_tx_test.cpp
     statetest_logs_hash_test.cpp
     tracing_test.cpp

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -1,0 +1,69 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <test/statetest/statetest.hpp>
+
+using namespace evmone;
+
+TEST(statetest_loader, load_empty_test)
+{
+    std::istringstream s{"{}"};
+    EXPECT_THROW(test::load_state_test(s), std::invalid_argument);
+}
+
+TEST(statetest_loader, load_minimal_test)
+{
+    std::istringstream s{R"({
+        "test": {
+            "_info": {},
+            "pre": {},
+            "transaction": {
+                "gasPrice": "",
+                "sender": "",
+                "to": "",
+                "data": null,
+                "gasLimit": "0",
+                "value": null
+            },
+            "post": {},
+            "env": {
+                "currentNumber": "0",
+                "currentTimestamp": "0",
+                "currentGasLimit": "0",
+                "currentCoinbase": ""
+            }
+        }
+    })"};
+    const test::StateTransitionTest st = test::load_state_test(s);
+    // TODO: should add some comparison operator to State, BlockInfo, AccessList
+    EXPECT_EQ(st.pre_state.get_accounts().size(), 0);
+    EXPECT_EQ(st.block.number, 0);
+    EXPECT_EQ(st.block.timestamp, 0);
+    EXPECT_EQ(st.block.gas_limit, 0);
+    EXPECT_EQ(st.block.coinbase, address{});
+    EXPECT_EQ(st.block.prev_randao, bytes32{});
+    EXPECT_EQ(st.block.base_fee, 0);
+    EXPECT_EQ(st.multi_tx.kind, test::TestMultiTransaction::Kind::legacy);
+    EXPECT_EQ(st.multi_tx.data, bytes{});
+    EXPECT_EQ(st.multi_tx.gas_limit, 0);
+    EXPECT_EQ(st.multi_tx.max_gas_price, 0);
+    EXPECT_EQ(st.multi_tx.max_priority_gas_price, 0);
+    EXPECT_EQ(st.multi_tx.sender, address{});
+    EXPECT_EQ(st.multi_tx.to, std::nullopt);
+    EXPECT_EQ(st.multi_tx.value, 0);
+    EXPECT_EQ(st.multi_tx.access_list.size(), 0);
+    EXPECT_EQ(st.multi_tx.chain_id, 0);
+    EXPECT_EQ(st.multi_tx.nonce, 0);
+    EXPECT_EQ(st.multi_tx.r, 0);
+    EXPECT_EQ(st.multi_tx.s, 0);
+    EXPECT_EQ(st.multi_tx.v, 0);
+    EXPECT_EQ(st.multi_tx.access_lists.size(), 0);
+    EXPECT_EQ(st.multi_tx.inputs.size(), 0);
+    EXPECT_EQ(st.multi_tx.gas_limits.size(), 1);
+    EXPECT_EQ(st.multi_tx.gas_limits[0], 0);
+    EXPECT_EQ(st.multi_tx.values.size(), 0);
+    EXPECT_EQ(st.cases.size(), 0);
+    EXPECT_EQ(st.input_labels.size(), 0);
+}


### PR DESCRIPTION
Refactor JSON test loading procedures to take generic input stream (instead of a file path) to make it easy to create unit tests for them.