### PR TITLE
bench: Lambda capture structured bindings (C++20)

### DIFF
--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -162,8 +162,8 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
             for (auto& [vm_name, vm] : registered_vms)
             {
                 const auto name = std::string{vm_name} + "/total/" + case_name;
-                RegisterBenchmark(name, [&vm_ = vm, &b, &input](State& state) {
-                    bench_evmc_execute(state, vm_, b.code, input.input, input.expected_output);
+                RegisterBenchmark(name, [&vm, &b, &input](State& state) {
+                    bench_evmc_execute(state, vm, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }
         }

--- a/test/bench/synthetic_benchmarks.cpp
+++ b/test/bench/synthetic_benchmarks.cpp
@@ -252,11 +252,10 @@ void register_synthetic_benchmarks()
 
     for (auto& [vm_name, vm] : registered_vms)
     {
-        // TODO(clang16): Simplify lambda capture [&vm].
         RegisterBenchmark(std::string{vm_name} + "/total/synth/loop_v1",
-            [&vm_ = vm](State& state) { bench_evmc_execute(state, vm_, generate_loop_v1({})); });
+            [&vm](State& state) { bench_evmc_execute(state, vm, generate_loop_v1({})); });
         RegisterBenchmark(std::string{vm_name} + "/total/synth/loop_v2",
-            [&vm_ = vm](State& state) { bench_evmc_execute(state, vm_, generate_loop_v2({})); });
+            [&vm](State& state) { bench_evmc_execute(state, vm, generate_loop_v2({})); });
     }
 
     for (const auto params : params_list)
@@ -264,8 +263,8 @@ void register_synthetic_benchmarks()
         for (auto& [vm_name, vm] : registered_vms)
         {
             RegisterBenchmark(std::string{vm_name} + "/total/synth/" + to_string(params),
-                [&vm_ = vm, params](
-                    State& state) { bench_evmc_execute(state, vm_, generate_code(params)); })
+                [&vm, params](
+                    State& state) { bench_evmc_execute(state, vm, generate_code(params)); })
                 ->Unit(kMicrosecond);
         }
     }


### PR DESCRIPTION
Refactor lambda usage to capture structured bindings (finally available in C++20) without declaring additional lambda capture variable. This also fixes clang-17 "declaration shadows a structured binding" warnings.