### PR TITLE
bench: Fix clang-17 compiler warnings

### DIFF
--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -162,8 +162,8 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
             for (auto& [vm_name, vm] : registered_vms)
             {
                 const auto name = std::string{vm_name} + "/total/" + case_name;
-                RegisterBenchmark(name.c_str(), [&vm = vm, &b, &input](State& state) {
-                    bench_evmc_execute(state, vm, b.code, input.input, input.expected_output);
+                RegisterBenchmark(name.c_str(), [&vm_ = vm, &b, &input](State& state) {
+                    bench_evmc_execute(state, vm_, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }
         }

--- a/test/bench/synthetic_benchmarks.cpp
+++ b/test/bench/synthetic_benchmarks.cpp
@@ -257,9 +257,9 @@ void register_synthetic_benchmarks()
     for (auto& [vm_name, vm] : registered_vms)
     {
         RegisterBenchmark((std::string{vm_name} + "/total/synth/loop_v1").c_str(),
-            [&vm = vm](State& state) { bench_evmc_execute(state, vm, generate_loop_v1({})); });
+            [&vm_ = vm](State& state) { bench_evmc_execute(state, vm_, generate_loop_v1({})); });
         RegisterBenchmark((std::string{vm_name} + "/total/synth/loop_v2").c_str(),
-            [&vm = vm](State& state) { bench_evmc_execute(state, vm, generate_loop_v2({})); });
+            [&vm_ = vm](State& state) { bench_evmc_execute(state, vm_, generate_loop_v2({})); });
     }
 
     for (const auto params : params_list)
@@ -267,8 +267,8 @@ void register_synthetic_benchmarks()
         for (auto& [vm_name, vm] : registered_vms)
         {
             RegisterBenchmark((std::string{vm_name} + "/total/synth/" + to_string(params)).c_str(),
-                [&vm = vm, params](
-                    State& state) { bench_evmc_execute(state, vm, generate_code(params)); })
+                [&vm_ = vm, params](
+                    State& state) { bench_evmc_execute(state, vm_, generate_code(params)); })
                 ->Unit(kMicrosecond);
         }
     }


### PR DESCRIPTION
Avoid `-Wshadow` warnings from clang-17. The proper fix is in #596 but we cannot apply it yet due to insufficient compiler support.