### PR TITLE
tracing: Separate gas parameter

### DIFF
--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -242,7 +242,10 @@ void dispatch(const CostTable& cost_table, ExecutionState& state, const uint8_t*
             const auto offset = static_cast<uint32_t>(position.code_it - code);
             const auto stack_height = static_cast<int>(position.stack_top - stack_bottom);
             if (offset < state.original_code.size())  // Skip STOP from code padding.
-                tracer->notify_instruction_start(offset, position.stack_top, stack_height, state);
+            {
+                tracer->notify_instruction_start(
+                    offset, position.stack_top, stack_height, state.gas_left, state);
+            }
         }
 
         const auto op = *position.code_it;

--- a/lib/evmone/tracing.cpp
+++ b/lib/evmone/tracing.cpp
@@ -41,7 +41,7 @@ class HistogramTracer : public Tracer
     }
 
     void on_instruction_start(uint32_t pc, const intx::uint256* /*stack_top*/, int /*stack_height*/,
-        const ExecutionState& /*state*/) noexcept override
+        int64_t /*gas*/, const ExecutionState& /*state*/) noexcept override
     {
         auto& ctx = m_contexts.top();
         ++ctx.counts[ctx.code[pc]];
@@ -106,7 +106,7 @@ class InstructionTracer : public Tracer
     }
 
     void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height,
-        const ExecutionState& state) noexcept override
+        int64_t gas, const ExecutionState& state) noexcept override
     {
         const auto& ctx = m_contexts.top();
 
@@ -115,7 +115,7 @@ class InstructionTracer : public Tracer
         m_out << R"("pc":)" << std::dec << pc;
         m_out << R"(,"op":)" << std::dec << int{opcode};
         m_out << R"(,"opName":")" << get_name(opcode) << '"';
-        m_out << R"(,"gas":)" << std::hex << "0x" << state.gas_left;
+        m_out << R"(,"gas":0x)" << std::hex << gas;
         output_stack(stack_top, stack_height);
 
         // Full memory can be dumped as evmc::hex({state.memory.data(), state.memory.size()}),

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -40,19 +40,19 @@ public:
     }
 
     void notify_instruction_start(  // NOLINT(misc-no-recursion)
-        uint32_t pc, intx::uint256* stack_top, int stack_height,
+        uint32_t pc, intx::uint256* stack_top, int stack_height, int64_t gas,
         const ExecutionState& state) noexcept
     {
-        on_instruction_start(pc, stack_top, stack_height, state);
+        on_instruction_start(pc, stack_top, stack_height, gas, state);
         if (m_next_tracer)
-            m_next_tracer->notify_instruction_start(pc, stack_top, stack_height, state);
+            m_next_tracer->notify_instruction_start(pc, stack_top, stack_height, gas, state);
     }
 
 private:
     virtual void on_execution_start(
         evmc_revision rev, const evmc_message& msg, bytes_view code) noexcept = 0;
     virtual void on_instruction_start(uint32_t pc, const intx::uint256* stack_top, int stack_height,
-        const ExecutionState& state) noexcept = 0;
+        int64_t gas, const ExecutionState& state) noexcept = 0;
     virtual void on_execution_end(const evmc_result& result) noexcept = 0;
 };
 

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -57,7 +57,8 @@ protected:
         void on_execution_end(const evmc_result& /*result*/) noexcept override { m_code = {}; }
 
         void on_instruction_start(uint32_t pc, const intx::uint256* /*stack_top*/,
-            int /*stack_height*/, const evmone::ExecutionState& /*state*/) noexcept override
+            int /*stack_height*/, int64_t /*gas*/,
+            const evmone::ExecutionState& /*state*/) noexcept override
         {
             const auto opcode = m_code[pc];
             m_trace << m_name << pc << ":" << evmone::instr::traits[opcode].name << " ";
@@ -82,7 +83,8 @@ protected:
         void on_execution_end(const evmc_result& /*result*/) noexcept override {}
 
         void on_instruction_start(uint32_t /*pc*/, const intx::uint256* /*stack_top*/,
-            int /*stack_height*/, const evmone::ExecutionState& /*state*/) noexcept override
+            int /*stack_height*/, int64_t /*gas*/,
+            const evmone::ExecutionState& /*state*/) noexcept override
         {}
 
     public:


### PR DESCRIPTION
Decouple "gas left" from ExecutionState and pass it as separate param.