### PR TITLE
Pass gas to instructions by value

### DIFF
--- a/lib/evmone/advanced_analysis.hpp
+++ b/lib/evmone/advanced_analysis.hpp
@@ -80,6 +80,7 @@ public:
 /// The execution state specialized for the Advanced interpreter.
 struct AdvancedExecutionState : ExecutionState
 {
+    int64_t gas_left = 0;
     Stack stack;
 
     /// The gas cost of the current block.
@@ -93,6 +94,7 @@ struct AdvancedExecutionState : ExecutionState
         const evmc_host_interface& host_interface, evmc_host_context* host_ctx,
         bytes_view _code) noexcept
       : ExecutionState{message, revision, host_interface, host_ctx, _code},
+        gas_left{message.gas},
         stack{stack_space.bottom()}
     {}
 
@@ -109,6 +111,7 @@ struct AdvancedExecutionState : ExecutionState
         bytes_view _code) noexcept
     {
         ExecutionState::reset(message, revision, host_interface, host_ctx, _code);
+        gas_left = message.gas;
         stack.reset(stack_space.bottom());
         analysis.advanced = nullptr;  // For consistency with previous behavior.
         current_block_cost = 0;

--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -58,7 +58,7 @@ evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_cont
 
 /// Executes in Baseline interpreter on the given external and initialized state.
 EVMC_EXPORT evmc_result execute(
-    const VM&, ExecutionState& state, const CodeAnalysis& analysis) noexcept;
+    const VM&, int64_t gas_limit, ExecutionState& state, const CodeAnalysis& analysis) noexcept;
 
 }  // namespace baseline
 }  // namespace evmone

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -125,7 +125,6 @@ public:
 class ExecutionState
 {
 public:
-    int64_t gas_left = 0;
     int64_t gas_refund = 0;
     Memory memory;
     const evmc_message* msg = nullptr;
@@ -166,11 +165,7 @@ public:
     ExecutionState(const evmc_message& message, evmc_revision revision,
         const evmc_host_interface& host_interface, evmc_host_context* host_ctx,
         bytes_view _code) noexcept
-      : gas_left{message.gas},
-        msg{&message},
-        host{host_interface, host_ctx},
-        rev{revision},
-        original_code{_code}
+      : msg{&message}, host{host_interface, host_ctx}, rev{revision}, original_code{_code}
     {}
 
     /// Resets the contents of the ExecutionState so that it could be reused.
@@ -178,7 +173,6 @@ public:
         const evmc_host_interface& host_interface, evmc_host_context* host_ctx,
         bytes_view _code) noexcept
     {
-        gas_left = message.gas;
         gas_refund = 0;
         memory.clear();
         msg = &message;

--- a/test/bench/helpers.hpp
+++ b/test/bench/helpers.hpp
@@ -65,7 +65,7 @@ inline evmc::Result baseline_execute(evmc::VM& c_vm, ExecutionState& exec_state,
 {
     const auto& vm = *static_cast<evmone::VM*>(c_vm.get_raw_pointer());
     exec_state.reset(msg, rev, host.get_interface(), host.to_context(), code);
-    return evmc::Result{baseline::execute(vm, exec_state, analysis)};
+    return evmc::Result{baseline::execute(vm, msg.gas, exec_state, analysis)};
 }
 
 inline evmc::Result evmc_execute(evmc::VM& vm, FakeExecutionState& /*exec_state*/,

--- a/test/unittests/execution_state_test.cpp
+++ b/test/unittests/execution_state_test.cpp
@@ -28,7 +28,6 @@ TEST(execution_state, construct)
     const evmone::ExecutionState st{
         msg, EVMC_MAX_REVISION, host_interface, nullptr, {code, std::size(code)}};
 
-    EXPECT_EQ(st.gas_left, -1);
     EXPECT_EQ(st.memory.size(), 0);
     EXPECT_EQ(st.msg, &msg);
     EXPECT_EQ(st.rev, EVMC_MAX_REVISION);
@@ -42,7 +41,6 @@ TEST(execution_state, default_construct)
 {
     const evmone::ExecutionState st;
 
-    EXPECT_EQ(st.gas_left, 0);
     EXPECT_EQ(st.memory.size(), 0);
     EXPECT_EQ(st.msg, nullptr);
     EXPECT_EQ(st.rev, EVMC_FRONTIER);


### PR DESCRIPTION
- Pass and return gas counter to instructions implementations by value, don't use `ExecutionState::gas_left`. This improves performance.
- Introduce `Result` type `{status, gas}`.
- Change `StopToken` to `TermResult` (strong alias of `Result`).
- Remove `gas_left` from `ExecutionState`.