### PR TITLE
state: Clean up state finalization

### DIFF
--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -119,6 +119,12 @@ struct TransactionReceipt
     BloomFilter logs_bloom_filter;
 };
 
+/// Finalize state after applying a "block" of transactions.
+///
+/// Applies block reward to coinbase and deletes empty touched accounts (post Spurious Dragon).
+void finalize(
+    State& state, evmc_revision rev, const address& coinbase, std::optional<uint64_t> block_reward);
+
 [[nodiscard]] std::variant<TransactionReceipt, std::error_code> transition(
     State& state, const BlockInfo& block, const Transaction& tx, evmc_revision rev, evmc::VM& vm);
 

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -28,6 +28,10 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm)
             validate_deployed_code(state, rev);
 
             const auto res = state::transition(state, test.block, tx, rev, vm);
+
+            // Finalize block with reward 0.
+            state::finalize(state, rev, test.block.coinbase, 0);
+
             if (holds_alternative<state::TransactionReceipt>(res))
                 EXPECT_EQ(logs_hash(get<state::TransactionReceipt>(res).logs), expected.logs_hash);
             else

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char* argv[])
     fs::path output_result_file;
     fs::path output_alloc_file;
     fs::path output_body_file;
-    std::optional<intx::uint256> block_reward;
+    std::optional<uint64_t> block_reward;
     uint64_t chain_id = 0;
 
     try
@@ -57,7 +57,7 @@ int main(int argc, const char* argv[])
             else if (arg == "--output.alloc" && ++i < argc)
                 output_alloc_file = argv[i];
             else if (arg == "--state.reward" && ++i < argc && argv[i] != "-1"sv)
-                block_reward = intx::from_string<intx::uint256>(argv[i]);
+                block_reward = intx::from_string<uint64_t>(argv[i]);
             else if (arg == "--state.chainid" && ++i < argc)
                 chain_id = intx::from_string<uint64_t>(argv[i]);
             else if (arg == "--output.body" && ++i < argc)
@@ -157,8 +157,7 @@ int main(int argc, const char* argv[])
                 }
             }
 
-            if (block_reward.has_value())
-                state.touch(block.coinbase).balance += *block_reward;
+            state::finalize(state, rev, block.coinbase, block_reward);
 
             j_result["logsHash"] = hex0x(logs_hash(txs_logs));
             j_result["stateRoot"] = hex0x(state::mpt_hash(state.get_accounts()));

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -22,6 +22,7 @@ void state_transition::TearDown()
     ASSERT_TRUE(holds_alternative<TransactionReceipt>(res))
         << std::get<std::error_code>(res).message();
     const auto& receipt = std::get<TransactionReceipt>(res);
+    evmone::state::finalize(state, rev, block.coinbase, 0);
 
     EXPECT_EQ(receipt.status, expect.status);
     if (expect.gas_used.has_value())


### PR DESCRIPTION
- Separate selfdestruct handling from empty account clearing.
- Apply block reward to coinbase consistently.
- Use it to properly clean state in `t8n` and `state-test-runner`.