### PR TITLE
Move `stdx::to_underlying` to separated header

### DIFF
--- a/test/state/precompiles.hpp
+++ b/test/state/precompiles.hpp
@@ -3,18 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "../utils/stdx/utility.hpp"
 #include <evmc/evmc.hpp>
 #include <optional>
-#include <type_traits>
-
-namespace stdx
-{
-template <typename EnumT>
-inline constexpr auto to_underlying(EnumT e) noexcept
-{
-    return static_cast<std::underlying_type_t<EnumT>>(e);
-}
-}  // namespace stdx
 
 namespace evmone::state
 {

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -13,6 +13,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
     target_sources(
         testutils PRIVATE
         bytecode.hpp
+        stdx/utility.hpp
         utils.hpp
     )
 endif()

--- a/test/utils/stdx/utility.hpp
+++ b/test/utils/stdx/utility.hpp
@@ -1,0 +1,14 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <type_traits>
+
+namespace stdx
+{
+template <typename EnumT>
+inline constexpr auto to_underlying(EnumT e) noexcept
+{
+    return static_cast<std::underlying_type_t<EnumT>>(e);
+}
+}  // namespace stdx


### PR DESCRIPTION
Required by https://github.com/ethereum/evmone/pull/608#discussion_r1158359009