### PR TITLE
eofparse: Allow to specify forkname

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -619,6 +619,9 @@ uint8_t get_eof_version(bytes_view container) noexcept
 
 EOFValidationError validate_eof(evmc_revision rev, bytes_view container) noexcept
 {
+    if (rev < EVMC_PRAGUE)
+        return EOFValidationError::invalid_code;
+
     if (!is_eof_container(container))
         return EOFValidationError::invalid_prefix;
 
@@ -626,9 +629,6 @@ EOFValidationError validate_eof(evmc_revision rev, bytes_view container) noexcep
 
     if (version == 1)
     {
-        if (rev < EVMC_PRAGUE)
-            return EOFValidationError::eof_version_unknown;
-
         const auto header_or_error = validate_eof1(rev, container);
         if (const auto* error = std::get_if<EOFValidationError>(&header_or_error))
             return *error;
@@ -645,8 +645,8 @@ std::string_view get_error_message(EOFValidationError err) noexcept
     {
     case EOFValidationError::success:
         return "success";
-    case EOFValidationError::starts_with_format:
-        return "starts_with_format";
+    case EOFValidationError::invalid_code:
+        return "invalid_code";
     case EOFValidationError::invalid_prefix:
         return "invalid_prefix";
     case EOFValidationError::eof_version_mismatch:

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -68,7 +68,7 @@ struct EOF1Header
 enum class EOFValidationError
 {
     success,
-    starts_with_format,
+    invalid_code,
     invalid_prefix,
     eof_version_mismatch,
     eof_version_unknown,

--- a/test/eofparse/CMakeLists.txt
+++ b/test/eofparse/CMakeLists.txt
@@ -3,5 +3,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(evmone-eofparse eofparse.cpp)
-target_link_libraries(evmone-eofparse PRIVATE evmone)
+target_link_libraries(evmone-eofparse PRIVATE evmone evmone::statetestutils)
 target_include_directories(evmone-eofparse PRIVATE ${evmone_private_include_dir})

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -69,10 +69,10 @@ TEST(eof_validation, validate_EOF_version)
         EOFValidationError::eof_version_unknown);
 }
 
-TEST(eof_validation, valid_EOF1_code_pre_shanghai)
+TEST(eof_validation, valid_EOF1_code_pre_prague)
 {
-    EXPECT_EQ(validate_eof("EF0001 010004 0200010001 00 00800000 FE", EVMC_PARIS),
-        EOFValidationError::eof_version_unknown);
+    EXPECT_EQ(validate_eof("EF0001 010004 0200010001 00 00800000 FE", EVMC_CANCUN),
+        EOFValidationError::invalid_code);
 }
 
 TEST(eof_validation, minimal_valid_EOF1_code)


### PR DESCRIPTION
Return `err: invalid_code`  for all Forks before ~~Cancun~~ Prague.

Needed by retesteth's new validation format ([example](https://github.com/ethereum/tests/blob/c8d47d2324f686994d8b01b3550e19b3c6332677/src/EOFTestsFiller/EIP5450/validInvalidFiller.yml#L5805-L5807))

~~This branch is based on branch: `coinbase-touching-cleanup`~~