### PR TITLE
statetest, ci: Update EOF state tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -414,7 +414,7 @@ jobs:
       - build_silkworm:
           commit: 30ca8b324fcffb574c23c09fcba6386e57a7a5af
       - download_execution_tests:
-          rev: v11.3
+          rev: v12.2
       - run:
           name: "Silkworm-driven blockchain tests (Advanced)"
           working_directory: ~/build
@@ -437,11 +437,13 @@ jobs:
     steps:
       - build
       - download_execution_tests:
-          commit: v11.3
+          rev: v12.2
       - run:
           name: "State tests"
           working_directory: ~/build
-          command: EVMONE_PRECOMPILES_STUB=~/project/test/state/precompiles_stub.json bin/evmone-statetest ~/tests/GeneralStateTests ~/tests/LegacyTests/Constantinople/GeneralStateTests
+          command: |
+            export EVMONE_PRECOMPILES_STUB=~/project/test/state/precompiles_stub.json 
+            bin/evmone-statetest ~/tests/GeneralStateTests ~/tests/EIPTests/StateTests/stEOF ~/tests/LegacyTests/Constantinople/GeneralStateTests
       - collect_coverage_gcc
       - upload_coverage:
           flags: statetests

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -61,8 +61,6 @@ int main(int argc, char* argv[])
     // The default test filter. To enable all tests use `--gtest_filter=*`.
     testing::FLAGS_gtest_filter =
         "-"
-        // Unsupported or broken EIP implementations:
-        "EIPTests/stEOF/*.*:"  // EOF implementation is broken
         // Slow tests:
         "stCreateTest.CreateOOGafterMaxCodesize:"      // pass
         "stQuadraticComplexityTest.Call50000_sha256:"  // pass


### PR DESCRIPTION
EIP/EOF tests enabled.

```
[----------] 2 tests from ori
[ RUN      ] ori.CreateEOF1
[       OK ] ori.CreateEOF1 (2 ms)
[ RUN      ] ori.EOF1ValidInvalid
[       OK ] ori.EOF1ValidInvalid (2 ms)
[----------] 2 tests from ori (5 ms total)

[----------] 12 tests from stEIP3540
[ RUN      ] stEIP3540.CREATE2_EOF1
[       OK ] stEIP3540.CREATE2_EOF1 (1 ms)
[ RUN      ] stEIP3540.CREATE2_EOF1Invalid
[       OK ] stEIP3540.CREATE2_EOF1Invalid (11 ms)
[ RUN      ] stEIP3540.CREATE2_EOF1Invalid_FromEOF
[       OK ] stEIP3540.CREATE2_EOF1Invalid_FromEOF (4 ms)
[ RUN      ] stEIP3540.CREATE2_EOF1_FromEOF
[       OK ] stEIP3540.CREATE2_EOF1_FromEOF (0 ms)
[ RUN      ] stEIP3540.CREATE_EOF1
[       OK ] stEIP3540.CREATE_EOF1 (0 ms)
[ RUN      ] stEIP3540.CREATE_EOF1Invalid
[       OK ] stEIP3540.CREATE_EOF1Invalid (11 ms)
[ RUN      ] stEIP3540.CREATE_EOF1Invalid_FromEOF
[       OK ] stEIP3540.CREATE_EOF1Invalid_FromEOF (4 ms)
[ RUN      ] stEIP3540.CREATE_EOF1_FromEOF
[       OK ] stEIP3540.CREATE_EOF1_FromEOF (0 ms)
[ RUN      ] stEIP3540.CreateTransactionEOF1
[       OK ] stEIP3540.CreateTransactionEOF1 (0 ms)
[ RUN      ] stEIP3540.CreateTransactionInvalidEOF1
[       OK ] stEIP3540.CreateTransactionInvalidEOF1 (7 ms)
[ RUN      ] stEIP3540.EOF1_Calls
[       OK ] stEIP3540.EOF1_Calls (1 ms)
[ RUN      ] stEIP3540.EOF1_Execution
[       OK ] stEIP3540.EOF1_Execution (1 ms)
[----------] 12 tests from stEIP3540 (45 ms total)

[----------] 11 tests from stEIP3670
[ RUN      ] stEIP3670.CREATE2_EOF1DeployValidOpcodes
[       OK ] stEIP3670.CREATE2_EOF1DeployValidOpcodes (5 ms)
[ RUN      ] stEIP3670.CREATE2_EOF1Invalid
[       OK ] stEIP3670.CREATE2_EOF1Invalid (8 ms)
[ RUN      ] stEIP3670.CREATE2_EOF1InvalidOpcodes
[       OK ] stEIP3670.CREATE2_EOF1InvalidOpcodes (3 ms)
[ RUN      ] stEIP3670.CREATE2_EOF1Invalid_FromEOF
[       OK ] stEIP3670.CREATE2_EOF1Invalid_FromEOF (2 ms)
[ RUN      ] stEIP3670.CREATE_EOF1DeployValidOpcodes
[       OK ] stEIP3670.CREATE_EOF1DeployValidOpcodes (5 ms)
[ RUN      ] stEIP3670.CREATE_EOF1Invalid
[       OK ] stEIP3670.CREATE_EOF1Invalid (8 ms)
[ RUN      ] stEIP3670.CREATE_EOF1InvalidOpcodes
[       OK ] stEIP3670.CREATE_EOF1InvalidOpcodes (3 ms)
[ RUN      ] stEIP3670.CREATE_EOF1Invalid_FromEOF
[       OK ] stEIP3670.CREATE_EOF1Invalid_FromEOF (2 ms)
[ RUN      ] stEIP3670.CreateTransactionEOF1InvalidOpcodes
[       OK ] stEIP3670.CreateTransactionEOF1InvalidOpcodes (5 ms)
[ RUN      ] stEIP3670.CreateTransactionEOF1ValidOpcodes
[       OK ] stEIP3670.CreateTransactionEOF1ValidOpcodes (4 ms)
[ RUN      ] stEIP3670.CreateTransactionInvalidEOF1
[       OK ] stEIP3670.CreateTransactionInvalidEOF1 (6 ms)
[----------] 11 tests from stEIP3670 (57 ms total)

[----------] 4 tests from stEIP4200
[ RUN      ] stEIP4200.EOF1_RJUMP_RJUMPI_RJUMPV_Execution
[       OK ] stEIP4200.EOF1_RJUMP_RJUMPI_RJUMPV_Execution (2 ms)
[ RUN      ] stEIP4200.RJUMPI_MaxOffset
[       OK ] stEIP4200.RJUMPI_MaxOffset (2 ms)
[ RUN      ] stEIP4200.RJUMPV_MaxOffset
[       OK ] stEIP4200.RJUMPV_MaxOffset (2 ms)
[ RUN      ] stEIP4200.RJUMP_MaxOffset
[       OK ] stEIP4200.RJUMP_MaxOffset (2 ms)
[----------] 4 tests from stEIP4200 (9 ms total)

[----------] 1 test from stEIP4750
[ RUN      ] stEIP4750.CALLF_RETF_Execution
[       OK ] stEIP4750.CALLF_RETF_Execution (2 ms)
[----------] 1 test from stEIP4750 (2 ms total)

[----------] 1 test from stEIP5450
[ RUN      ] stEIP5450.EOF1_CALLF_Execution
[       OK ] stEIP5450.EOF1_CALLF_Execution (1 ms)
[----------] 1 test from stEIP5450 (1 ms total)

[----------] 30 tests from stChangedEIP150
[ RUN      ] stChangedEIP150.Call1024BalanceTooLow
[       OK ] stChangedEIP150.Call1024BalanceTooLow (36 ms)
[ RUN      ] stChangedEIP150.Call1024PreCalls
[       OK ] stChangedEIP150.Call1024PreCalls (59 ms)
[ RUN      ] stChangedEIP150.Callcode1024BalanceTooLow
[       OK ] stChangedEIP150.Callcode1024BalanceTooLow (34 ms)
[ RUN      ] stChangedEIP150.callcall_00_OOGE_1
[       OK ] stChangedEIP150.callcall_00_OOGE_1 (0 ms)
[ RUN      ] stChangedEIP150.callcall_00_OOGE_2
[       OK ] stChangedEIP150.callcall_00_OOGE_2 (0 ms)
[ RUN      ] stChangedEIP150.callcall_00_OOGE_valueTransfer
[       OK ] stChangedEIP150.callcall_00_OOGE_valueTransfer (0 ms)
[ RUN      ] stChangedEIP150.callcallcall_000_OOGMAfter
[       OK ] stChangedEIP150.callcallcall_000_OOGMAfter (0 ms)
[ RUN      ] stChangedEIP150.callcallcallcode_001_OOGMAfter_1
[       OK ] stChangedEIP150.callcallcallcode_001_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcallcallcode_001_OOGMAfter_2
[       OK ] stChangedEIP150.callcallcallcode_001_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcallcallcode_001_OOGMAfter_3
[       OK ] stChangedEIP150.callcallcallcode_001_OOGMAfter_3 (0 ms)
[ RUN      ] stChangedEIP150.callcallcodecall_010_OOGMAfter_1
[       OK ] stChangedEIP150.callcallcodecall_010_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcallcodecall_010_OOGMAfter_2
[       OK ] stChangedEIP150.callcallcodecall_010_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcallcodecall_010_OOGMAfter_3
[       OK ] stChangedEIP150.callcallcodecall_010_OOGMAfter_3 (0 ms)
[ RUN      ] stChangedEIP150.callcallcodecallcode_011_OOGMAfter_1
[       OK ] stChangedEIP150.callcallcodecallcode_011_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcallcodecallcode_011_OOGMAfter_2
[       OK ] stChangedEIP150.callcallcodecallcode_011_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcall_100_OOGMAfter_1
[       OK ] stChangedEIP150.callcodecallcall_100_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcall_100_OOGMAfter_2
[       OK ] stChangedEIP150.callcodecallcall_100_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcall_100_OOGMAfter_3
[       OK ] stChangedEIP150.callcodecallcall_100_OOGMAfter_3 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcallcode_101_OOGMAfter_1
[       OK ] stChangedEIP150.callcodecallcallcode_101_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcallcode_101_OOGMAfter_2
[       OK ] stChangedEIP150.callcodecallcallcode_101_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcallcode_101_OOGMAfter_3
[       OK ] stChangedEIP150.callcodecallcallcode_101_OOGMAfter_3 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecall_110_OOGMAfter_1
[       OK ] stChangedEIP150.callcodecallcodecall_110_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecall_110_OOGMAfter_2
[       OK ] stChangedEIP150.callcodecallcodecall_110_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecall_110_OOGMAfter_3
[       OK ] stChangedEIP150.callcodecallcodecall_110_OOGMAfter_3 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter
[       OK ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter_1
[       OK ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter_1 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter_2
[       OK ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter_2 (0 ms)
[ RUN      ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter_3
[       OK ] stChangedEIP150.callcodecallcodecallcode_111_OOGMAfter_3 (0 ms)
[ RUN      ] stChangedEIP150.contractCreationMakeCallThatAskMoreGasThenTransactionProvided
[       OK ] stChangedEIP150.contractCreationMakeCallThatAskMoreGasThenTransactionProvided (0 ms)
[ RUN      ] stChangedEIP150.createInitFail_OOGduringInit
[       OK ] stChangedEIP150.createInitFail_OOGduringInit (0 ms)
[----------] 30 tests from stChangedEIP150 (139 ms total)
```