### PR TITLE
Fix printing bytes32 values on state transition test failures

### DIFF
--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -7,6 +7,7 @@
 #include <evmone/eof.hpp>
 #include <evmone/instructions_traits.hpp>
 #include <intx/intx.hpp>
+#include <test/state/hash_utils.hpp>
 #include <test/utils/utils.hpp>
 #include <algorithm>
 #include <ostream>


### PR DESCRIPTION
This is not a great fix, but I haven't figured out anything better yet, and this worked for me.

The bug: in `state_transition.cpp` there's assertion for storage values:  https://github.com/ethereum/evmone/blob/100c8f9da2588abdbe45a260b55f7698c826134f/test/unittests/state_transition.cpp#L59

When `value` (`evmc::bytes32`) comparison fails, printing code inside Google.Test macros doesn't find the right `operator<<` (declared in `hash_utils.hpp`) and instead implicitly converts it to `bytecode` and prints that:
```
/home/andrei/dev/evmone/test/unittests/state_transition.cpp:59: Failure
Expected equality of these values:
  acc->storage[key].current
    Which is: 6000
  value
    Which is: 6001
account 0x000000000000000000000000000000000000c0de key 0x0000000000000000000000000000000000000000000000000000000000000000
```
Byte values are prefixed with `60`, i.e. converted to PUSH instruction.

Expected output:
```
/home/andrei/dev/evmone/test/unittests/state_transition.cpp:59: Failure
Expected equality of these values:
  acc->storage[key].current
    Which is: 0x0000000000000000000000000000000000000000000000000000000000000000
  value
    Which is: 0x0000000000000000000000000000000000000000000000000000000000000001
account 0x000000000000000000000000000000000000c0de key 0x0000000000000000000000000000000000000000000000000000000000000000
```

At the same time using `operator<<` directly in `state_transition.cpp` works correctly.