### PR TITLE
Implement MCOPY (EIP-5656)

### DIFF
--- a/lib/evmone/instructions_opcodes.hpp
+++ b/lib/evmone/instructions_opcodes.hpp
@@ -162,6 +162,7 @@ enum Opcode : uint8_t
 
     OP_DUPN = 0xb5,
     OP_SWAPN = 0xb6,
+    OP_MCOPY = 0xb7,
 
     OP_CREATE = 0xf0,
     OP_CALL = 0xf1,

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -164,6 +164,7 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
     table[EVMC_SHANGHAI][OP_PUSH0] = 2;
 
     table[EVMC_CANCUN] = table[EVMC_SHANGHAI];
+    table[EVMC_CANCUN][OP_MCOPY] = 3;
     table[EVMC_CANCUN][OP_DUPN] = 3;
     table[EVMC_CANCUN][OP_SWAPN] = 3;
     table[EVMC_CANCUN][OP_RJUMP] = 2;
@@ -375,6 +376,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
 
     table[OP_DUPN] = {"DUPN", 1, false, 0, 1, EVMC_CANCUN};
     table[OP_SWAPN] = {"SWAPN", 1, false, 0, 0, EVMC_CANCUN};
+    table[OP_MCOPY] = {"MCOPY", 0, false, 3, -3, EVMC_CANCUN};
 
     table[OP_CREATE] = {"CREATE", 0, false, 3, -2, EVMC_FRONTIER};
     table[OP_CALL] = {"CALL", 0, false, 7, -6, EVMC_FRONTIER};

--- a/lib/evmone/instructions_xmacro.hpp
+++ b/lib/evmone/instructions_xmacro.hpp
@@ -226,7 +226,7 @@
     ON_OPCODE_UNDEFINED(0xb4)                               \
     ON_OPCODE_IDENTIFIER(OP_DUPN, dupn)                     \
     ON_OPCODE_IDENTIFIER(OP_SWAPN, swapn)                   \
-    ON_OPCODE_UNDEFINED(0xb7)                               \
+    ON_OPCODE_IDENTIFIER(OP_MCOPY, mcopy)                   \
     ON_OPCODE_UNDEFINED(0xb8)                               \
     ON_OPCODE_UNDEFINED(0xb9)                               \
     ON_OPCODE_UNDEFINED(0xba)                               \

--- a/test/unittests/instructions_test.cpp
+++ b/test/unittests/instructions_test.cpp
@@ -110,6 +110,7 @@ constexpr bool instruction_only_in_evmone(evmc_revision rev, Opcode op) noexcept
     case OP_RETF:
     case OP_DUPN:
     case OP_SWAPN:
+    case OP_MCOPY:
         return true;
     default:
         return false;

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -234,6 +234,11 @@ inline bytecode mstore8(bytecode index, bytecode value)
     return value + index + OP_MSTORE8;
 }
 
+inline bytecode mcopy(bytecode dst, bytecode src, bytecode length)
+{
+    return length + src + dst + OP_MCOPY;
+}
+
 inline bytecode jump(bytecode target)
 {
     return target + OP_JUMP;


### PR DESCRIPTION
Implements [EIP-5656: Memory copying instruction](https://eips.ethereum.org/EIPS/eip-5656).