### PR TITLE
statetest: Workaround GCC 13 -Wdangling-reference

### DIFF
--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -345,7 +345,7 @@ static void from_json(const json::json& j, StateTransitionTest& o)
     if (!j.is_object() || j.empty())
         throw std::invalid_argument{"JSON test must be an object with single key of the test name"};
 
-    const auto& j_t = j.begin().value();  // Content is in a dict with the test name.
+    const auto& j_t = *j.begin();  // Content is in a dict with the test name.
 
     o.pre_state = from_json<state::State>(j_t.at("pre"));
 


### PR DESCRIPTION
GCC 13 has added new warning "dangling-reference" and it causes a lot of false positives.

See
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109642
- https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=6b927b1297e66e26e62e722bf15c921dcbbd25b9
- https://twitter.com/vzverovich/status/1654845759395893248