### PR TITLE
Add output operator for EOFValidationError to be used by Google.Test

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <limits>
 #include <numeric>
+#include <ostream>
 #include <span>
 #include <stack>
 #include <variant>
@@ -609,5 +610,11 @@ std::string_view get_error_message(EOFValidationError err) noexcept
         return "impossible";
     }
     return "<unknown>";
+}
+
+std::ostream& operator<<(std::ostream& os, EOFValidationError err) noexcept
+{
+    os << get_error_message(err);
+    return os;
 }
 }  // namespace evmone

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -104,6 +104,9 @@ enum class EOFValidationError
 /// Returns the error message corresponding to an error code.
 [[nodiscard]] EVMC_EXPORT std::string_view get_error_message(EOFValidationError err) noexcept;
 
+/// Output operator for EOFValidationError.
+EVMC_EXPORT std::ostream& operator<<(std::ostream& os, EOFValidationError err) noexcept;
+
 /// Loads big endian int16_t from data. Unsafe.
 /// TODO: Move it to intx
 inline int16_t read_int16_be(auto it) noexcept


### PR DESCRIPTION
This makes EOF validation tests output better failures.