### PR TITLE
Move CALLF immediate argument validation to validate_instructions()

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -224,6 +224,13 @@ EOFValidationError validate_instructions(
             if (i >= code.size())
                 return EOFValidationError::truncated_instruction;
         }
+        else if (op == OP_CALLF)
+        {
+            const auto fid = read_uint16_be(&code[i + 1]);
+            if (fid >= header.types.size())
+                return EOFValidationError::invalid_code_section_index;
+            i += 2;
+        }
         else if (op == OP_DATALOADN)
         {
             const auto index = read_uint16_be(&code[i + 1]);
@@ -327,9 +334,6 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
         if (opcode == OP_CALLF)
         {
             const auto fid = read_uint16_be(&code[i + 1]);
-
-            if (fid >= code_types.size())
-                return EOFValidationError::invalid_code_section_index;
 
             stack_height_required = static_cast<int8_t>(code_types[fid].inputs);
             stack_height_change =

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -725,6 +725,15 @@ TEST(eof_valication, max_stack_heigh)
     }
 }
 
+TEST(eof_validation, EOF1_callf_truncated)
+{
+    EXPECT_EQ(validate_eof("EF0001 010004 0200010001 030000 00 00000000 B0"),
+        EOFValidationError::truncated_instruction);
+
+    EXPECT_EQ(validate_eof("EF0001 010004 0200010002 030000 00 00000000 B000"),
+        EOFValidationError::truncated_instruction);
+}
+
 TEST(eof_validation, callf_invalid_code_section_index)
 {
     EXPECT_EQ(validate_eof("EF0001 010004 0200010004 030000 00 00000000 b0000100"),


### PR DESCRIPTION
Based on #663 

Validating immediate argument is of `CALLF` shouldn't be part of stack validation, but rather instruction validation.

`DATALOADN` and `RJUMPV` (`max_offset`) arguments are already validated in `validate_instructions()` and #553 adds `CREATE3` and `RETURNCONTRACT` there too, so it makes sense to have all these similar validations in one place. 