### PR TITLE
Blockchain tests support: Do not expect tx sender always exist

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(
     state_transition_block_test.cpp
     state_transition_create_test.cpp
     state_transition_eof_test.cpp
+    state_transition_tx_test.cpp
     state_tx_test.cpp
     statetest_loader_block_info_test.cpp
     statetest_loader_test.cpp

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -5,6 +5,7 @@
 
 #include <evmone/evmone.h>
 #include <gtest/gtest.h>
+#include <test/state/errors.hpp>
 #include <test/state/host.hpp>
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
@@ -43,6 +44,10 @@ protected:
 
     struct Expectation
     {
+        /// The transaction is invalid because of the given error.
+        /// The rest of Expectation is ignored if the error is expected.
+        ErrorCode tx_error = SUCCESS;
+
         evmc_status_code status = EVMC_SUCCESS;
         std::optional<int64_t> gas_used;
 

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -1,0 +1,38 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "state_transition.hpp"
+
+using namespace evmc::literals;
+using namespace evmone::test;
+
+TEST_F(state_transition, tx_non_existing_sender)
+{
+    tx.to = To;
+    tx.max_gas_price = 0;
+    tx.max_priority_gas_price = 0;
+    tx.nonce = 0;
+    block.base_fee = 0;
+    pre.get_accounts().erase(Sender);
+
+    rev = EVMC_BERLIN;
+
+    expect.status = EVMC_SUCCESS;
+    expect.post.at(Sender).nonce = 1;
+    expect.post.at(Coinbase).exists = false;
+}
+
+TEST_F(state_transition, invalid_tx_non_existing_sender)
+{
+    tx.to = To;
+    tx.max_gas_price = 1;
+    tx.max_priority_gas_price = 1;
+    tx.nonce = 0;
+    block.base_fee = 1;
+    pre.get_accounts().erase(Sender);
+
+    rev = EVMC_BERLIN;
+
+    expect.tx_error = INSUFFICIENT_FUNDS;
+}

--- a/test/unittests/state_tx_test.cpp
+++ b/test/unittests/state_tx_test.cpp
@@ -7,11 +7,10 @@
 #include <test/state/state.hpp>
 
 using namespace evmone::state;
+using namespace evmc::literals;
 
 TEST(state_tx, validate_nonce)
 {
-    using evmc::operator""_address;
-
     const BlockInfo bi{.gas_limit = 0x989680,
         .coinbase = 0x01_address,
         .prev_randao = {},
@@ -43,4 +42,42 @@ TEST(state_tx, validate_nonce)
     EXPECT_EQ(
         std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000)).message(),
         "nonce too high");
+}
+
+TEST(state_tx, validate_sender)
+{
+    BlockInfo bi{.gas_limit = 0x989680,
+        .coinbase = 0x01_address,
+        .prev_randao = {},
+        .base_fee = 0,
+        .withdrawals = {}};
+    const Account acc{.nonce = 0, .balance = 0};
+    Transaction tx{
+        .data = {},
+        .gas_limit = 60000,
+        .max_gas_price = bi.base_fee,
+        .max_priority_gas_price = 0,
+        .sender = 0x02_address,
+        .to = {},
+        .value = 0,
+        .access_list = {},
+        .nonce = 0,
+        .r = 0,
+        .s = 0,
+    };
+
+    ASSERT_FALSE(
+        holds_alternative<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000)));
+
+    bi.base_fee = 1;
+
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000)).message(),
+        "max fee per gas less than block base fee");
+
+    tx.max_gas_price = bi.base_fee;
+
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000)).message(),
+        "insufficient funds for gas * price + value");
 }


### PR DESCRIPTION
Properly handle the case when the account of transaction sender doesn't
exist. In pre-Byzantium revisions such transaction could be valid with
gas price 0. In any case the transaction validation should not crash.

Fixes https://github.com/ethereum/evmone/issues/692.