### PR TITLE
test: Workaround GCC 12 warning at -O3

### DIFF
--- a/test/unittests/state_mpt_hash_test.cpp
+++ b/test/unittests/state_mpt_hash_test.cpp
@@ -45,7 +45,7 @@ TEST(state_mpt_hash, two_accounts)
     Account acc2;
     acc2.nonce = 1;
     acc2.balance = -2_u256;
-    acc2.code = {0x00};
+    acc2.code = bytes{0x00};  // Note: `= {0x00}` causes GCC 12 warning at -O3.
     acc2.storage[0x01_bytes32] = {0xfe_bytes32};
     acc2.storage[0x02_bytes32] = {0xfd_bytes32};
     accounts[0x01_address] = acc2;


### PR DESCRIPTION
When compiling `code = {0x00}` with GCC 12 -O3 it detects a false positive buffer overflow and gives a warning. Workaround it by using explicit `code = bytes{0x00}`.

```
/usr/include/c++/12/bits/char_traits.h:268:23: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets -4611686018427387902 and [-4611686018427387903, 4611686018427387904] may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  268 |       __builtin_memcpy(__s1, __s2, __n * sizeof(char_type));
      |       ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The warning is gone in GCC 13.