### PR TITLE
t8n: Add withdrawalsRoot to result

### DIFF
--- a/test/state/mpt_hash.cpp
+++ b/test/state/mpt_hash.cpp
@@ -53,4 +53,15 @@ hash256 mpt_hash(std::span<const TransactionReceipt> receipts)
     return trie.hash();
 }
 
+hash256 mpt_hash(std::span<const Withdrawal> withdrawals)
+{
+    MPT trie;
+    for (size_t i = 0; i < withdrawals.size(); ++i)
+        trie.insert(
+            rlp::encode(i), rlp::encode_tuple(withdrawals[i].index, withdrawals[i].validatorIndex,
+                                withdrawals[i].recipient, withdrawals[i].amount_in_gwei));
+
+    return trie.hash();
+}
+
 }  // namespace evmone::state

--- a/test/state/mpt_hash.hpp
+++ b/test/state/mpt_hash.hpp
@@ -12,6 +12,7 @@ namespace evmone::state
 struct Account;
 struct Transaction;
 struct TransactionReceipt;
+struct Withdrawal;
 
 /// Computes Merkle Patricia Trie root hash for the given collection of state accounts.
 hash256 mpt_hash(const std::unordered_map<address, Account>& accounts);
@@ -21,5 +22,8 @@ hash256 mpt_hash(std::span<const Transaction> transactions);
 
 /// Computes Merkle Patricia Trie root hash for the given collection of transactions receipts.
 hash256 mpt_hash(std::span<const TransactionReceipt> receipts);
+
+/// Computes Merkle Patricia Trie root hash for the given collection of withdrawals.
+hash256 mpt_hash(std::span<const Withdrawal> withdrawals);
 
 }  // namespace evmone::state

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -68,6 +68,8 @@ public:
 
 struct Withdrawal
 {
+    uint64_t index = 0;
+    uint64_t validatorIndex = 0;
     address recipient;
     uint64_t amount_in_gwei = 0;  ///< The amount is denominated in gwei.
 

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -176,7 +176,9 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
     {
         for (const auto& withdrawal : *withdrawals_it)
         {
-            withdrawals.push_back({from_json<evmc::address>(withdrawal.at("address")),
+            withdrawals.push_back({from_json<uint64_t>(withdrawal.at("index")),
+                from_json<uint64_t>(withdrawal.at("validatorIndex")),
+                from_json<evmc::address>(withdrawal.at("address")),
                 from_json<uint64_t>(withdrawal.at("amount"))});
         }
     }

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -68,6 +68,7 @@ int main(int argc, const char* argv[])
 
         state::BlockInfo block;
         state::State state;
+        bool withdrawals_enabled = false;
 
         if (!alloc_file.empty())
         {
@@ -78,6 +79,8 @@ int main(int argc, const char* argv[])
         {
             const auto j = json::json::parse(std::ifstream{env_file});
             block = test::from_json<state::BlockInfo>(j);
+            if (j.contains("withdrawals"))
+                withdrawals_enabled = true;
         }
 
         json::json j_result;
@@ -172,6 +175,8 @@ int main(int argc, const char* argv[])
 
         j_result["logsBloom"] = hex0x(compute_bloom_filter(receipts));
         j_result["receiptsRoot"] = hex0x(state::mpt_hash(receipts));
+        if (withdrawals_enabled)
+            j_result["withdrawalsRoot"] = hex0x(state::mpt_hash(block.withdrawals));
         j_result["txRoot"] = hex0x(state::mpt_hash(transactions));
         j_result["gasUsed"] = hex0x(cumulative_gas_used);
 

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -11,7 +11,7 @@ TEST_F(state_transition, block_apply_withdrawal)
 {
     static constexpr auto withdrawal_address = 0x8888_address;
 
-    block.withdrawals = {{withdrawal_address, 3}};
+    block.withdrawals = {{0, 0, withdrawal_address, 3}};
     tx.to = To;
     expect.post[withdrawal_address].balance = intx::uint256{3} * 1'000'000'000;
 }


### PR DESCRIPTION
Adds `withdrawalsRoot` to `evmone-t8n`'s output result. 

When `evmone-t8n` support was initially added to [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests), the framework didn't verify all block header fields. This was subsequently added in https://github.com/ethereum/execution-spec-tests/pull/217, which causes test cases executed for `fork=Shanghai` to fail with `evmone-t8n`. This PR remedies the fails by adding the `withdrawalsRoot` to t8n's output.

With this PR, all tests pass against https://github.com/ethereum/execution-spec-tests/commit/af3d64f203dba49f9e9443d48a750c8849e98d1d and the `withdrawalsRoot` matches that of `geth 1.12.2-stable-bed84606`.