### PR TITLE
state: Support block hashes

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -320,9 +320,10 @@ evmc_tx_context Host::get_tx_context() const noexcept
 
 bytes32 Host::get_block_hash(int64_t block_number) const noexcept
 {
-    (void)block_number;
-    // TODO: This is not properly implemented, but only single state test requires BLOCKHASH
-    //       and is fine with any value.
+    if (const auto& it = m_block.known_block_hashes.find(block_number);
+        it != m_block.known_block_hashes.end())
+        return it->second;
+
     return {};
 }
 

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -87,6 +87,7 @@ struct BlockInfo
     bytes32 prev_randao;
     uint64_t base_fee = 0;
     std::vector<Withdrawal> withdrawals;
+    std::unordered_map<int64_t, hash256> known_block_hashes = {};
 };
 
 using AccessList = std::vector<std::pair<address, std::vector<bytes32>>>;

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -181,10 +181,17 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
         }
     }
 
+    std::unordered_map<int64_t, hash256> block_hashes;
+    if (const auto block_hashes_it = j.find("blockHashes"); block_hashes_it != j.end())
+    {
+        for (const auto& [j_num, j_hash] : block_hashes_it->items())
+            block_hashes[from_json<int64_t>(j_num)] = from_json<hash256>(j_hash);
+    }
+
     return {from_json<int64_t>(j.at("currentNumber")), from_json<int64_t>(j.at("currentTimestamp")),
         from_json<int64_t>(j.at("currentGasLimit")),
         from_json<evmc::address>(j.at("currentCoinbase")), difficulty, base_fee,
-        std::move(withdrawals)};
+        std::move(withdrawals), std::move(block_hashes)};
 }
 
 template <>

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -2,6 +2,7 @@
 // Copyright 2023 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../utils/bytecode.hpp"
 #include "state_transition.hpp"
 
 using namespace evmc::literals;
@@ -14,4 +15,22 @@ TEST_F(state_transition, block_apply_withdrawal)
     block.withdrawals = {{withdrawal_address, 3}};
     tx.to = To;
     expect.post[withdrawal_address].balance = intx::uint256{3} * 1'000'000'000;
+}
+
+TEST_F(state_transition, known_block_hash)
+{
+    block.known_block_hashes = {
+        {1, 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32},
+        {2, 0x0000000000000000000000000000000000000000000000000000000000000111_bytes32}};
+    block.number = 5;
+
+    const auto code =
+        push(1) + OP_BLOCKHASH + push(0) + OP_SSTORE + push(2) + OP_BLOCKHASH + push(1) + OP_SSTORE;
+
+    tx.to = To;
+    pre.insert(*tx.to, {.nonce = 1, .code = code});
+    expect.post[To].storage[0x00_bytes32] =
+        0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32;
+    expect.post[To].storage[0x01_bytes32] =
+        0x0000000000000000000000000000000000000000000000000000000000000111_bytes32;
 }

--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -17,7 +17,11 @@ TEST(statetest_loader, block_info)
             "currentTimestamp": "0",
             "currentBaseFee": "7",
             "currentRandom": "0x00",
-            "withdrawals": []
+            "withdrawals": [],
+            "blockHashes": {
+                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
+                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
+            }
         })";
 
     const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
@@ -27,6 +31,10 @@ TEST(statetest_loader, block_info)
     EXPECT_EQ(bi.base_fee, 7);
     EXPECT_EQ(bi.timestamp, 0);
     EXPECT_EQ(bi.number, 0);
+    EXPECT_EQ(bi.known_block_hashes.at(0),
+        0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
+    EXPECT_EQ(bi.known_block_hashes.at(1),
+        0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
 }
 
 TEST(statetest_loader, block_info_hex)


### PR DESCRIPTION
Implement loading JSON `block_number => block_hash` map and expose it to `Host::get_block_hash()` via `BlockInfo`.