### PR TITLE
Build and test riscv32

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -86,6 +86,14 @@ commands:
           command: |
             curl -L https://github.com/Kitware/CMake/releases/download/v<<parameters.version>>/cmake-<<parameters.version>>-linux-x86_64.tar.gz | sudo tar -xz --strip=1
 
+  install_riscv_toolchain:
+    steps:
+      - run:
+          name: "Install RISC-V Toolchain"
+          working_directory: /usr/local
+          command: |
+            curl -L https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/2023.07.07/riscv32-glibc-ubuntu-22.04-llvm-nightly-2023.07.07-nightly.tar.gz | sudo tar -xz
+
   checkout_submodules:
     steps:
       - run:
@@ -659,6 +667,16 @@ jobs:
           working_directory: ~/build
           command: (! qemu-x86_64-static bin/evmone-unittests 2>&1) | grep "CPU does not support"
 
+  riscv32:
+    executor: linux-gcc-latest
+    environment:
+      BUILD_TYPE: Release
+      CMAKE_OPTIONS: -DCMAKE_TOOLCHAIN_FILE=~/project/cmake/toolchains/riscv32.cmake
+    steps:
+      - install_riscv_toolchain
+      - build
+      - test
+
 
 
 workflows:
@@ -705,4 +723,5 @@ workflows:
       # - xcode-min
       - gcc-32bit
       - x86-64-v1
+      - riscv32
       - fuzzing

--- a/cmake/toolchains/riscv32.cmake
+++ b/cmake/toolchains/riscv32.cmake
@@ -1,0 +1,19 @@
+# evmone: Ethereum Virtual Machine
+# Copyright 2023 Pawel Bylica.
+# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+
+set(RISCV /usr/local/riscv)
+
+set(CMAKE_SYSTEM_PROCESSOR riscv32)
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_C_COMPILER ${RISCV}/bin/clang)
+set(CMAKE_CXX_COMPILER ${RISCV}/bin/clang++)
+
+set(CMAKE_CXX_FLAGS_INIT -stdlib=libc++)
+
+set(CMAKE_FIND_ROOT_PATH ${RISCV}/sysroot)
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+set(CMAKE_CROSSCOMPILING_EMULATOR qemu-riscv32-static;-L;${CMAKE_FIND_ROOT_PATH})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -7,7 +7,7 @@ set(PREFIX ${PROJECT_NAME}/integration)
 get_target_property(EVMONE_LIB_TYPE evmone TYPE)
 if(EVMONE_LIB_TYPE STREQUAL SHARED_LIBRARY)
 
-    add_test(NAME ${PREFIX}/histogram COMMAND $<TARGET_FILE:evmc::tool> --vm $<TARGET_FILE:evmone>,histogram run 6000808080800101010200)
+    add_test(NAME ${PREFIX}/histogram COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,histogram run 6000808080800101010200)
     set_tests_properties(
         ${PREFIX}/histogram PROPERTIES PASS_REGULAR_EXPRESSION
         "--- # HISTOGRAM depth=0
@@ -19,7 +19,7 @@ PUSH1,1
 DUP1,4
 ")
 
-    add_test(NAME ${PREFIX}/trace COMMAND $<TARGET_FILE:evmc::tool> --vm $<TARGET_FILE:evmone>,trace run 60006002800103)
+    add_test(NAME ${PREFIX}/trace COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,trace run 60006002800103)
     set_tests_properties(
         ${PREFIX}/trace PROPERTIES PASS_REGULAR_EXPRESSION
         "\"pc\":0,\"op\":96,\"gas\":\"0xf4240\",\"gasCost\":\"0x3\",\"memSize\":0,\"stack\":\\[\\],\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\"}


### PR DESCRIPTION
This uses a pre-built RISC-V toolchain to build and test evmone.

This compiles evmone and dependencies to `rv32imafdc` with `ilp32d` ABI. I.e. this target has hardware support for floating point.

Our preference would be to compile for `rv32imac` with `ilp32` ABI. However, there are some obstacles to get there:

1. The pre-built toolchain is built for `ilp32d`. We would need to build the toolchain ourselves.
2. We can hack it by setting `-march=rv32imac -mabi=ilp32d`. The compiler is not very happy about using architecture with incompatible ABI but it will proceed anyway. Unfortunately, the dependencies have some floating-point code so we also need to provide soft-float library. I was not able to make it build so far.