### PR TITLE
test: Capture the trace of state_transition

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(
     state_transition_block_test.cpp
     state_transition_create_test.cpp
     state_transition_eof_test.cpp
+    state_transition_trace_test.cpp
     state_transition_transient_storage_test.cpp
     state_transition_tx_test.cpp
     state_tx_test.cpp

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -32,6 +32,7 @@ protected:
     static constexpr auto Coinbase = 0xc014bace_address;
 
     static inline evmc::VM vm{evmc_create_evmone()};
+    static inline evmc::VM tracing_vm{evmc_create_evmone(), {{"trace", "1"}}};
 
     struct ExpectedAccount
     {
@@ -48,10 +49,18 @@ protected:
         /// The rest of Expectation is ignored if the error is expected.
         ErrorCode tx_error = SUCCESS;
 
+        /// The expected EVM status code of the transaction execution.
         evmc_status_code status = EVMC_SUCCESS;
+
+        /// The expected amount of gas used by the transaction.
         std::optional<int64_t> gas_used;
 
+        /// The expected post-execution state.
         std::unordered_map<address, ExpectedAccount> post;
+
+        /// The expected EVM execution trace. If not empty transaction execution will be performed
+        /// with tracing enabled and the output compared.
+        std::string_view trace;
     };
 
 

--- a/test/unittests/state_transition_trace_test.cpp
+++ b/test/unittests/state_transition_trace_test.cpp
@@ -1,0 +1,24 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "state_transition.hpp"
+#include <test/utils/bytecode.hpp>
+
+using namespace evmc::literals;
+using namespace evmone::test;
+
+TEST_F(state_transition, trace_example)
+{
+    tx.to = To;
+    pre.insert(To, {.code = revert(0, 1)});
+
+    expect.status = EVMC_REVERT;
+    expect.post[To].exists = true;
+
+    expect.trace = R"(
+{"pc":0,"op":96,"gas":"0xef038","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":2,"op":96,"gas":"0xef035","gasCost":"0x3","memSize":0,"stack":["0x1"],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":4,"op":253,"gas":"0xef032","gasCost":"0x0","memSize":0,"stack":["0x1","0x0"],"depth":1,"refund":0,"opName":"REVERT"}
+)";
+}


### PR DESCRIPTION
Optionally (when `expect.trace = "<trace string>"`) is used capture the transaction execution trace in state_transition and compare it with the expected one.

Replaces #699.