### PR TITLE
ci: Show codecov report even if CI fails

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: false
+
 comment:
   layout: "diff, flags, files"
 


### PR DESCRIPTION
Because the Windows CI is currently failing due to under-the-hood MSVC compiler upgrade do not hold Codecov reports.