### PR TITLE
Upgrade EVMC to 11.0.0-alpha.2

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -315,7 +315,8 @@ evmc_tx_context Host::get_tx_context() const noexcept
         m_block.prev_randao,
         0x01_bytes32,  // Chain ID is expected to be 1.
         uint256be{m_block.base_fee},
-        nullptr,  // TODO: Add blob hashes.
+        uint256be{},  // TODO: Add blob base fee.
+        nullptr,      // TODO: Add blob hashes.
         0,
     };
 }


### PR DESCRIPTION
This enables `BLOBBASEFEE` implementation and fixes small issues with CMake cross-compilation.