### PR TITLE
Implement `BLOBBASEFEE` instruction from EIP-7516

### DIFF
--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -510,6 +510,11 @@ inline void blobhash(StackTop stack, ExecutionState& state) noexcept
                 0;
 }
 
+inline void blobbasefee(StackTop stack, ExecutionState& state) noexcept
+{
+    stack.push(intx::be::load<uint256>(state.get_tx_context().blob_base_fee));
+}
+
 inline Result extcodesize(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
 {
     auto& x = stack.top();

--- a/lib/evmone/instructions_opcodes.hpp
+++ b/lib/evmone/instructions_opcodes.hpp
@@ -70,6 +70,7 @@ enum Opcode : uint8_t
     OP_SELFBALANCE = 0x47,
     OP_BASEFEE = 0x48,
     OP_BLOBHASH = 0x49,
+    OP_BLOBBASEFEE = 0x4a,
 
     OP_POP = 0x50,
     OP_MLOAD = 0x51,

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -165,6 +165,7 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
 
     table[EVMC_CANCUN] = table[EVMC_SHANGHAI];
     table[EVMC_CANCUN][OP_BLOBHASH] = 3;
+    table[EVMC_CANCUN][OP_BLOBBASEFEE] = 2;
     table[EVMC_CANCUN][OP_TLOAD] = warm_storage_read_cost;
     table[EVMC_CANCUN][OP_TSTORE] = warm_storage_read_cost;
     table[EVMC_CANCUN][OP_MCOPY] = 3;
@@ -289,6 +290,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_SELFBALANCE] = {"SELFBALANCE", 0, false, 0, 1, EVMC_ISTANBUL};
     table[OP_BASEFEE] = {"BASEFEE", 0, false, 0, 1, EVMC_LONDON};
     table[OP_BLOBHASH] = {"BLOBHASH", 0, false, 1, 0, EVMC_CANCUN};
+    table[OP_BLOBBASEFEE] = {"BLOBBASEFEE", 0, false, 0, 1, EVMC_CANCUN};
 
     table[OP_POP] = {"POP", 0, false, 1, -1, EVMC_FRONTIER};
     table[OP_MLOAD] = {"MLOAD", 0, false, 1, 0, EVMC_FRONTIER};

--- a/lib/evmone/instructions_xmacro.hpp
+++ b/lib/evmone/instructions_xmacro.hpp
@@ -110,7 +110,7 @@
     ON_OPCODE_IDENTIFIER(OP_SELFBALANCE, selfbalance)       \
     ON_OPCODE_IDENTIFIER(OP_BASEFEE, basefee)               \
     ON_OPCODE_IDENTIFIER(OP_BLOBHASH, blobhash)             \
-    ON_OPCODE_UNDEFINED(0x4a)                               \
+    ON_OPCODE_IDENTIFIER(OP_BLOBBASEFEE, blobbasefee)       \
     ON_OPCODE_UNDEFINED(0x4b)                               \
     ON_OPCODE_UNDEFINED(0x4c)                               \
     ON_OPCODE_UNDEFINED(0x4d)                               \

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(
     evm_eip3855_push0_test.cpp
     evm_eip3860_initcode_test.cpp
     evm_eip4844_blobhash_test.cpp
+    evm_eip7516_blobbasefee_test.cpp
     evm_eof_test.cpp
     evm_eof_calls_test.cpp
     evm_eof_function_test.cpp

--- a/test/unittests/evm_eip7516_blobbasefee_test.cpp
+++ b/test/unittests/evm_eip7516_blobbasefee_test.cpp
@@ -1,0 +1,44 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+/// This file contains EVM unit tests for EIP-7516: "BLOBBASEFEE opcode"
+/// https://eips.ethereum.org/EIPS/eip-7516
+
+#include "evm_fixture.hpp"
+
+using namespace evmc::literals;
+using namespace intx;
+using evmone::test::evm;
+
+TEST_P(evm, blobbasefee_pre_cancun)
+{
+    rev = EVMC_SHANGHAI;
+    const auto code = bytecode{OP_BLOBBASEFEE};
+
+    execute(code);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, blobbasefee_1)
+{
+    rev = EVMC_CANCUN;
+    host.tx_context.blob_base_fee = 0x01_bytes32;
+
+    execute(bytecode{} + OP_BLOBBASEFEE);
+    EXPECT_GAS_USED(EVMC_SUCCESS, 2);
+
+    execute(bytecode{} + OP_BLOBBASEFEE + ret_top());
+    EXPECT_GAS_USED(EVMC_SUCCESS, 17);
+    EXPECT_OUTPUT_INT(1);
+}
+
+TEST_P(evm, blobbasefee_dede)
+{
+    rev = EVMC_CANCUN;
+    host.tx_context.blob_base_fee =
+        0x8ededededededededededededededededededededededededededededededed1_bytes32;
+
+    execute(bytecode{} + OP_BLOBBASEFEE + ret_top());
+    EXPECT_OUTPUT_INT(0x8ededededededededededededededededededededededededededededededed1_u256);
+}

--- a/test/unittests/instructions_test.cpp
+++ b/test/unittests/instructions_test.cpp
@@ -108,6 +108,7 @@ constexpr bool instruction_only_in_evmone(evmc_revision rev, Opcode op) noexcept
     switch (op)
     {
     case OP_BLOBHASH:
+    case OP_BLOBBASEFEE:
     case OP_RJUMP:
     case OP_RJUMPI:
     case OP_RJUMPV:


### PR DESCRIPTION
Implement `BLOBBASEFEE` instruction from [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516): "BLOBBASEFEE opcode".