### PR TITLE
Support blob transaction type (EIP-4844)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -515,7 +515,8 @@ jobs:
           command: >
             EVMONE_PRECOMPILES_STUB=~/project/test/state/precompiles_stub.json 
             bin/evmone-blockchaintest
-            ~/tests/EIPTests/BlockchainTests/bcEIP1153-transientStorage
+            --gtest_filter='-*StateTests/stEOF/*.*'
+            ~/tests/EIPTests/BlockchainTests/
       - download_execution_tests:
           repo: ipsilon/tests
           rev: eof-nrf-20231128

--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -36,6 +36,7 @@ struct BlockHeader
     hash256 transactions_root;
     hash256 withdrawal_root;
     hash256 parent_beacon_block_root;
+    uint64_t excess_blob_gas;
 };
 
 struct TestBlock

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -41,6 +41,7 @@ BlockHeader from_json<BlockHeader>(const json::json& j)
         .transactions_root = from_json<hash256>(j.at("transactionsTrie")),
         .withdrawal_root = load_if_exists<hash256>(j, "withdrawalsRoot"),
         .parent_beacon_block_root = load_if_exists<hash256>(j, "parentBeaconBlockRoot"),
+        .excess_blob_gas = load_if_exists<uint64_t>(j, "excessBlobGas"),
     };
 }
 

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -61,6 +61,8 @@ static TestBlock load_test_block(const json::json& j, evmc_revision rev)
         tb.block_info.prev_randao = tb.expected_block_header.prev_randao;
         tb.block_info.base_fee = tb.expected_block_header.base_fee_per_gas;
         tb.block_info.parent_beacon_block_root = tb.expected_block_header.parent_beacon_block_root;
+        tb.block_info.blob_base_fee =
+            compute_blob_gas_price(tb.expected_block_header.excess_blob_gas);
 
         // Override prev_randao with difficulty pre-Merge
         if (rev < EVMC_PARIS)

--- a/test/state/errors.hpp
+++ b/test/state/errors.hpp
@@ -23,6 +23,10 @@ enum ErrorCode : int
     GAS_LIMIT_REACHED,
     SENDER_NOT_EOA,
     INIT_CODE_SIZE_LIMIT_EXCEEDED,
+    CREATE_BLOB_TX,
+    EMPTY_BLOB_HASHES_LIST,
+    INVALID_BLOB_HASH_VERSION,
+    BLOB_GAS_LIMIT_EXCEEDED,
     UNKNOWN_ERROR,
 };
 
@@ -40,7 +44,7 @@ inline const std::error_category& evmone_category() noexcept
             case SUCCESS:
                 return "";
             case INTRINSIC_GAS_TOO_LOW:
-                return "intrinsic gas too low:";
+                return "intrinsic gas too low";
             case TX_TYPE_NOT_SUPPORTED:
                 return "transaction type not supported";
             case INSUFFICIENT_FUNDS:
@@ -61,6 +65,14 @@ inline const std::error_category& evmone_category() noexcept
                 return "sender not an eoa:";
             case INIT_CODE_SIZE_LIMIT_EXCEEDED:
                 return "max initcode size exceeded";
+            case CREATE_BLOB_TX:
+                return "blob transaction must not be a create transaction";
+            case EMPTY_BLOB_HASHES_LIST:
+                return "empty blob hashes list";
+            case INVALID_BLOB_HASH_VERSION:
+                return "invalid blob hash version";
+            case BLOB_GAS_LIMIT_EXCEEDED:
+                return "blob gas limit exceeded";
             case UNKNOWN_ERROR:
                 return "Unknown error";
             default:

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -335,7 +335,7 @@ evmc_tx_context Host::get_tx_context() const noexcept
         m_block.prev_randao,
         0x01_bytes32,  // Chain ID is expected to be 1.
         uint256be{m_block.base_fee},
-        uint256be{},  // TODO: Add blob base fee.
+        intx::be::store<uint256be>(m_block.blob_base_fee),
         nullptr,      // TODO: Add blob hashes.
         0,
     };

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -336,8 +336,8 @@ evmc_tx_context Host::get_tx_context() const noexcept
         0x01_bytes32,  // Chain ID is expected to be 1.
         uint256be{m_block.base_fee},
         intx::be::store<uint256be>(m_block.blob_base_fee),
-        nullptr,      // TODO: Add blob hashes.
-        0,
+        m_tx.blob_hashes.data(),
+        m_tx.blob_hashes.size(),
     };
 }
 

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -104,6 +104,10 @@ struct BlockInfo
     /// for computing the blob gas price in the current block.
     uint64_t excess_blob_gas = 0;
 
+    /// The blob gas price parameter from EIP-4844.
+    /// This values is not stored in block headers directly but computed from excess_blob_gas.
+    intx::uint256 blob_base_fee = 0;
+
     std::vector<Ommer> ommers;
     std::vector<Withdrawal> withdrawals;
     std::unordered_map<int64_t, hash256> known_block_hashes;
@@ -179,6 +183,9 @@ struct TransactionReceipt
     /// Root hash of the state after this transaction. Used only in old pre-Byzantium transactions.
     std::optional<bytes32> post_state;
 };
+
+/// Computes the current blob gas price based on the excess blob gas.
+intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept;
 
 /// Finalize state after applying a "block" of transactions.
 ///

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -99,6 +99,11 @@ struct BlockInfo
     bytes32 prev_randao;
     hash256 parent_beacon_block_root;
     uint64_t base_fee = 0;
+
+    /// The "excess blob gas" parameter from EIP-4844
+    /// for computing the blob gas price in the current block.
+    uint64_t excess_blob_gas = 0;
+
     std::vector<Ommer> ommers;
     std::vector<Withdrawal> withdrawals;
     std::unordered_map<int64_t, hash256> known_block_hashes;

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -121,4 +121,7 @@ inline std::string hex0x(const bytes_view& v)
     return "0x" + evmc::hex(v);
 }
 
+/// Computes the current blob gas price based on the excess blob gas.
+intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept;
+
 }  // namespace evmone::test

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -120,8 +120,4 @@ inline std::string hex0x(const bytes_view& v)
 {
     return "0x" + evmc::hex(v);
 }
-
-/// Computes the current blob gas price based on the excess blob gas.
-intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept;
-
 }  // namespace evmone::test

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -249,6 +249,7 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
         .parent_beacon_block_root = {},
         .base_fee = base_fee,
         .excess_blob_gas = excess_blob_gas,
+        .blob_base_fee = state::compute_blob_gas_price(excess_blob_gas),
         .ommers = std::move(ommers),
         .withdrawals = std::move(withdrawals),
         .known_block_hashes = std::move(block_hashes),

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -27,8 +27,8 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
 
             validate_deployed_code(state, rev);
 
-            const auto res =
-                state::transition(state, test.block, tx, rev, vm, test.block.gas_limit);
+            const auto res = state::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
+                state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
 
             // Finalize block with reward 0.
             state::finalize(state, rev, test.block.coinbase, 0, {}, {});

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -165,7 +165,8 @@ int main(int argc, const char* argv[])
                         std::clog.rdbuf(trace_file_output.rdbuf());
                     }
 
-                    auto res = state::transition(state, block, tx, rev, vm, block_gas_left);
+                    // FIXME: Handle blob gas.
+                    auto res = state::transition(state, block, tx, rev, vm, block_gas_left, 0);
 
                     if (holds_alternative<std::error_code>(res))
                     {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
     evmone_test.cpp
     execution_state_test.cpp
     instructions_test.cpp
+    state_block_test.cpp
     state_bloom_filter_test.cpp
     state_difficulty_test.cpp
     state_mpt_hash_test.cpp

--- a/test/unittests/state_block_test.cpp
+++ b/test/unittests/state_block_test.cpp
@@ -1,0 +1,27 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <test/state/state.hpp>
+
+using namespace evmone::state;
+using namespace intx;
+
+TEST(state_block, blob_gas_price)
+{
+    static constexpr uint64_t TARGET_BLOB_GAS_PER_BLOCK = 0x60000;
+
+    EXPECT_EQ(compute_blob_gas_price(0), 1);
+    EXPECT_EQ(compute_blob_gas_price(1), 1);
+    EXPECT_EQ(compute_blob_gas_price(TARGET_BLOB_GAS_PER_BLOCK), 1);
+    EXPECT_EQ(compute_blob_gas_price(TARGET_BLOB_GAS_PER_BLOCK * 2), 1);
+    EXPECT_EQ(compute_blob_gas_price(TARGET_BLOB_GAS_PER_BLOCK * 7), 2);
+
+    EXPECT_EQ(compute_blob_gas_price(10'000'000), 19);
+    EXPECT_EQ(compute_blob_gas_price(100'000'000), 10203769476395);
+
+    // Close to the computation overflowing:
+    EXPECT_EQ(compute_blob_gas_price(400'000'000),
+        10840331274704280429132033759016842817414750029778539_u256);
+}

--- a/test/unittests/state_rlp_test.cpp
+++ b/test/unittests/state_rlp_test.cpp
@@ -457,3 +457,98 @@ TEST(state_rlp, tx_to_rlp_eip2930_with_non_empty_access_list)
     EXPECT_EQ(keccak256(rlp::encode(tx)),
         0xf076e75aa935552e20e5d9fd4d1dda4ff33399ff3d6ac22843ae646f82c385d4_bytes32);
 }
+
+TEST(state_rlp, tx_to_rlp_blob)
+{
+    state::Transaction tx{};
+
+    tx.type = evmone::state::Transaction::Type::blob;
+    tx.data = ""_b;
+    tx.gas_limit = 30000;
+    tx.max_gas_price = 14237787676;
+    tx.max_priority_gas_price = 0;
+    tx.sender = 0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5_address;
+    tx.to = 0x535b918f3724001fd6fb52fcc6cbc220592990a3_address;
+    tx.value = 73360267083380739_u256;
+    tx.access_list = {};
+    tx.nonce = 132949;
+    tx.r = 0x2fe690e16de3534bee626150596573d57cb56d0c2e48a02f64c0a03c1636ce2a_u256;
+    tx.s = 0x4814f3dc7dac2ee153a2456aa3968717af7400972167dfb00b1cce1c23b6dd9f_u256;
+    tx.v = 1;
+    tx.chain_id = 1;
+    tx.max_blob_gas_price = 4;
+    tx.blob_hashes = {0x0111111111111111111111111111111111111111111111111111111111111111_bytes32,
+        0x0122222222222222222222222222222222222222222222222222222222222222_bytes32};
+
+    const auto rlp_rep = rlp::encode(tx);
+    EXPECT_EQ(rlp_rep,
+        "03"
+        "f8b7"
+        "01"
+        "83020755"
+        "80"
+        "850350a3661c"
+        "827530"
+        "94535b918f3724001fd6fb52fcc6cbc220592990a3"
+        "880104a0c63421f803"
+        "80"
+        "c0"
+        "04"
+        "f842"
+        "a00111111111111111111111111111111111111111111111111111111111111111"
+        "a00122222222222222222222222222222222222222222222222222222222222222"
+        "01"
+        "a02fe690e16de3534bee626150596573d57cb56d0c2e48a02f64c0a03c1636ce2a"
+        "a04814f3dc7dac2ee153a2456aa3968717af7400972167dfb00b1cce1c23b6dd9f"_hex);
+}
+
+TEST(state_rlp, tx_to_rlp_blob_invalid_v_value)
+{
+    state::Transaction tx{};
+
+    tx.type = evmone::state::Transaction::Type::blob;
+    tx.data = ""_b;
+    tx.gas_limit = 30000;
+    tx.max_gas_price = 14237787676;
+    tx.max_priority_gas_price = 0;
+    tx.sender = 0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5_address;
+    tx.to = 0x535b918f3724001fd6fb52fcc6cbc220592990a3_address;
+    tx.value = 73360267083380739_u256;
+    tx.access_list = {};
+    tx.nonce = 132949;
+    tx.r = 0x2fe690e16de3534bee626150596573d57cb56d0c2e48a02f64c0a03c1636ce2a_u256;
+    tx.s = 0x4814f3dc7dac2ee153a2456aa3968717af7400972167dfb00b1cce1c23b6dd9f_u256;
+    tx.v = 2;
+    tx.chain_id = 1;
+    tx.max_blob_gas_price = 4;
+    tx.blob_hashes = {0x0111111111111111111111111111111111111111111111111111111111111111_bytes32,
+        0x0122222222222222222222222222222222222222222222222222222222222222_bytes32};
+
+    EXPECT_THAT([tx]() { rlp::encode(tx); },
+        ThrowsMessage<std::invalid_argument>("`v` value for blob transaction must be 0 or 1"));
+}
+
+TEST(state_rlp, tx_to_rlp_blob_invalid_to_value)
+{
+    state::Transaction tx{};
+
+    tx.type = evmone::state::Transaction::Type::blob;
+    tx.data = ""_b;
+    tx.gas_limit = 30000;
+    tx.max_gas_price = 14237787676;
+    tx.max_priority_gas_price = 0;
+    tx.sender = 0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5_address;
+    tx.value = 73360267083380739_u256;
+    tx.access_list = {};
+    tx.nonce = 132949;
+    tx.r = 0x2fe690e16de3534bee626150596573d57cb56d0c2e48a02f64c0a03c1636ce2a_u256;
+    tx.s = 0x4814f3dc7dac2ee153a2456aa3968717af7400972167dfb00b1cce1c23b6dd9f_u256;
+    tx.v = 1;
+    tx.chain_id = 1;
+    tx.max_blob_gas_price = 4;
+    tx.blob_hashes = {0x0111111111111111111111111111111111111111111111111111111111111111_bytes32,
+        0x0122222222222222222222222222222222222222222222222222222222222222_bytes32};
+
+    EXPECT_THAT([tx]() { rlp::encode(tx); },
+        ThrowsMessage<std::invalid_argument>("`to` value for blob transaction must not be null"));
+}

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -47,7 +47,8 @@ void state_transition::TearDown()
     if (trace)
         trace_capture.emplace();
 
-    const auto res = evmone::state::transition(state, block, tx, rev, selected_vm, block.gas_limit);
+    const auto res = state::transition(state, block, tx, rev, selected_vm, block.gas_limit,
+        state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
 
     if (const auto expected_error = make_error_code(expect.tx_error))
     {
@@ -70,8 +71,7 @@ void state_transition::TearDown()
     ASSERT_TRUE(holds_alternative<TransactionReceipt>(res))
         << std::get<std::error_code>(res).message();
     const auto& receipt = std::get<TransactionReceipt>(res);
-    evmone::state::finalize(
-        state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
+    state::finalize(state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
 
     if (trace)
     {

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -60,3 +60,14 @@ TEST_F(state_transition, block_apply_ommers_reward)
     // Two ommers +1/32 * block_reward for each. +21000 cost of the tx goes to coinbase.
     expect.post[Coinbase].balance = 21000 + intx::uint256{block_reward} + block_reward / 16;
 }
+
+TEST_F(state_transition, eip7516_blob_base_fee)
+{
+    rev = EVMC_CANCUN;
+
+    block.blob_base_fee = 0xabcd;
+    tx.to = To;
+    pre.insert(*tx.to, {.code = sstore(0x4a, OP_BLOBBASEFEE)});
+
+    expect.post[To].storage[0x4a_bytes32] = 0xabcd_bytes32;
+}

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -36,3 +36,24 @@ TEST_F(state_transition, invalid_tx_non_existing_sender)
 
     expect.tx_error = INSUFFICIENT_FUNDS;
 }
+
+TEST_F(state_transition, blob_tx_insuficient_funds)
+{
+    tx.to = To;
+    tx.gas_limit = 25000;
+    tx.max_gas_price = 1;
+    tx.max_priority_gas_price = 0;
+    tx.nonce = 1;
+    tx.type = Transaction::Type::blob;
+    tx.blob_hashes.emplace_back(
+        0x0100000000000000000000000000000000000000000000000000000000000000_bytes32);
+    tx.max_blob_gas_price = 1;
+    block.base_fee = 1;
+
+    pre.get_accounts()[tx.sender].balance = 0x20000 + 25000;
+
+    rev = EVMC_CANCUN;
+
+    expect.post.at(Coinbase).exists = false;
+    expect.status = EVMC_SUCCESS;
+}

--- a/test/unittests/state_tx_test.cpp
+++ b/test/unittests/state_tx_test.cpp
@@ -30,17 +30,18 @@ TEST(state_tx, validate_nonce)
         .r = 0,
         .s = 0,
     };
-    ASSERT_FALSE(
-        holds_alternative<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000)));
+
+    ASSERT_FALSE(holds_alternative<std::error_code>(
+        validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0)));
 
     tx.nonce = 0;
-    EXPECT_EQ(
-        std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000)).message(),
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0))
+                  .message(),
         "nonce too low");
 
     tx.nonce = 2;
-    EXPECT_EQ(
-        std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000)).message(),
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0))
+                  .message(),
         "nonce too high");
 }
 
@@ -66,18 +67,89 @@ TEST(state_tx, validate_sender)
         .s = 0,
     };
 
-    ASSERT_FALSE(
-        holds_alternative<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000)));
+    ASSERT_FALSE(holds_alternative<std::error_code>(
+        validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0)));
 
     bi.base_fee = 1;
 
-    EXPECT_EQ(
-        std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000)).message(),
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000, 0))
+                  .message(),
         "max fee per gas less than block base fee");
 
     tx.max_gas_price = bi.base_fee;
 
-    EXPECT_EQ(
-        std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000)).message(),
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000, 0))
+                  .message(),
         "insufficient funds for gas * price + value");
+}
+
+TEST(state_tx, validate_blob_tx)
+{
+    const BlockInfo bi{.gas_limit = 0x989680, .base_fee = 1, .blob_base_fee = 1};
+    const Account acc{.nonce = 0, .balance = 1000000};
+    Transaction tx{
+        .type = Transaction::Type::blob,
+        .gas_limit = 60000,
+        .max_gas_price = bi.base_fee,
+        .sender = 0x02_address,
+        .to = {},
+    };
+
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_SHANGHAI, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+                  .message(),
+        make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED).message());
+
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+                  .message(),
+        make_error_code(ErrorCode::CREATE_BLOB_TX).message());
+
+    tx.to = 0x01_address;
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+                  .message(),
+        make_error_code(ErrorCode::EMPTY_BLOB_HASHES_LIST).message());
+
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000001_bytes32);
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000002_bytes32);
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000003_bytes32);
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000004_bytes32);
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000005_bytes32);
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000006_bytes32);
+
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+                  .message(),
+        make_error_code(ErrorCode::FEE_CAP_LESS_THEN_BLOCKS).message());
+
+    tx.max_blob_gas_price = 1;
+    tx.blob_hashes.push_back(
+        0x0100000000000000000000000000000000000000000000000000000000000007_bytes32);
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+                  .message(),
+        make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED).message());
+
+    tx.blob_hashes.pop_back();
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK - 1))
+                  .message(),
+        make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED).message());
+
+    EXPECT_EQ(std::get<int64_t>(validate_transaction(
+                  acc, bi, tx, EVMC_CANCUN, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)),
+        39000);
+
+    tx.blob_hashes[0] = 0x0200000000000000000000000000000000000000000000000000000000000001_bytes32;
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+                  .message(),
+        make_error_code(ErrorCode::INVALID_BLOB_HASH_VERSION).message());
 }

--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -257,3 +257,68 @@ TEST(statetest_loader, block_info_ommers)
     EXPECT_EQ(bi.ommers[1].beneficiary, 0x0000000000000000000000000000000000000200_address);
     EXPECT_EQ(bi.ommers[1].delta, 4);
 }
+
+TEST(statetest_loader, block_info_parent_blob_gas)
+{
+    constexpr std::string_view input = R"({
+            "currentCoinbase": "0x1111111111111111111111111111111111111111",
+            "currentDifficulty": "0x0",
+            "currentGasLimit": "0x0",
+            "currentNumber": "0",
+            "currentTimestamp": "0",
+            "currentBaseFee": "7",
+            "currentRandom": "0x00",
+            "withdrawals": [],
+            "blockHashes": {
+                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
+                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
+            },
+            "parentExcessBlobGas": "1",
+            "parentBlobGasUsed": "0x60000"
+        })";
+
+    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
+    EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
+    EXPECT_EQ(bi.gas_limit, 0x0);
+    EXPECT_EQ(bi.base_fee, 7);
+    EXPECT_EQ(bi.timestamp, 0);
+    EXPECT_EQ(bi.number, 0);
+    EXPECT_EQ(bi.known_block_hashes.at(0),
+        0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
+    EXPECT_EQ(bi.known_block_hashes.at(1),
+        0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
+    EXPECT_EQ(bi.excess_blob_gas, 1);
+}
+
+TEST(statetest_loader, block_info_current_blob_gas)
+{
+    constexpr std::string_view input = R"({
+            "currentCoinbase": "0x1111111111111111111111111111111111111111",
+            "currentDifficulty": "0x0",
+            "currentGasLimit": "0x0",
+            "currentNumber": "0",
+            "currentTimestamp": "0",
+            "currentBaseFee": "7",
+            "currentRandom": "0x00",
+            "withdrawals": [],
+            "blockHashes": {
+                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
+                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
+            },
+            "currentExcessBlobGas": "2"
+        })";
+
+    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
+    EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
+    EXPECT_EQ(bi.gas_limit, 0x0);
+    EXPECT_EQ(bi.base_fee, 7);
+    EXPECT_EQ(bi.timestamp, 0);
+    EXPECT_EQ(bi.number, 0);
+    EXPECT_EQ(bi.known_block_hashes.at(0),
+        0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
+    EXPECT_EQ(bi.known_block_hashes.at(1),
+        0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
+    EXPECT_EQ(bi.excess_blob_gas, 2);
+}


### PR DESCRIPTION
- Add blob tx type support in state. 
- Modify `transition` and `validate_transaction` functions to pass `blob_gas_left` parameter.
- Update unit tests
- Support blob tx in t8n
- Compute `excess_blob_gas` and `blob_gas_price`.