### PR TITLE
Properly clear transient storage after transaction execution

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -507,6 +507,13 @@ jobs:
             bin/evmone-blockchaintest
             --gtest_filter='*:-bcMultiChainTest.*:bcTotalDifficultyTest.*:bcForkStressTest.ForkStressTest:bcGasPricerTest.RPC_API_Test:bcValidBlockTest.SimpleTx3LowS'
             ~/tests/BlockchainTests/ValidBlocks
+      - run:
+          name: "Blockchain tests (EIPs)"
+          working_directory: ~/build
+          command: >
+            EVMONE_PRECOMPILES_STUB=~/project/test/state/precompiles_stub.json 
+            bin/evmone-blockchaintest
+            ~/tests/EIPTests/BlockchainTests/bcEIP1153-transientStorage
       - download_execution_tests:
           repo: ipsilon/tests
           rev: eof-update-20230828

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -255,10 +255,11 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
         delete_empty_accounts(state);
 
     // Set accounts and their storage access status to cold in the end of transition process
-    for (auto& acc : state.get_accounts())
+    for (auto& [addr, acc] : state.get_accounts())
     {
-        acc.second.access_status = EVMC_ACCESS_COLD;
-        for (auto& [_, val] : acc.second.storage)
+        acc.transient_storage.clear();
+        acc.access_status = EVMC_ACCESS_COLD;
+        for (auto& [key, val] : acc.storage)
         {
             val.access_status = EVMC_ACCESS_COLD;
             val.original = val.current;


### PR DESCRIPTION
The transient storage [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153)
must not persist between transactions. Clear the transient storage
attached to every account at the end of transaction execution.