### PR TITLE
Rename error non_empty_stack_on_terminating_instruction

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -406,7 +406,7 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
                     static_cast<int8_t>(code_types[func_index].outputs + code_types[fid].inputs -
                                         code_types[fid].outputs);
                 if (stack_heights[i] > stack_height_required)
-                    return EOFValidationError::non_empty_stack_on_terminating_instruction;
+                    return EOFValidationError::code_section_outputs_mismatch;
             }
         }
 
@@ -470,7 +470,7 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
             }
         }
         else if (opcode == OP_RETF && stack_height != code_types[func_index].outputs)
-            return EOFValidationError::non_empty_stack_on_terminating_instruction;
+            return EOFValidationError::code_section_outputs_mismatch;
     }
 
     const auto max_stack_height = *std::max_element(stack_heights.begin(), stack_heights.end());
@@ -675,8 +675,8 @@ std::string_view get_error_message(EOFValidationError err) noexcept
         return "no_terminating_instruction";
     case EOFValidationError::stack_height_mismatch:
         return "stack_height_mismatch";
-    case EOFValidationError::non_empty_stack_on_terminating_instruction:
-        return "non_empty_stack_on_terminating_instruction";
+    case EOFValidationError::code_section_outputs_mismatch:
+        return "code_section_outputs_mismatch";
     case EOFValidationError::unreachable_instructions:
         return "unreachable_instructions";
     case EOFValidationError::stack_underflow:

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -91,7 +91,7 @@ enum class EOFValidationError
     invalid_max_stack_height,
     no_terminating_instruction,
     stack_height_mismatch,
-    non_empty_stack_on_terminating_instruction,
+    code_section_outputs_mismatch,
     max_stack_height_above_limit,
     inputs_outputs_num_above_limit,
     unreachable_instructions,

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -912,7 +912,7 @@ TEST(eof_validation, callf_stack_validation)
     // function 2: (2, 1) :             POP RETF
     EXPECT_EQ(validate_eof("EF0001 01000C 020003000400070002 040000 00 008000010001000202010002 "
                            "E3000100 5F5F5FE30002E4 50E4"),
-        EOFValidationError::non_empty_stack_on_terminating_instruction);
+        EOFValidationError::code_section_outputs_mismatch);
 
     // function 0: (0, non-returning) : CALLF{1} STOP
     // function 1: (0, 1) :             PUSH0 CALLF{2} RETF
@@ -1034,7 +1034,7 @@ TEST(eof_validation, jumpf_into_returning_stack_validation)
     // Extra items on stack at JUMPF
     EXPECT_EQ(validate_eof("EF0001 01000C 020003000100070002 040000 00 008000000002000403020003 00 "
                            "5F5F5F5FE50002 50e4"),
-        EOFValidationError::non_empty_stack_on_terminating_instruction);
+        EOFValidationError::code_section_outputs_mismatch);
 
     // Not enough inputs on stack at JUMPF
     EXPECT_EQ(validate_eof("EF0001 01000C 020003000100050002 040000 00 008000000002000203020003 00 "
@@ -1052,7 +1052,7 @@ TEST(eof_validation, jumpf_into_returning_stack_validation)
     // Extra items on stack at JUMPF
     EXPECT_EQ(validate_eof("EF0001 01000C 020003000100080003 040000 00 008000000002000503010003 00 "
                            "5F5F5F5F5FE50002 5050e4"),
-        EOFValidationError::non_empty_stack_on_terminating_instruction);
+        EOFValidationError::code_section_outputs_mismatch);
 
     // Not enough inputs on stack at JUMPF
     EXPECT_EQ(validate_eof("EF0001 01000C 020003000100060003 040000 00 008000000002000303010003 00 "


### PR DESCRIPTION
Error `non_empty_stack_on_terminating_instruction` is currently only used when there is a [mismatch between the number of stack items in current function context and the total number of defined outputs](https://github.com/ethereum/evmone/blob/master/lib/evmone/eof.cpp#L421-L422), which is no longer accurate. 

This PR changes the error name to indicate outputs mismatch.