### PR TITLE
Upgrade conan version required to build silkworm

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -133,6 +133,8 @@ commands:
             git submodule update --init --recursive --progress
       - run:
           name: "Install conan"
+          # Use conan version from the Silkworm documentation.
+          # https://github.com/erigontech/silkworm#building-on-linux--macos
           command: sudo pip install --break-system-packages conan==1.60.2
       - run:
           name: "Configure Silkworm"

--- a/circle.yml
+++ b/circle.yml
@@ -133,7 +133,7 @@ commands:
             git submodule update --init --recursive --progress
       - run:
           name: "Install conan"
-          command: sudo pip install --break-system-packages conan==1.58
+          command: sudo pip install --break-system-packages conan==1.60.2
       - run:
           name: "Configure Silkworm"
           working_directory: ~/silkworm


### PR DESCRIPTION
Change conan version to exact (`1.60.2`) one pointed in [silkworm documentation](https://github.com/erigontech/silkworm#building-on-linux--macos)