### PR TITLE
host: Don't assume the sender account exists

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -107,7 +107,7 @@ std::variant<int64_t, std::error_code> validate_transaction(const Account& sende
     if (!sender_acc.code.empty())
         return make_error_code(SENDER_NOT_EOA);  // Origin must not be a contract (EIP-3607).
 
-    if (sender_acc.nonce == Account::NonceMax)
+    if (sender_acc.nonce == Account::NonceMax)  // Nonce value limit (EIP-2681).
         return make_error_code(NONCE_HAS_MAX_VALUE);
 
     if (sender_acc.nonce < tx.nonce)

--- a/test/unittests/state_transition_create_test.cpp
+++ b/test/unittests/state_transition_create_test.cpp
@@ -32,3 +32,15 @@ TEST_F(state_transition, create_tx)
 
     expect.post[create_address].code = bytes{0xFE};
 }
+
+TEST_F(state_transition, create2_max_nonce)
+{
+    // The address to be created by CREATE2 of the "To" sender and empty initcode.
+    static constexpr auto create_address = 0x36fd63ce1cb5ee2993f19d1fae4e84d52f6f1595_address;
+
+    tx.to = To;
+    pre.insert(*tx.to, {.nonce = ~uint64_t{0}, .code = create2()});
+
+    expect.post[*tx.to].nonce = pre.get(*tx.to).nonce;  // Nonce is unchanged.
+    expect.post[create_address].exists = false;
+}


### PR DESCRIPTION
This change is basically refactoring with the goal not to access the call sender's account unnecessary.