### PR TITLE
Refactor precompiles detection

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -263,8 +263,8 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
         dst_acc->balance += value;
     }
 
-    if (auto precompiled_result = call_precompile(m_rev, msg); precompiled_result.has_value())
-        return std::move(*precompiled_result);
+    if (is_precompile(m_rev, msg.code_address))
+        return call_precompile(m_rev, msg);
 
     // Copy of the code. Revert will invalidate the account.
     const auto code = dst_acc != nullptr ? dst_acc->code : bytes{};
@@ -350,7 +350,7 @@ evmc_access_status Host::access_account(const address& addr) noexcept
     const auto status = std::exchange(acc.access_status, EVMC_ACCESS_WARM);
 
     // Overwrite status for precompiled contracts: they are always warm.
-    if (status == EVMC_ACCESS_COLD && addr >= 0x01_address && addr <= 0x09_address)
+    if (status == EVMC_ACCESS_COLD && is_precompile(m_rev, addr))
         return EVMC_ACCESS_WARM;
 
     return status;

--- a/test/state/precompiles.hpp
+++ b/test/state/precompiles.hpp
@@ -9,9 +9,7 @@
 
 namespace evmone::state
 {
-/// The total number of known precompiles ids, including 0.
-inline constexpr std::size_t NumPrecompiles = 10;
-
+/// The precompile identifiers and their corresponding addresses.
 enum class PrecompileId : uint8_t
 {
     ecrecover = 0x01,
@@ -23,7 +21,14 @@ enum class PrecompileId : uint8_t
     ecmul = 0x07,
     ecpairing = 0x08,
     blake2bf = 0x09,
+
+    since_byzantium = expmod,   ///< The first precompile introduced in Byzantium.
+    since_istanbul = blake2bf,  ///< The first precompile introduced in Istanbul.
+    latest = blake2bf           ///< The latest introduced precompile (highest address).
 };
+
+/// The total number of known precompiles ids, including 0.
+inline constexpr std::size_t NumPrecompiles = stdx::to_underlying(PrecompileId::latest) + 1;
 
 struct ExecutionResult
 {
@@ -31,5 +36,9 @@ struct ExecutionResult
     size_t output_size;
 };
 
-std::optional<evmc::Result> call_precompile(evmc_revision rev, const evmc_message& msg) noexcept;
+/// Checks if the address @p addr is considered a precompiled contract in the revision @p rev.
+bool is_precompile(evmc_revision rev, const evmc::address& addr) noexcept;
+
+/// Executes the message to a precompiled contract (msg.code_address must be a precompile).
+evmc::Result call_precompile(evmc_revision rev, const evmc_message& msg) noexcept;
 }  // namespace evmone::state

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_sources(
     state_mpt_hash_test.cpp
     state_mpt_test.cpp
     state_new_account_address_test.cpp
+    state_precompiles_test.cpp
     state_rlp_test.cpp
     state_transition.hpp
     state_transition.cpp

--- a/test/unittests/state_precompiles_test.cpp
+++ b/test/unittests/state_precompiles_test.cpp
@@ -1,0 +1,42 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <test/state/precompiles.hpp>
+
+using namespace evmc;
+using namespace evmone::state;
+
+TEST(state_precompiles, is_precompile)
+{
+    for (int r = 0; r <= EVMC_MAX_REVISION; ++r)
+    {
+        const auto rev = static_cast<evmc_revision>(r);
+
+        EXPECT_FALSE(is_precompile(rev, 0x00_address));
+
+        // Frontier:
+        EXPECT_TRUE(is_precompile(rev, 0x01_address));
+        EXPECT_TRUE(is_precompile(rev, 0x02_address));
+        EXPECT_TRUE(is_precompile(rev, 0x03_address));
+        EXPECT_TRUE(is_precompile(rev, 0x04_address));
+
+        // Byzantium:
+        EXPECT_EQ(is_precompile(rev, 0x05_address), rev >= EVMC_BYZANTIUM);
+        EXPECT_EQ(is_precompile(rev, 0x06_address), rev >= EVMC_BYZANTIUM);
+        EXPECT_EQ(is_precompile(rev, 0x07_address), rev >= EVMC_BYZANTIUM);
+        EXPECT_EQ(is_precompile(rev, 0x08_address), rev >= EVMC_BYZANTIUM);
+
+        // Istanbul:
+        EXPECT_EQ(is_precompile(rev, 0x09_address), rev >= EVMC_ISTANBUL);
+
+        // Future?
+        EXPECT_FALSE(is_precompile(rev, 0x0a_address));
+        EXPECT_FALSE(is_precompile(rev, 0x0b_address));
+        EXPECT_FALSE(is_precompile(rev, 0x0c_address));
+        EXPECT_FALSE(is_precompile(rev, 0x0d_address));
+        EXPECT_FALSE(is_precompile(rev, 0x0e_address));
+        EXPECT_FALSE(is_precompile(rev, 0x0f_address));
+    }
+}


### PR DESCRIPTION
Extract a precompile address recognition into new is_precompile()
function and use it in all places where this information is needed.

Improve maintenance of "precompile ids" by adding aliases to the enum.

Add unit tests for is_precompile().