### PR TITLE
test: Improve maintainability of JSON loading

### DIFF
--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -23,15 +23,24 @@ T load_if_exists(const json::json& j, std::string_view key)
 template <>
 BlockHeader from_json<BlockHeader>(const json::json& j)
 {
-    return {from_json<hash256>(j.at("parentHash")), from_json<address>(j.at("coinbase")),
-        from_json<hash256>(j.at("stateRoot")), from_json<hash256>(j.at("receiptTrie")),
-        state::bloom_filter_from_bytes(from_json<bytes>(j.at("bloom"))),
-        load_if_exists<int64_t>(j, "difficulty"), load_if_exists<bytes32>(j, "mixHash"),
-        from_json<int64_t>(j.at("number")), from_json<int64_t>(j.at("gasLimit")),
-        from_json<int64_t>(j.at("gasUsed")), from_json<int64_t>(j.at("timestamp")),
-        from_json<bytes>(j.at("extraData")), load_if_exists<uint64_t>(j, "baseFeePerGas"),
-        from_json<hash256>(j.at("hash")), from_json<hash256>(j.at("transactionsTrie")),
-        load_if_exists<hash256>(j, "withdrawalsRoot")};
+    return {
+        .parent_hash = from_json<hash256>(j.at("parentHash")),
+        .coinbase = from_json<address>(j.at("coinbase")),
+        .state_root = from_json<hash256>(j.at("stateRoot")),
+        .receipts_root = from_json<hash256>(j.at("receiptTrie")),
+        .logs_bloom = state::bloom_filter_from_bytes(from_json<bytes>(j.at("bloom"))),
+        .difficulty = load_if_exists<int64_t>(j, "difficulty"),
+        .prev_randao = load_if_exists<bytes32>(j, "mixHash"),
+        .block_number = from_json<int64_t>(j.at("number")),
+        .gas_limit = from_json<int64_t>(j.at("gasLimit")),
+        .gas_used = from_json<int64_t>(j.at("gasUsed")),
+        .timestamp = from_json<int64_t>(j.at("timestamp")),
+        .extra_data = from_json<bytes>(j.at("extraData")),
+        .base_fee_per_gas = load_if_exists<uint64_t>(j, "baseFeePerGas"),
+        .hash = from_json<hash256>(j.at("hash")),
+        .transactions_root = from_json<hash256>(j.at("transactionsTrie")),
+        .withdrawal_root = load_if_exists<hash256>(j, "withdrawalsRoot"),
+    };
 }
 
 static TestBlock load_test_block(const json::json& j, evmc_revision rev)

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -108,7 +108,10 @@ std::string print_state(const state::State& s)
             out << "\tstorage : "
                 << "\n";
             for (const auto& [s_key, val] : ordered_storage)
-                out << "\t\t" << s_key << " : " << hex0x(val.current) << "\n";
+            {
+                if (val.current)  // Skip 0 values.
+                    out << "\t\t" << s_key << " : " << hex0x(val.current) << "\n";
+            }
         }
     }
 

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -33,13 +33,12 @@ static std::optional<T> integer_from_json(const json::json& j)
         return {};
 
     const auto s = j.get<std::string>();
-    size_t num_processed = 0;
-    T v = 0;
-    if constexpr (std::is_same_v<T, uint64_t>)
-        v = std::stoull(s, &num_processed, 0);
-    else
-        v = std::stoll(s, &num_processed, 0);
 
+    // Always load integers as unsigned and cast to the required type.
+    // This will work for cases where a test case uses uint64 timestamps while we use int64.
+    // TODO: Change timestamp type to uint64.
+    size_t num_processed = 0;
+    const auto v = static_cast<T>(std::stoull(s, &num_processed, 0));
     if (num_processed == 0 || num_processed != s.size())
         return {};
     return v;

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -222,11 +222,21 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
     if (parent_timestamp_it != j.end())
         parent_timestamp = from_json<int64_t>(*parent_timestamp_it);
 
-    return {from_json<int64_t>(j.at("currentNumber")), from_json<int64_t>(j.at("currentTimestamp")),
-        parent_timestamp, from_json<int64_t>(j.at("currentGasLimit")),
-        from_json<evmc::address>(j.at("currentCoinbase")), current_difficulty, parent_difficulty,
-        parent_uncle_hash, prev_randao, base_fee, std::move(ommers), std::move(withdrawals),
-        std::move(block_hashes)};
+    return state::BlockInfo{
+        .number = from_json<int64_t>(j.at("currentNumber")),
+        .timestamp = from_json<int64_t>(j.at("currentTimestamp")),
+        .parent_timestamp = parent_timestamp,
+        .gas_limit = from_json<int64_t>(j.at("currentGasLimit")),
+        .coinbase = from_json<evmc::address>(j.at("currentCoinbase")),
+        .difficulty = current_difficulty,
+        .parent_difficulty = parent_difficulty,
+        .parent_ommers_hash = parent_uncle_hash,
+        .prev_randao = prev_randao,
+        .base_fee = base_fee,
+        .ommers = std::move(ommers),
+        .withdrawals = std::move(withdrawals),
+        .known_block_hashes = std::move(block_hashes),
+    };
 }
 
 template <>

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -52,9 +52,16 @@ TEST(json_loader, int64_t)
         from_json<int64_t>(basic_json("9223372036854775807")), std::numeric_limits<int64_t>::max());
     EXPECT_EQ(from_json<int64_t>(basic_json("-9223372036854775808")),
         std::numeric_limits<int64_t>::min());
-    EXPECT_THROW(from_json<int64_t>(basic_json("0xffffffffffffffff")), std::out_of_range);
-    EXPECT_THROW(from_json<int64_t>(basic_json("9223372036854775808")), std::out_of_range);
-    EXPECT_THROW(from_json<int64_t>(basic_json("-9223372036854775809")), std::out_of_range);
+
+    // Unfortunate conversion results:
+    EXPECT_EQ(from_json<int64_t>(basic_json("0xffffffffffffffff")), int64_t{-1});
+    EXPECT_EQ(
+        from_json<int64_t>(basic_json("9223372036854775808")), std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(from_json<int64_t>(basic_json("-9223372036854775809")),
+        std::numeric_limits<int64_t>::max());
+
+    EXPECT_THROW(from_json<uint64_t>(basic_json("0x10000000000000000")), std::out_of_range);
+    EXPECT_THROW(from_json<uint64_t>(basic_json("18446744073709551616")), std::out_of_range);
 
     // Octal is also supported.
     EXPECT_EQ(from_json<int64_t>(basic_json("0777")), 0777);


### PR DESCRIPTION
- Use designated initializers for big structs like `BlockInfo` and `BlockHeader`. They show how JSON names are mapped to field names and help avoiding complicated merge conflicts.
- Load JSON integers as unsigned values + cast to signed if needed. This workarounds the problem with execution-spec-tests where timestamps can be uint64.
- Omit 0 storage values from state dumps in `evmone-blockchaintest`.