### PR TITLE
cmake: Disable -Wmissing-field-initializers in GCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ if(CABLE_COMPILER_GNULIKE)
     add_compile_options(
         -Wmissing-declarations
         -Wno-attributes  # Allow using unknown attributes.
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-missing-field-initializers>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
     )
     cable_add_cxx_compiler_flag_if_supported(-Wduplicated-cond)

--- a/test/state/account.hpp
+++ b/test/state/account.hpp
@@ -35,15 +35,15 @@ struct Account
     uint64_t nonce = 0;
 
     /// The account balance.
-    intx::uint256 balance = {};
+    intx::uint256 balance;
 
     /// The account storage map.
-    std::unordered_map<bytes32, StorageValue> storage = {};
+    std::unordered_map<bytes32, StorageValue> storage;
 
-    std::unordered_map<bytes32, bytes32> transient_storage = {};
+    std::unordered_map<bytes32, bytes32> transient_storage;
 
     /// The account code.
-    bytes code = {};
+    bytes code;
 
     /// The account has been destructed and should be erased at the end of of a transaction.
     bool destructed = false;

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -95,12 +95,12 @@ struct BlockInfo
     address coinbase;
     int64_t difficulty = 0;
     int64_t parent_difficulty = 0;
-    hash256 parent_ommers_hash = {};
+    hash256 parent_ommers_hash;
     bytes32 prev_randao;
     uint64_t base_fee = 0;
-    std::vector<Ommer> ommers = {};
+    std::vector<Ommer> ommers;
     std::vector<Withdrawal> withdrawals;
-    std::unordered_map<int64_t, hash256> known_block_hashes = {};
+    std::unordered_map<int64_t, hash256> known_block_hashes;
 };
 
 using AccessList = std::vector<std::pair<address, std::vector<bytes32>>>;

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -8,8 +8,6 @@
 #include <test/state/errors.hpp>
 #include <test/state/host.hpp>
 
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-
 namespace evmone::test
 {
 using namespace evmone;


### PR DESCRIPTION
This warning is too noisy for C++ designated initializer.