### PR TITLE
Implement EIP-6780 "SELFDESTRUCT"

### DIFF
--- a/test/state/account.hpp
+++ b/test/state/account.hpp
@@ -53,6 +53,9 @@ struct Account
     /// or it is a newly created temporary account.
     bool erasable = false;
 
+    /// The account has been created in the current transaction.
+    bool just_created = false;
+
     evmc_access_status access_status = EVMC_ACCESS_COLD;
 
     [[nodiscard]] bool is_empty() const noexcept

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -254,11 +254,14 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
     if (rev >= EVMC_SPURIOUS_DRAGON)
         delete_empty_accounts(state);
 
-    // Set accounts and their storage access status to cold in the end of transition process
+    // Post-transaction clean-up.
+    // - Set accounts and their storage access status to cold.
+    // - Clear the "just created" account flag.
     for (auto& [addr, acc] : state.get_accounts())
     {
         acc.transient_storage.clear();
         acc.access_status = EVMC_ACCESS_COLD;
+        acc.just_created = false;
         for (auto& [key, val] : acc.storage)
         {
             val.access_status = EVMC_ACCESS_COLD;

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(
     state_transition_block_test.cpp
     state_transition_create_test.cpp
     state_transition_eof_test.cpp
+    state_transition_selfdestruct_test.cpp
     state_transition_trace_test.cpp
     state_transition_transient_storage_test.cpp
     state_transition_tx_test.cpp

--- a/test/unittests/state_transition_selfdestruct_test.cpp
+++ b/test/unittests/state_transition_selfdestruct_test.cpp
@@ -1,0 +1,48 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../utils/bytecode.hpp"
+#include "state_transition.hpp"
+
+using namespace evmc::literals;
+using namespace evmone::test;
+
+TEST_F(state_transition, selfdestruct_shanghai)
+{
+    rev = EVMC_SHANGHAI;
+    tx.to = To;
+    pre.insert(*tx.to, {.balance = 0x4e, .code = selfdestruct(0xbe_address)});
+
+    expect.post[To].exists = false;
+    expect.post[0xbe_address].balance = 0x4e;
+}
+
+TEST_F(state_transition, selfdestruct_cancun)
+{
+    rev = EVMC_CANCUN;
+    tx.to = To;
+    pre.insert(*tx.to, {.balance = 0x4e, .code = selfdestruct(0xbe_address)});
+
+    expect.post[To].balance = 0;
+    expect.post[0xbe_address].balance = 0x4e;
+}
+
+TEST_F(state_transition, selfdestruct_to_self_cancun)
+{
+    rev = EVMC_CANCUN;
+    tx.to = To;
+    pre.insert(*tx.to, {.balance = 0x4e, .code = selfdestruct(To)});
+
+    expect.post[To].balance = 0x4e;
+}
+
+TEST_F(state_transition, selfdestruct_same_tx_cancun)
+{
+    rev = EVMC_CANCUN;
+    tx.value = 0x4e;
+    tx.data = selfdestruct(0xbe_address);
+    pre.get(Sender).balance += 0x4e;
+
+    expect.post[0xbe_address].balance = 0x4e;
+}


### PR DESCRIPTION
Implement the EIP-6780 "SELFDESTRUCT only in same transaction".
https://eips.ethereum.org/EIPS/eip-6780

This EIP changes the functionality of the `SELFDESTRUCT` instruction.
The new functionality will be only to send all Ether in the account
to the beneficiary, except that the current behavior is preserved when
`SELFDESTRUCT` is called in the same transaction a contract was created.