### PR TITLE
blockchaintest: Add support for revision transitions

### DIFF
--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -5,6 +5,7 @@
 
 #include "../state/bloom_filter.hpp"
 #include "../state/state.hpp"
+#include "../utils/utils.hpp"
 #include <evmc/evmc.hpp>
 #include <span>
 #include <vector>
@@ -61,7 +62,7 @@ struct BlockchainTest
     std::vector<TestBlock> test_blocks;
     BlockHeader genesis_block_header;
     state::State pre_state;
-    evmc_revision rev;
+    RevisionSchedule rev;
 
     Expectation expectation;
 };

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -120,10 +120,10 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
     bt.name = name;
     bt.genesis_block_header = from_json<BlockHeader>(j.at("genesisBlockHeader"));
     bt.pre_state = from_json<State>(j.at("pre"));
-    bt.rev = to_rev(j.at("network").get<std::string>());
+    bt.rev = to_rev_schedule(j.at("network").get<std::string>());
 
     for (const auto& el : j.at("blocks"))
-        bt.test_blocks.emplace_back(load_test_block(el, bt.rev));
+        bt.test_blocks.emplace_back(load_test_block(el, bt.rev.get_revision(0)));
 
     bt.expectation.last_block_hash = from_json<hash256>(j.at("lastblockhash"));
 

--- a/test/unittests/blockchaintest_loader_test.cpp
+++ b/test/unittests/blockchaintest_loader_test.cpp
@@ -138,7 +138,7 @@ TEST(json_loader, blockchain_test)
 
     EXPECT_EQ(btt.size(), 1);
     EXPECT_EQ(btt[0].test_blocks.size(), 1);
-    EXPECT_EQ(btt[0].rev, evmc_revision::EVMC_SHANGHAI);
+    EXPECT_EQ(btt[0].rev.get_revision(0), evmc_revision::EVMC_SHANGHAI);
     EXPECT_EQ(btt[0].name, "000-fork=Shanghai-fill_stack");
     EXPECT_EQ(btt[0].genesis_block_header.timestamp, 0);
     EXPECT_EQ(btt[0].genesis_block_header.gas_limit, 0x016345785d8a0000);
@@ -229,7 +229,7 @@ TEST(json_loader, blockchain_test_post_state_hash)
                 "hash": "0xe1bcc830589216abdc79cb3075f06f7b133f7b0cf257ecb346da33c354099700"
             },
             "lastblockhash": "0x01de610f00331cea813e8143d51eb44ca352cdd90c602bb4b4bcf3c6cf9d5531",
-            "network": "Shanghai",
+            "network": "ShanghaiToCancunAtTime15k",
             "pre": {
                 "0x0000000000000000000000000000000000000100": {
                     "nonce": "0x00",
@@ -253,7 +253,8 @@ TEST(json_loader, blockchain_test_post_state_hash)
 
     EXPECT_EQ(btt.size(), 1);
     EXPECT_EQ(btt[0].test_blocks.size(), 1);
-    EXPECT_EQ(btt[0].rev, evmc_revision::EVMC_SHANGHAI);
+    EXPECT_EQ(btt[0].rev.get_revision(0), evmc_revision::EVMC_SHANGHAI);
+    EXPECT_EQ(btt[0].rev.get_revision(15'000), evmc_revision::EVMC_CANCUN);
     EXPECT_EQ(btt[0].name, "000-fork=Shanghai-fill_stack");
     EXPECT_EQ(btt[0].genesis_block_header.timestamp, 0);
     EXPECT_EQ(btt[0].genesis_block_header.gas_limit, 0x016345785d8a0000);
@@ -360,7 +361,7 @@ TEST(json_loader, blockchain_test_pre_paris)
 
     EXPECT_EQ(btt.size(), 1);
     EXPECT_EQ(btt[0].test_blocks.size(), 1);
-    EXPECT_EQ(btt[0].rev, evmc_revision::EVMC_LONDON);
+    EXPECT_EQ(btt[0].rev.get_revision(0), evmc_revision::EVMC_LONDON);
     EXPECT_EQ(btt[0].name, "000-fork=Shanghai-fill_stack");
     EXPECT_EQ(btt[0].genesis_block_header.timestamp, 0);
     EXPECT_EQ(btt[0].genesis_block_header.gas_limit, 0x016345785d8a0000);

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -42,4 +42,13 @@ evmc_revision to_rev(std::string_view s)
     throw std::invalid_argument{"unknown revision: " + std::string{s}};
 }
 
+RevisionSchedule to_rev_schedule(std::string_view s)
+{
+    if (s == "ShanghaiToCancunAtTime15k")
+        return {EVMC_SHANGHAI, EVMC_CANCUN, 15'000};
+
+    const auto single_rev = to_rev(s);
+    return {single_rev, single_rev, 0};
+}
+
 }  // namespace evmone::test

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -14,9 +14,30 @@ using evmc::hex;
 
 namespace evmone::test
 {
+/// The EVM revision schedule based on timestamps.
+struct RevisionSchedule
+{
+    /// The revision of the first block.
+    evmc_revision genesis_rev = EVMC_FRONTIER;
+
+    /// The final revision to transition to.
+    evmc_revision final_rev = genesis_rev;
+
+    /// The timestamp of the transition to the final revision.
+    int64_t transition_time = 0;
+
+    /// Returns the specific revision for the given timestamp.
+    [[nodiscard]] evmc_revision get_revision(int64_t timestamp) const noexcept
+    {
+        return timestamp >= transition_time ? final_rev : genesis_rev;
+    }
+};
 
 /// Translates tests fork name to EVM revision
 evmc_revision to_rev(std::string_view s);
+
+/// Translates tests fork name to the EVM revision schedule.
+RevisionSchedule to_rev_schedule(std::string_view s);
 
 }  // namespace evmone::test
 


### PR DESCRIPTION
Add support for blockchain tests with predefined timestamp of a revision transition (e.g. transtion from Shanghai to Cancun at the timestamp of 15000).