### PR TITLE
test: Export state transition tests to JSON

### DIFF
--- a/test/integration/statetest/CMakeLists.txt
+++ b/test/integration/statetest/CMakeLists.txt
@@ -116,3 +116,27 @@ set_tests_properties(
     ${PREFIX}/tx_invalid_nonce PROPERTIES
     PASS_REGULAR_EXPRESSION "unexpected invalid transaction: nonce too high"
 )
+
+# Tests for exporting JSON tests
+
+set(EXPORT_DIR exported_tests)
+
+add_test(
+    NAME ${PREFIX}/export_to_json
+    COMMAND evmone-unittests --gtest_filter=state_transition.*
+)
+set_tests_properties(
+    ${PREFIX}/export_to_json PROPERTIES
+    ENVIRONMENT EVMONE_EXPORT_TESTS=${EXPORT_DIR}
+    FIXTURES_SETUP EXPORT_JSON_TESTS
+)
+
+add_test(
+    NAME ${PREFIX}/execute_exported_tests
+    # TODO: Broken exported tests are filtered out.
+    COMMAND evmone-statetest ${EXPORT_DIR} --gtest_filter=-*block.*:*tx.tx_non_existing_sender
+)
+set_tests_properties(
+    ${PREFIX}/execute_exported_tests PROPERTIES
+    FIXTURES_REQUIRED EXPORT_JSON_TESTS
+)

--- a/test/statetest/CMakeLists.txt
+++ b/test/statetest/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(
     evmone-statetestutils PRIVATE
     ../blockchaintest/blockchaintest_loader.cpp
     statetest.hpp
+    statetest_export.cpp
     statetest_loader.cpp
     statetest_logs_hash.cpp
 )

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -8,6 +8,8 @@
 #include <gtest/gtest.h>
 #include <iostream>
 
+namespace fs = std::filesystem;
+
 namespace
 {
 class StateTest : public testing::Test

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -5,9 +5,7 @@
 
 #include "../state/state.hpp"
 #include <nlohmann/json.hpp>
-#include <filesystem>
 
-namespace fs = std::filesystem;
 namespace json = nlohmann;
 
 namespace evmone::test
@@ -91,6 +89,9 @@ state::State from_json<state::State>(const json::json& j);
 
 template <>
 state::Transaction from_json<state::Transaction>(const json::json& j);
+
+/// Exports the State (accounts) to JSON format (aka pre/post/alloc state).
+json::json to_json(const std::unordered_map<address, state::Account>& accounts);
 
 StateTransitionTest load_state_test(std::istream& input);
 

--- a/test/statetest/statetest_export.cpp
+++ b/test/statetest/statetest_export.cpp
@@ -1,0 +1,28 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "statetest.hpp"
+
+namespace evmone::test
+{
+json::json to_json(const std::unordered_map<address, state::Account>& accounts)
+{
+    json::json j;
+    for (const auto& [addr, acc] : accounts)
+    {
+        auto& j_acc = j[hex0x(addr)];
+        j_acc["nonce"] = hex0x(acc.nonce);
+        j_acc["balance"] = hex0x(acc.balance);
+        j_acc["code"] = hex0x(bytes_view(acc.code.data(), acc.code.size()));
+
+        auto& j_storage = j_acc["storage"] = json::json::object();
+        for (const auto& [key, val] : acc.storage)
+        {
+            if (!is_zero(val.current))
+                j_storage[hex0x(key)] = hex0x(val.current);
+        }
+    }
+    return j;
+}
+}  // namespace evmone::test

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -238,19 +238,8 @@ int main(int argc, const char* argv[])
         std::ofstream{output_dir / output_result_file} << std::setw(2) << j_result;
 
         // Print out current state to outAlloc file
-        json::json j_alloc;
-        for (const auto& [addr, acc] : state.get_accounts())
-        {
-            j_alloc[hex0x(addr)]["nonce"] = hex0x(acc.nonce);
-            for (const auto& [key, val] : acc.storage)
-                if (!is_zero(val.current))
-                    j_alloc[hex0x(addr)]["storage"][hex0x(key)] = hex0x(val.current);
-
-            j_alloc[hex0x(addr)]["code"] = hex0x(bytes_view(acc.code.data(), acc.code.size()));
-            j_alloc[hex0x(addr)]["balance"] = hex0x(acc.balance);
-        }
-
-        std::ofstream{output_dir / output_alloc_file} << std::setw(2) << j_alloc;
+        std::ofstream{output_dir / output_alloc_file} << std::setw(2)
+                                                      << to_json(state.get_accounts());
 
         if (!output_body_file.empty())
             std::ofstream{output_dir / output_body_file} << hex0x(rlp::encode(transactions));

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -2,8 +2,19 @@
 // Copyright 2023 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#ifdef _MSC_VER
+// Disable warning C4996: 'getenv': This function or variable may be unsafe.
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "state_transition.hpp"
 #include <evmone/eof.hpp>
+#include <test/state/mpt_hash.hpp>
+#include <test/statetest/statetest.hpp>
+#include <filesystem>
+#include <fstream>
+
+namespace fs = std::filesystem;
 
 namespace evmone::test
 {
@@ -65,6 +76,7 @@ void state_transition::TearDown()
             EXPECT_TRUE(pre.get_accounts().contains(addr)) << "unexpected account " << addr;
         }
 
+        // TODO: Export also tests with invalid transactions.
         return;  // Do not check anything else.
     }
 
@@ -127,5 +139,67 @@ void state_transition::TearDown()
     {
         EXPECT_TRUE(expect.post.contains(addr)) << "unexpected account " << addr;
     }
+
+    if (const auto export_dir = std::getenv("EVMONE_EXPORT_TESTS"); export_dir != nullptr)
+        export_state_test(receipt, state, export_dir);
+}
+
+namespace
+{
+/// Creates the file path for the exported test based on its name.
+fs::path get_export_test_path(const testing::TestInfo& test_info, std::string_view export_dir)
+{
+    const std::string_view test_suite_name{test_info.test_suite_name()};
+
+    const auto stem = fs::path{test_info.file()}.stem().string();
+    auto filename = std::string_view{stem};
+    if (filename.starts_with(test_suite_name))
+        filename.remove_prefix(test_suite_name.size() + 1);
+    if (filename.ends_with("_test"))
+        filename.remove_suffix(5);
+
+    const auto dir = fs::path{export_dir} / test_suite_name / filename;
+
+    fs::create_directories(dir);
+    return dir / (std::string{test_info.name()} + ".json");
+}
+}  // namespace
+
+void state_transition::export_state_test(
+    const TransactionReceipt& receipt, const State& post, std::string_view export_dir)
+{
+    const auto& test_info = *testing::UnitTest::GetInstance()->current_test_info();
+
+    json::json j;
+    auto& jt = j[test_info.name()];
+
+    auto& jenv = jt["env"];
+    jenv["currentNumber"] = hex0x(block.number);
+    jenv["currentTimestamp"] = hex0x(block.timestamp);
+    jenv["currentGasLimit"] = hex0x(block.gas_limit);
+    jenv["currentCoinbase"] = hex0x(block.coinbase);
+    jenv["currentBaseFee"] = hex0x(block.base_fee);
+
+    jt["pre"] = to_json(pre.get_accounts());
+
+    auto& jtx = jt["transaction"];
+    if (tx.to.has_value())
+        jtx["to"] = hex0x(*tx.to);
+    jtx["sender"] = hex0x(tx.sender);
+    jtx["secretKey"] = hex0x(SenderSecretKey);
+    jtx["nonce"] = hex0x(tx.nonce);
+    jtx["maxFeePerGas"] = hex0x(tx.max_gas_price);
+    jtx["maxPriorityFeePerGas"] = hex0x(tx.max_priority_gas_price);
+
+    jtx["data"][0] = hex0x(tx.data);
+    jtx["gasLimit"][0] = hex0x(tx.gas_limit);
+    jtx["value"][0] = hex0x(tx.value);
+
+    auto& jpost = jt["post"][evmc::to_string(rev)][0];
+    jpost["indexes"] = {{"data", 0}, {"gas", 0}, {"value", 0}};
+    jpost["hash"] = hex0x(mpt_hash(post.get_accounts()));
+    jpost["logs"] = hex0x(logs_hash(receipt.logs));
+
+    std::ofstream{get_export_test_path(test_info, export_dir)} << std::setw(2) << j;
 }
 }  // namespace evmone::test

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -24,6 +24,10 @@ protected:
     /// Private key: 0x2b1263d2b.
     static constexpr auto Sender = 0xe100713FC15400D1e94096a545879E7c6407001e_address;
 
+    /// The secret (private) key of the Sender address.
+    static constexpr auto SenderSecretKey =
+        0x00000000000000000000000000000000000000000000000000000002b1263d2b_bytes32;
+
     /// The default destination address of the test transaction.
     static constexpr auto To = 0xc0de_address;
 
@@ -65,6 +69,7 @@ protected:
     evmc_revision rev = EVMC_SHANGHAI;
     uint64_t block_reward = 0;
     BlockInfo block{
+        .number = 1,  // Some EVMs don't like blocks with number 0.
         .gas_limit = 1'000'000,
         .coinbase = Coinbase,
         .base_fee = 999,
@@ -83,6 +88,10 @@ protected:
 
     /// The test runner.
     void TearDown() override;
+
+    /// Exports the test in the JSON State Test format in the given directory.
+    void export_state_test(
+        const TransactionReceipt& receipt, const State& post, std::string_view export_dir);
 };
 
 }  // namespace evmone::test


### PR DESCRIPTION
Add option to export the "state_transition" test suite to JSON State Test format.

The current version of the export feature has limitations:
- tests with invalid transaction are not exported
- not every test property is properly exported
- some exported tests fail in `evmone-statetest`