### PR TITLE
Fix and update CREATE4 failure scenarios

### DIFF
--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -65,6 +65,15 @@ struct EOF1Header
         return container.substr(data_offset);
     }
 
+    /// A helper to check whether the container can be an initcontainer.
+    [[nodiscard]] bool can_init(bytes_view container) const noexcept
+    {
+        // Containers with truncated data section cannot be initcontainers.
+        const auto truncated_data =
+            static_cast<size_t>(data_offset + data_size) != container.size();
+        return !truncated_data;
+    }
+
     /// A helper to extract reference to a specific container section.
     [[nodiscard]] bytes_view get_container(
         bytes_view container, size_t container_idx) const noexcept

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -149,7 +149,7 @@ inline TermResult stop_impl(StackTop /*stack*/, int64_t gas_left, ExecutionState
     // STOP is forbidden inside CREATE3/4 context
     if constexpr (Status == EVMC_SUCCESS)
     {
-        if (state.msg->kind == EVMC_CREATE3 || state.msg->kind == EVMC_CREATE4)
+        if (state.msg->kind == EVMC_CREATE3_4)
             return {EVMC_UNDEFINED_INSTRUCTION, gas_left};
     }
 
@@ -1133,7 +1133,7 @@ inline TermResult return_impl(StackTop stack, int64_t gas_left, ExecutionState& 
     // RETURN is forbidden inside CREATE3 context
     if constexpr (StatusCode == EVMC_SUCCESS)
     {
-        if (state.msg->kind == EVMC_CREATE3 || state.msg->kind == EVMC_CREATE4)
+        if (state.msg->kind == EVMC_CREATE3_4)
             return {EVMC_UNDEFINED_INSTRUCTION, gas_left};
     }
 
@@ -1157,7 +1157,7 @@ inline TermResult returncontract(
     const auto& offset = stack[0];
     const auto& size = stack[1];
 
-    if (state.msg->kind != EVMC_CREATE3 && state.msg->kind != EVMC_CREATE4)
+    if (state.msg->kind != EVMC_CREATE3_4)
         return {EVMC_UNDEFINED_INSTRUCTION, gas_left};
 
     if (!check_memory(gas_left, state.memory, offset, size))

--- a/test/state/errors.hpp
+++ b/test/state/errors.hpp
@@ -23,6 +23,7 @@ enum ErrorCode : int
     GAS_LIMIT_REACHED,
     SENDER_NOT_EOA,
     INIT_CODE_SIZE_LIMIT_EXCEEDED,
+    INIT_CODE_COUNT_LIMIT_EXCEEDED,
     CREATE_BLOB_TX,
     EMPTY_BLOB_HASHES_LIST,
     INVALID_BLOB_HASH_VERSION,
@@ -66,6 +67,8 @@ inline const std::error_category& evmone_category() noexcept
                 return "sender not an eoa:";
             case INIT_CODE_SIZE_LIMIT_EXCEEDED:
                 return "max initcode size exceeded";
+            case INIT_CODE_COUNT_LIMIT_EXCEEDED:
+                return "max initcode count exceeded";
             case CREATE_BLOB_TX:
                 return "blob transaction must not be a create transaction";
             case EMPTY_BLOB_HASHES_LIST:

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -14,6 +14,7 @@ using evmc::uint256be;
 
 inline constexpr size_t max_code_size = 0x6000;
 inline constexpr size_t max_initcode_size = 2 * max_code_size;
+inline constexpr size_t max_initcode_count = 256;
 
 /// Computes the address of to-be-created contract.
 ///

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -390,6 +390,8 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
 
 [[nodiscard]] bytes rlp_encode(const Transaction& tx)
 {
+    assert(tx.type <= Transaction::Type::blob);
+
     // TODO: Refactor this function. For all type of transactions most of the code is similar.
     if (tx.type == Transaction::Type::legacy)
     {
@@ -422,7 +424,7 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
                    tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
                    tx.access_list, static_cast<bool>(tx.v), tx.r, tx.s);
     }
-    else
+    else  // Transaction::Type::blob
     {
         if (tx.v > 1)
             throw std::invalid_argument("`v` value for blob transaction must be 0 or 1");

--- a/test/unittests/evm_eof_test.cpp
+++ b/test/unittests/evm_eof_test.cpp
@@ -390,7 +390,7 @@ TEST_P(evm, eof_create3)
     EXPECT_EQ(output, "000000000000000000000000cc010203040506070809010203040506070809ce"_hex);
 
     // test executing initcontainer
-    msg.kind = EVMC_CREATE3;
+    msg.kind = EVMC_CREATE3_4;
     execute(init_container, aux_data);
     EXPECT_STATUS(EVMC_SUCCESS);
     const auto deployed_container = eof1_bytecode(bytecode(OP_INVALID), 0, deploy_data + aux_data);


### PR DESCRIPTION
- adjusts failure scenarios to new spec after https://github.com/ipsilon/eof/commit/e927c283e881136acb99981190dd4377463e6cd5
- fixes a stack management bug in CREATE4 light failure modes + adds test
- as a bonus it updates the validity rules for `InitcodeTransaction` and adds an `rlp_encode` specialization for it.

Do not merge before [changes to `evmc`](https://github.com/ethereum/evmc/pull/700) are merged (collapsing `EVMC_CREATE3` and `4`)