### PR TITLE
EOF bytecode test helper refactor

### DIFF
--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -257,8 +257,9 @@ TEST(analysis, jumpdests_groups)
 
 TEST(analysis, example1_eof1)
 {
-    const auto code = eof1_bytecode(
-        push(0x2a) + push(0x1e) + OP_MSTORE8 + OP_MSIZE + push(0) + OP_SSTORE, 2, "deadbeef");
+    const bytecode code =
+        eof_bytecode(push(0x2a) + push(0x1e) + OP_MSTORE8 + OP_MSIZE + push(0) + OP_SSTORE, 2)
+            .data("deadbeef");
     const auto header = evmone::read_valid_eof1_header(code);
     const auto analysis = analyze(EVMC_PRAGUE, header.get_code(code, 0));
 

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -619,7 +619,7 @@ TEST(eof_validation, deprecated_instructions)
 {
     for (auto op : {OP_CALLCODE, OP_SELFDESTRUCT, OP_JUMP, OP_JUMPI, OP_PC})
     {
-        EXPECT_EQ(validate_eof(eof1_bytecode(op)), EOFValidationError::undefined_instruction);
+        EXPECT_EQ(validate_eof(eof_bytecode(op)), EOFValidationError::undefined_instruction);
     }
 }
 
@@ -705,19 +705,19 @@ TEST(eof_validation, max_stack_height)
     }
 
     {
-        auto code = eof1_bytecode(rjumpi(2, 0) + 1 + OP_STOP, 1);
+        auto code = eof_bytecode(rjumpi(2, 0) + 1 + OP_STOP, 1);
 
         EXPECT_EQ(validate_eof(code), EOFValidationError::stack_height_mismatch);
     }
 
     {
-        auto code = eof1_bytecode(rjumpi(-3, 0) + OP_STOP, 1);
+        auto code = eof_bytecode(rjumpi(-3, 0) + OP_STOP, 1);
 
         EXPECT_EQ(validate_eof(code), EOFValidationError::stack_height_mismatch);
     }
 
     {
-        auto code = eof1_bytecode(rjumpv({-4}, 0) + OP_STOP, 1);
+        auto code = eof_bytecode(rjumpv({-4}, 0) + OP_STOP, 1);
 
         EXPECT_EQ(validate_eof(code), EOFValidationError::stack_height_mismatch);
     }
@@ -1063,17 +1063,17 @@ TEST(eof_validation, jumpf_into_returning_stack_validation)
 TEST(eof_validation, jumpf_stack_overflow)
 {
     {
-        const auto code = eof1_bytecode(512 * push(1) + OP_JUMPF + bytecode{"0x0000"_hex}, 512);
+        const auto code = eof_bytecode(512 * push(1) + OP_JUMPF + bytecode{"0x0000"_hex}, 512);
         EXPECT_EQ(validate_eof(code), EOFValidationError::success);
     }
 
     {
-        const auto code = eof1_bytecode(513 * push(1) + OP_JUMPF + bytecode{"0x0000"_hex}, 513);
+        const auto code = eof_bytecode(513 * push(1) + OP_JUMPF + bytecode{"0x0000"_hex}, 513);
         EXPECT_EQ(validate_eof(code), EOFValidationError::stack_overflow);
     }
 
     {
-        const auto code = eof1_bytecode(1023 * push(1) + OP_JUMPF + bytecode{"0x0000"_hex}, 1023);
+        const auto code = eof_bytecode(1023 * push(1) + OP_JUMPF + bytecode{"0x0000"_hex}, 1023);
         EXPECT_EQ(validate_eof(code), EOFValidationError::stack_overflow);
     }
 }

--- a/test/unittests/evm_eof_calls_test.cpp
+++ b/test/unittests/evm_eof_calls_test.cpp
@@ -12,15 +12,15 @@ TEST_P(evm, eof1_delegatecall_eof1)
 {
     rev = EVMC_PRAGUE;
     constexpr auto callee = 0xca11ee_address;
-    host.accounts[callee].code = eof1_bytecode(OP_STOP);
+    host.accounts[callee].code = eof_bytecode(OP_STOP);
     bytes call_output{0x01, 0x02, 0x03};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
     host.call_result.gas_left = 100;
     host.call_result.status_code = EVMC_SUCCESS;
 
-    const auto code = eof1_bytecode(delegatecall(callee) + OP_RETURNDATASIZE + OP_PUSH0 + OP_PUSH0 +
-                                        OP_RETURNDATACOPY + ret(0, evmone::OP_RETURNDATASIZE),
+    const auto code = eof_bytecode(delegatecall(callee) + OP_RETURNDATASIZE + OP_PUSH0 + OP_PUSH0 +
+                                       OP_RETURNDATACOPY + ret(0, evmone::OP_RETURNDATASIZE),
         6);
 
     execute(code);
@@ -39,7 +39,7 @@ TEST_P(evm, eof1_delegatecall_legacy)
         SCOPED_TRACE("target code: " + hex(target_code));
         host.accounts[callee].code = target_code;
 
-        const auto code = eof1_bytecode(delegatecall(callee) + ret_top(), 6);
+        const auto code = eof_bytecode(delegatecall(callee) + ret_top(), 6);
 
         execute(code);
         EXPECT_GAS_USED(EVMC_SUCCESS, 133);  // Low gas usage because DELEGATECALL fails lightly.

--- a/test/unittests/evm_eof_rjump_test.cpp
+++ b/test/unittests/evm_eof_rjump_test.cpp
@@ -15,15 +15,15 @@ TEST_P(evm, eof1_rjump)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjumpi(3, 0) + rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1), 2);
+    auto code = eof_bytecode(rjumpi(3, 0) + rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1), 2);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     ASSERT_EQ(result.output_size, 1);
     EXPECT_EQ(result.output_data[0], 1);
 
-    code = eof1_bytecode(
-        rjumpi(3, 0) + rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1), 2, "deadbeef");
+    code = eof_bytecode(rjumpi(3, 0) + rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1), 2)
+               .data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -38,14 +38,14 @@ TEST_P(evm, eof1_rjump_backward)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjump(10) + mstore8(0, 1) + ret(0, 1) + rjump(-13), 2);
+    auto code = eof_bytecode(rjump(10) + mstore8(0, 1) + ret(0, 1) + rjump(-13), 2);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     ASSERT_EQ(result.output_size, 1);
     EXPECT_EQ(result.output_data[0], 1);
 
-    code = eof1_bytecode(rjump(10) + mstore8(0, 1) + ret(0, 1) + rjump(-13), 2, "deadbeef");
+    code = eof_bytecode(rjump(10) + mstore8(0, 1) + ret(0, 1) + rjump(-13), 2).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -60,7 +60,7 @@ TEST_P(evm, eof1_rjump_0_offset)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjump(0) + mstore8(0, 1) + ret(0, 1), 2);
+    auto code = eof_bytecode(rjump(0) + mstore8(0, 1) + ret(0, 1), 2);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -75,7 +75,7 @@ TEST_P(evm, eof1_rjumpi)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(
+    auto code = eof_bytecode(
         rjumpi(10, calldataload(0)) + mstore8(0, 2) + ret(0, 1) + mstore8(0, 1) + ret(0, 1), 2);
 
     // RJUMPI condition is true
@@ -98,8 +98,8 @@ TEST_P(evm, eof1_rjumpi_backwards)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjump(10) + mstore8(0, 1) + ret(0, 1) + rjumpi(-16, calldataload(0)) +
-                                  mstore8(0, 2) + ret(0, 1),
+    auto code = eof_bytecode(rjump(10) + mstore8(0, 1) + ret(0, 1) + rjumpi(-16, calldataload(0)) +
+                                 mstore8(0, 2) + ret(0, 1),
         2);
 
     // RJUMPI condition is true
@@ -122,7 +122,7 @@ TEST_P(evm, eof1_rjumpi_0_offset)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjumpi(0, calldataload(0)) + mstore8(0, 1) + ret(0, 1), 2);
+    auto code = eof_bytecode(rjumpi(0, calldataload(0)) + mstore8(0, 1) + ret(0, 1), 2);
 
     // RJUMPI condition is true
     execute(code, "01"_hex);
@@ -144,9 +144,10 @@ TEST_P(evm, eof1_rjumpv_single_offset)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjumpv({3}, 0) + OP_JUMPDEST + OP_JUMPDEST + OP_STOP + 20 + 40 + 0 +
-                                  OP_CODECOPY + ret(0, 20),
-        3, "ef000101000402000100010300000000000000fe");
+    auto code = eof_bytecode(rjumpv({3}, 0) + OP_JUMPDEST + OP_JUMPDEST + OP_STOP + 20 + 40 + 0 +
+                                 OP_CODECOPY + ret(0, 20),
+        3)
+                    .data("ef000101000402000100010300000000000000fe");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -162,10 +163,11 @@ TEST_P(evm, eof1_rjumpv_multiple_offsets)
         return;
 
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(rjump(12) + 10 + 68 + 0 + OP_CODECOPY + ret(0, 10) +
-                                  rjumpv({12, -22, 0}, 1) + 10 + 78 + 0 + OP_CODECOPY + ret(0, 10) +
-                                  20 + 68 + 0 + OP_CODECOPY + ret(0, 20),
-        3, "ef000101000402000100010300000000000000fe");
+    bytecode code = eof_bytecode(rjump(12) + 10 + 68 + 0 + OP_CODECOPY + ret(0, 10) +
+                                     rjumpv({12, -22, 0}, 1) + 10 + 78 + 0 + OP_CODECOPY +
+                                     ret(0, 10) + 20 + 68 + 0 + OP_CODECOPY + ret(0, 20),
+        3)
+                        .data("ef000101000402000100010300000000000000fe");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -207,7 +209,7 @@ TEST_P(evm, eof1_rjumpv_long_jumps)
     code += rjumpv({-0x7FFF, 0x7FFF - 8 - 2 - 8}, 0) +
             (0x7fff - 8 - 2 - 8) * bytecode{OP_JUMPDEST} + 5 + ret_top();
 
-    code = eof1_bytecode(code, 2);
+    code = eof_bytecode(code, 2);
     auto& rjumpv_cond = code[0x7fff - 3 - 5 + 3 + 1 + 19];
 
     execute(code);

--- a/test/unittests/evm_eof_test.cpp
+++ b/test/unittests/evm_eof_test.cpp
@@ -9,7 +9,7 @@ using evmone::test::evm;
 
 TEST_P(evm, eof1_execution)
 {
-    const auto code = eof1_bytecode(OP_STOP);
+    const auto code = eof_bytecode(OP_STOP);
 
     rev = EVMC_CANCUN;
     execute(code);
@@ -24,7 +24,7 @@ TEST_P(evm, eof1_execution_with_data_section)
 {
     rev = EVMC_PRAGUE;
     // data section contains ret(0, 1)
-    const auto code = eof1_bytecode(mstore8(0, 1) + OP_STOP, 2, ret(0, 1));
+    const auto code = eof_bytecode(mstore8(0, 1) + OP_STOP, 2).data(ret(0, 1));
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -34,14 +34,14 @@ TEST_P(evm, eof1_execution_with_data_section)
 TEST_P(evm, eof1_codesize)
 {
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(mstore8(0, OP_CODESIZE) + ret(0, 1), 2);
+    auto code = eof_bytecode(mstore8(0, OP_CODESIZE) + ret(0, 1), 2);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     ASSERT_EQ(result.output_size, 1);
     EXPECT_EQ(result.output_data[0], 28);
 
-    code = eof1_bytecode(mstore8(0, OP_CODESIZE) + ret(0, 1), 2, "deadbeef");
+    code = eof_bytecode(mstore8(0, OP_CODESIZE) + ret(0, 1), 2).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -52,14 +52,14 @@ TEST_P(evm, eof1_codesize)
 TEST_P(evm, eof1_codecopy_full)
 {
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(bytecode{31} + 0 + 0 + OP_CODECOPY + ret(0, 31), 3);
+    auto code = eof_bytecode(bytecode{31} + 0 + 0 + OP_CODECOPY + ret(0, 31), 3);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "ef0001010004020001000c0400000000800003601f6000600039601f6000f3"_hex);
 
-    code = eof1_bytecode(bytecode{35} + 0 + 0 + OP_CODECOPY + ret(0, 35), 3, "deadbeef");
+    code = eof_bytecode(bytecode{35} + 0 + 0 + OP_CODECOPY + ret(0, 35), 3).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -70,14 +70,14 @@ TEST_P(evm, eof1_codecopy_full)
 TEST_P(evm, eof1_codecopy_header)
 {
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(bytecode{15} + 0 + 0 + OP_CODECOPY + ret(0, 15), 3);
+    auto code = eof_bytecode(bytecode{15} + 0 + 0 + OP_CODECOPY + ret(0, 15), 3);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(
         bytes_view(result.output_data, result.output_size), "ef0001010004020001000c04000000"_hex);
 
-    code = eof1_bytecode(bytecode{15} + 0 + 0 + OP_CODECOPY + ret(0, 15), 3, "deadbeef");
+    code = eof_bytecode(bytecode{15} + 0 + 0 + OP_CODECOPY + ret(0, 15), 3).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -88,13 +88,13 @@ TEST_P(evm, eof1_codecopy_header)
 TEST_P(evm, eof1_codecopy_code)
 {
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(bytecode{12} + 19 + 0 + OP_CODECOPY + ret(0, 12), 3);
+    auto code = eof_bytecode(bytecode{12} + 19 + 0 + OP_CODECOPY + ret(0, 12), 3);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size), "600c6013600039600c6000f3"_hex);
 
-    code = eof1_bytecode(bytecode{12} + 19 + 0 + OP_CODECOPY + ret(0, 12), 3, "deadbeef");
+    code = eof_bytecode(bytecode{12} + 19 + 0 + OP_CODECOPY + ret(0, 12), 3).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -105,7 +105,8 @@ TEST_P(evm, eof1_codecopy_data)
 {
     rev = EVMC_PRAGUE;
 
-    const auto code = eof1_bytecode(bytecode{4} + 31 + 0 + OP_CODECOPY + ret(0, 4), 3, "deadbeef");
+    const auto code =
+        eof_bytecode(bytecode{4} + 31 + 0 + OP_CODECOPY + ret(0, 4), 3).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -116,14 +117,14 @@ TEST_P(evm, eof1_codecopy_out_of_bounds)
 {
     // 4 bytes out of container bounds - result is implicitly 0-padded
     rev = EVMC_PRAGUE;
-    auto code = eof1_bytecode(bytecode{35} + 0 + 0 + OP_CODECOPY + ret(0, 35), 3);
+    auto code = eof_bytecode(bytecode{35} + 0 + 0 + OP_CODECOPY + ret(0, 35), 3);
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "ef0001010004020001000c04000000008000036023600060003960236000f300000000"_hex);
 
-    code = eof1_bytecode(bytecode{39} + 0 + 0 + OP_CODECOPY + ret(0, 39), 3, "deadbeef");
+    code = eof_bytecode(bytecode{39} + 0 + 0 + OP_CODECOPY + ret(0, 39), 3).data("deadbeef");
 
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
@@ -160,7 +161,7 @@ TEST_P(evm, eof1_dataload)
     // data is 64 bytes long
     const auto data = bytes(8, 0x0) + bytes(8, 0x11) + bytes(8, 0x22) + bytes(8, 0x33) +
                       bytes(8, 0xaa) + bytes(8, 0xbb) + bytes(8, 0xcc) + bytes(8, 0xdd);
-    const auto code = eof1_bytecode(calldataload(0) + OP_DATALOAD + ret_top(), 2, data);
+    const auto code = eof_bytecode(calldataload(0) + OP_DATALOAD + ret_top(), 2).data(data);
 
     // DATALOAD(0)
     execute(code, "00"_hex);
@@ -211,21 +212,21 @@ TEST_P(evm, eof1_dataloadn)
                       bytes(8, 0xaa) + bytes(8, 0xbb) + bytes(8, 0xcc) + bytes(8, 0xdd);
 
     // DATALOADN{0}
-    auto code = eof1_bytecode(bytecode(OP_DATALOADN) + "0000" + ret_top(), 2, data);
+    auto code = eof_bytecode(bytecode(OP_DATALOADN) + "0000" + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000111111111111111122222222222222223333333333333333"_hex);
 
     // DATALOADN{1}
-    code = eof1_bytecode(bytecode(OP_DATALOADN) + "0001" + ret_top(), 2, data);
+    code = eof_bytecode(bytecode(OP_DATALOADN) + "0001" + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "00000000000000111111111111111122222222222222223333333333333333aa"_hex);
 
     // DATALOADN{32}
-    code = eof1_bytecode(bytecode(OP_DATALOADN) + "0020" + ret_top(), 2, data);
+    code = eof_bytecode(bytecode(OP_DATALOADN) + "0020" + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
@@ -241,35 +242,35 @@ TEST_P(evm, eof1_datasize)
     rev = EVMC_PRAGUE;
 
     // no data section
-    auto code = eof1_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2);
+    auto code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000000"_hex);
 
     bytes data = {0x0};
-    code = eof1_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2, data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000001"_hex);
 
     data = bytes(32, 0x0);
-    code = eof1_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2, data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000020"_hex);
 
     data = bytes(64, 0x0);
-    code = eof1_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2, data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000040"_hex);
 
     data = bytes(80, 0x0);
-    code = eof1_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2, data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
@@ -287,49 +288,49 @@ TEST_P(evm, eof1_datacopy)
     const auto data = bytes(8, 0x0) + bytes(8, 0x11) + bytes(8, 0x22) + bytes(8, 0x33) +
                       bytes(8, 0xaa) + bytes(8, 0xbb) + bytes(8, 0xcc) + bytes(8, 0xdd);
 
-    auto code = eof1_bytecode(bytecode(1) + 0 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    auto code = eof_bytecode(bytecode(1) + 0 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000000"_hex);
 
-    code = eof1_bytecode(bytecode(1) + 8 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(1) + 8 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "1100000000000000000000000000000000000000000000000000000000000000"_hex);
 
-    code = eof1_bytecode(bytecode(1) + 63 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(1) + 63 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "dd00000000000000000000000000000000000000000000000000000000000000"_hex);
 
-    code = eof1_bytecode(bytecode(0) + 64 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(0) + 64 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000000"_hex);
 
-    code = eof1_bytecode(bytecode(16) + 8 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(16) + 8 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "1111111111111111222222222222222200000000000000000000000000000000"_hex);
 
-    code = eof1_bytecode(bytecode(32) + 8 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(32) + 8 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "111111111111111122222222222222223333333333333333aaaaaaaaaaaaaaaa"_hex);
 
-    code = eof1_bytecode(bytecode(8) + 63 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(8) + 63 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "dd00000000000000000000000000000000000000000000000000000000000000"_hex);
 
-    code = eof1_bytecode(bytecode(0) + 65 + 0 + OP_DATACOPY + ret(0, 32), 3, data);
+    code = eof_bytecode(bytecode(0) + 65 + 0 + OP_DATACOPY + ret(0, 32), 3).data(data);
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
@@ -344,7 +345,7 @@ TEST_P(evm, datacopy_memory_cost)
 
     rev = EVMC_PRAGUE;
     const auto data = bytes{0};
-    const auto code = eof1_bytecode(bytecode(1) + 0 + 0 + OP_DATACOPY + OP_STOP, 3, data);
+    const auto code = eof_bytecode(bytecode(1) + 0 + 0 + OP_DATACOPY + OP_STOP, 3).data(data);
     execute(18, code);
     EXPECT_GAS_USED(EVMC_SUCCESS, 18);
 

--- a/test/unittests/evm_memory_test.cpp
+++ b/test/unittests/evm_memory_test.cpp
@@ -215,7 +215,7 @@ TEST_P(evm, memory_access)
                     continue;
 
                 code += bytecode{OP_STOP};
-                code = eof1_bytecode(code, 3, bytes(32, 0));
+                code = eof_bytecode(code, 3).data(bytes(32, 0));
             }
 
             const auto gas = 8796294610952;

--- a/test/unittests/state_transition_eof_test.cpp
+++ b/test/unittests/state_transition_eof_test.cpp
@@ -19,7 +19,7 @@ TEST_F(state_transition, eof_invalid_initcode)
         {
             .nonce = 1,
             .storage = {{0x01_bytes32, {.current = 0x01_bytes32, .original = 0x01_bytes32}}},
-            .code = eof1_bytecode(create() + push(1) + OP_SSTORE + OP_STOP, 3),
+            .code = eof_bytecode(create() + push(1) + OP_SSTORE + OP_STOP, 3),
         });
 
     EXPECT_EQ(pre.get(tx.sender).balance, 1'000'000'001);  // Fixture sanity check.

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -287,7 +287,7 @@ TEST_F(tracing, trace_eof)
     vm.add_tracer(evmone::create_instruction_tracer(trace_stream));
 
     trace_stream << '\n';
-    EXPECT_EQ(trace(eof1_bytecode(add(2, 3) + OP_STOP, 2), 0, 0, EVMC_PRAGUE), R"(
+    EXPECT_EQ(trace(bytecode{eof_bytecode(add(2, 3) + OP_STOP, 2)}, 0, 0, EVMC_PRAGUE), R"(
 {"pc":0,"op":96,"gas":"0xf4240","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":2,"op":96,"gas":"0xf423d","gasCost":"0x3","memSize":0,"stack":["0x3"],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":4,"op":1,"gas":"0xf423a","gasCost":"0x3","memSize":0,"stack":["0x3","0x2"],"depth":1,"refund":0,"opName":"ADD"}

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <evmc/evmc.hpp>
+#include <evmone/eof.hpp>
 #include <evmone/instructions_traits.hpp>
 #include <intx/intx.hpp>
 #include <test/utils/utils.hpp>
@@ -93,33 +94,57 @@ big_endian(T value)
 struct eof_bytecode
 {
 private:
-    bytecode m_code;
+    std::vector<bytecode> m_codes;
+    std::vector<evmone::EOFCodeType> m_types;
     bytecode m_data;
-    uint16_t m_max_stack_height = 0;
 
     /// Constructs EOF header bytes
     bytecode header() const
     {
-        assert(m_code.size() <= std::numeric_limits<uint16_t>::max());
+        assert(!m_codes.empty());
+        assert(m_codes[0].size() <= std::numeric_limits<uint16_t>::max());
         assert(m_data.size() <= std::numeric_limits<uint16_t>::max());
+        assert(m_codes.size() == m_types.size());
 
         constexpr uint8_t version = 0x01;
-        const auto code_size = static_cast<uint16_t>(m_code.size());
-        const auto data_size = static_cast<uint16_t>(m_data.size());
 
         bytecode out{bytes{0xEF, 0x00, version}};
-        out += "01" + big_endian(uint16_t{4});  // type header
-        out += "02"_hex + big_endian(uint16_t{1}) + big_endian(code_size);
+
+        // type header
+        const auto types_size = static_cast<uint16_t>(m_types.size() * 4);
+        out += "01" + big_endian(types_size);
+
+        // codes header
+        const auto code_count = static_cast<uint16_t>(m_codes.size());
+        out += "02"_hex + big_endian(code_count);
+        for (const auto& code : m_codes)
+        {
+            const auto code_size = static_cast<uint16_t>(code.size());
+            out += big_endian(code_size);
+        }
+
+        // data header
+        const auto data_size = static_cast<uint16_t>(m_data.size());
         out += "04" + big_endian(data_size);
-        out += "00";
-        out += "0080"_hex + big_endian(m_max_stack_height);  // type section
+        out += "00";  // terminator
+
+        // types section
+        for (const auto& type : m_types)
+            out += bytes{type.inputs, type.outputs} + big_endian(type.max_stack_height);
         return out;
     }
 
 public:
     explicit eof_bytecode(bytecode code, uint16_t max_stack_height = 0)
-      : m_code{std::move(code)}, m_max_stack_height{max_stack_height}
+      : m_codes{std::move(code)}, m_types{{0, 0x80, max_stack_height}}
     {}
+
+    auto& code(bytecode c, uint8_t inputs, uint8_t outputs, uint8_t max_stack_height)
+    {
+        m_codes.emplace_back(std::move(c));
+        m_types.emplace_back(inputs, outputs, max_stack_height);
+        return *this;
+    }
 
     auto& data(bytecode d)
     {
@@ -127,8 +152,20 @@ public:
         return *this;
     }
 
-    operator bytecode() const { return header() + m_code + m_data; }
+    operator bytecode() const
+    {
+        bytecode out{header()};
+        for (const auto& code : m_codes)
+            out += code;
+        out += m_data;
+        return out;
+    }
 };
+
+inline bytecode push0()
+{
+    return OP_PUSH0;
+}
 
 inline bytecode push(bytes_view data)
 {

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -90,31 +90,45 @@ big_endian(T value)
     return {static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value)};
 }
 
-inline bytecode eof_header(
-    uint8_t version, uint16_t code_size, uint16_t max_stack_height, uint16_t data_size)
+struct eof_bytecode
 {
-    bytecode out{bytes{0xEF, 0x00, version}};
-    out += "01" + big_endian(uint16_t{4});  // type header
-    out += "02"_hex + big_endian(uint16_t{1}) + big_endian(code_size);
-    out += "04" + big_endian(data_size);
-    out += "00";
-    out += "0080"_hex + big_endian(max_stack_height);  // type section
-    return out;
-}
+private:
+    bytecode m_code;
+    bytecode m_data;
+    uint16_t m_max_stack_height = 0;
 
-inline bytecode eof1_header(uint16_t code_size, uint16_t max_stack_height, uint16_t data_size = 0)
-{
-    return eof_header(1, code_size, max_stack_height, data_size);
-}
+    /// Constructs EOF header bytes
+    bytecode header() const
+    {
+        assert(m_code.size() <= std::numeric_limits<uint16_t>::max());
+        assert(m_data.size() <= std::numeric_limits<uint16_t>::max());
 
-inline bytecode eof1_bytecode(bytecode code, uint16_t max_stack_height = 0, bytecode data = {})
-{
-    assert(code.size() <= std::numeric_limits<uint16_t>::max());
-    assert(data.size() <= std::numeric_limits<uint16_t>::max());
-    return eof1_header(static_cast<uint16_t>(code.size()), max_stack_height,
-               static_cast<uint16_t>(data.size())) +
-           code + data;
-}
+        constexpr uint8_t version = 0x01;
+        const auto code_size = static_cast<uint16_t>(m_code.size());
+        const auto data_size = static_cast<uint16_t>(m_data.size());
+
+        bytecode out{bytes{0xEF, 0x00, version}};
+        out += "01" + big_endian(uint16_t{4});  // type header
+        out += "02"_hex + big_endian(uint16_t{1}) + big_endian(code_size);
+        out += "04" + big_endian(data_size);
+        out += "00";
+        out += "0080"_hex + big_endian(m_max_stack_height);  // type section
+        return out;
+    }
+
+public:
+    explicit eof_bytecode(bytecode code, uint16_t max_stack_height = 0)
+      : m_code{std::move(code)}, m_max_stack_height{max_stack_height}
+    {}
+
+    auto& data(bytecode d)
+    {
+        m_data = std::move(d);
+        return *this;
+    }
+
+    operator bytecode() const { return header() + m_code + m_data; }
+};
 
 inline bytecode push(bytes_view data)
 {


### PR DESCRIPTION
New builder-like utility in `bytecode.hpp` to generate EOF containers instead of old `eof1_bytecode()` function.