### PR TITLE
Compatibility with CMake 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.16...3.24)
+cmake_minimum_required(VERSION 3.16...3.27)
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/evmc/.git)
     message(FATAL_ERROR "Git submodules not initialized, execute:\n  git submodule update --init")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,17 +47,18 @@ cable_configure_compiler(NO_STACK_PROTECTION)
 if(CABLE_COMPILER_GNULIKE)
     add_compile_options(
         -Wmissing-declarations
-        -Wno-attributes  # Allow using unknown attributes.
-        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-missing-field-initializers>
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
+
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes>
+        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wno-missing-field-initializers>
+        $<$<CXX_COMPILER_ID:GNU>:-Wduplicated-cond>
+        $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
+
+        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unknown-attributes>
+        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wduplicate-enum>
+        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wnewline-eof>
+        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wunreachable-code-aggressive>
     )
-    cable_add_cxx_compiler_flag_if_supported(-Wduplicated-cond)
-    cable_add_cxx_compiler_flag_if_supported(-Wduplicate-enum)
-    cable_add_cxx_compiler_flag_if_supported(-Wfinal-dtor-non-final-class)
-    cable_add_cxx_compiler_flag_if_supported(-Wlogical-op)
-    cable_add_cxx_compiler_flag_if_supported(-Wnewline-eof)
-    cable_add_cxx_compiler_flag_if_supported(-Wsuggest-destructor-override)
-    cable_add_cxx_compiler_flag_if_supported(-Wunreachable-code-break)
 
     if(CABLE_COMPILER_CLANG)
         set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -7,7 +7,7 @@ set(HUNTER_CONFIGURATION_TYPES Release CACHE STRING "Build type of Hunter packag
 include(HunterGate)
 
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.24.11.tar.gz"
-    SHA1 "e49fb20a135675e406e95fbe9a591a630ccbbeaf"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.25.3.tar.gz"
+    SHA1 "0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb"
     LOCAL
 )

--- a/cmake/cable/HunterGate.cmake
+++ b/cmake/cable/HunterGate.cmake
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.2)
+#     cmake_minimum_required(VERSION 3.5)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -39,16 +39,16 @@
 #     hunter_add_package(Boo COMPONENTS Bar Baz)
 #
 # Projects:
-#     * https://github.com/hunter-packages/gate/
-#     * https://github.com/ruslo/hunter
+#     * https://github.com/cpp-pm/gate/
+#     * https://github.com/cpp-pm/hunter
 
 option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
 
 if(HUNTER_ENABLED)
-  if(CMAKE_VERSION VERSION_LESS "3.2")
+  if(CMAKE_VERSION VERSION_LESS "3.5")
     message(
         FATAL_ERROR
-        "At least CMake version 3.2 required for Hunter dependency management."
+        "At least CMake version 3.5 required for Hunter dependency management."
         " Update CMake or set HUNTER_ENABLED to OFF."
     )
   endif()
@@ -59,8 +59,9 @@ include(CMakeParseArguments) # cmake_parse_arguments
 option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
 option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
+set(HUNTER_ROOT "" CACHE FILEPATH "Override the HUNTER_ROOT.")
 
-set(HUNTER_ERROR_PAGE "https://docs.hunter.sh/en/latest/reference/errors")
+set(HUNTER_ERROR_PAGE "https://hunter.readthedocs.io/en/latest/reference/errors")
 
 function(hunter_gate_status_print)
   if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
@@ -133,10 +134,14 @@ function(hunter_gate_self root version sha1 result)
 
   string(SUBSTRING "${sha1}" 0 7 archive_id)
 
-  set(
-      hunter_self
-      "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
-  )
+  if(EXISTS "${root}/cmake/Hunter")
+    set(hunter_self "${root}")
+  else()
+    set(
+        hunter_self
+        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+    )
+  endif()
 
   set("${result}" "${hunter_self}" PARENT_SCOPE)
 endfunction()
@@ -144,24 +149,21 @@ endfunction()
 # Set HUNTER_GATE_ROOT cmake variable to suitable value.
 function(hunter_gate_detect_root)
   # Check CMake variable
-  string(COMPARE NOTEQUAL "${HUNTER_ROOT}" "" not_empty)
-  if(not_empty)
+  if(HUNTER_ROOT)
     set(HUNTER_GATE_ROOT "${HUNTER_ROOT}" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT detected by cmake variable")
     return()
   endif()
 
   # Check environment variable
-  string(COMPARE NOTEQUAL "$ENV{HUNTER_ROOT}" "" not_empty)
-  if(not_empty)
+  if(DEFINED ENV{HUNTER_ROOT})
     set(HUNTER_GATE_ROOT "$ENV{HUNTER_ROOT}" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT detected by environment variable")
     return()
   endif()
 
   # Check HOME environment variable
-  string(COMPARE NOTEQUAL "$ENV{HOME}" "" result)
-  if(result)
+  if(DEFINED ENV{HOME})
     set(HUNTER_GATE_ROOT "$ENV{HOME}/.hunter" PARENT_SCOPE)
     hunter_gate_status_debug("HUNTER_ROOT set using HOME environment variable")
     return()
@@ -169,8 +171,7 @@ function(hunter_gate_detect_root)
 
   # Check SYSTEMDRIVE and USERPROFILE environment variable (windows only)
   if(WIN32)
-    string(COMPARE NOTEQUAL "$ENV{SYSTEMDRIVE}" "" result)
-    if(result)
+    if(DEFINED ENV{SYSTEMDRIVE})
       set(HUNTER_GATE_ROOT "$ENV{SYSTEMDRIVE}/.hunter" PARENT_SCOPE)
       hunter_gate_status_debug(
           "HUNTER_ROOT set using SYSTEMDRIVE environment variable"
@@ -178,8 +179,7 @@ function(hunter_gate_detect_root)
       return()
     endif()
 
-    string(COMPARE NOTEQUAL "$ENV{USERPROFILE}" "" result)
-    if(result)
+    if(DEFINED ENV{USERPROFILE})
       set(HUNTER_GATE_ROOT "$ENV{USERPROFILE}/.hunter" PARENT_SCOPE)
       hunter_gate_status_debug(
           "HUNTER_ROOT set using USERPROFILE environment variable"
@@ -253,7 +253,13 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.2)\n"
+      "cmake_minimum_required(VERSION 3.5)\n"
+      "if(POLICY CMP0114)\n"
+      "  cmake_policy(SET CMP0114 NEW)\n"
+      "endif()\n"
+      "if(POLICY CMP0135)\n"
+      "  cmake_policy(SET CMP0135 NEW)\n"
+      "endif()\n"
       "project(HunterDownload LANGUAGES NONE)\n"
       "include(ExternalProject)\n"
       "ExternalProject_Add(\n"
@@ -490,37 +496,46 @@ macro(HunterGate)
     )
 
     set(_master_location "${_hunter_self}/cmake/Hunter")
-    get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
-    set(_done_location "${_archive_id_location}/DONE")
-    set(_sha1_location "${_archive_id_location}/SHA1")
+    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
+      # Hunter downloaded manually (e.g. by 'git clone')
+      set(_unused "xxxxxxxxxx")
+      set(HUNTER_GATE_SHA1 "${_unused}")
+      set(HUNTER_GATE_VERSION "${_unused}")
+    else()
+      get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+      set(_done_location "${_archive_id_location}/DONE")
+      set(_sha1_location "${_archive_id_location}/SHA1")
 
-    # Check Hunter already downloaded by HunterGate
-    if(NOT EXISTS "${_done_location}")
-      hunter_gate_download("${_archive_id_location}")
-    endif()
+      # Check Hunter already downloaded by HunterGate
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_download("${_archive_id_location}")
+      endif()
 
-    if(NOT EXISTS "${_done_location}")
-      hunter_gate_internal_error("hunter_gate_download failed")
-    endif()
+      if(NOT EXISTS "${_done_location}")
+        hunter_gate_internal_error("hunter_gate_download failed")
+      endif()
 
-    if(NOT EXISTS "${_sha1_location}")
-      hunter_gate_internal_error("${_sha1_location} not found")
-    endif()
-    file(READ "${_sha1_location}" _sha1_value)
-    string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
-    if(NOT _is_equal)
-      hunter_gate_internal_error(
-          "Short SHA1 collision:"
-          "  ${_sha1_value} (from ${_sha1_location})"
-          "  ${HUNTER_GATE_SHA1} (HunterGate)"
-      )
-    endif()
-    if(NOT EXISTS "${_master_location}")
-      hunter_gate_user_error(
-          "Master file not found:"
-          "  ${_master_location}"
-          "try to update Hunter/HunterGate"
-      )
+      if(NOT EXISTS "${_sha1_location}")
+        hunter_gate_internal_error("${_sha1_location} not found")
+      endif()
+      file(READ "${_sha1_location}" _sha1_value)
+      string(TOLOWER "${_sha1_value}" _sha1_value_lower)
+      string(TOLOWER "${HUNTER_GATE_SHA1}" _HUNTER_GATE_SHA1_lower)
+      string(COMPARE EQUAL "${_sha1_value_lower}" "${_HUNTER_GATE_SHA1_lower}" _is_equal)
+      if(NOT _is_equal)
+        hunter_gate_internal_error(
+            "Short SHA1 collision:"
+            "  ${_sha1_value} (from ${_sha1_location})"
+            "  ${HUNTER_GATE_SHA1} (HunterGate)"
+        )
+      endif()
+      if(NOT EXISTS "${_master_location}")
+        hunter_gate_user_error(
+            "Master file not found:"
+            "  ${_master_location}"
+            "try to update Hunter/HunterGate"
+        )
+      endif()
     endif()
     include("${_master_location}")
     set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -117,7 +117,7 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
     {
         if (advanced_vm != nullptr)
         {
-            RegisterBenchmark(("advanced/analyse/" + b.name).c_str(), [&b](State& state) {
+            RegisterBenchmark("advanced/analyse/" + b.name, [&b](State& state) {
                 bench_analyse<advanced::AdvancedCodeAnalysis, advanced_analyse>(
                     state, default_revision, b.code);
             })->Unit(kMicrosecond);
@@ -125,7 +125,7 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
 
         if (baseline_vm != nullptr)
         {
-            RegisterBenchmark(("baseline/analyse/" + b.name).c_str(), [&b](State& state) {
+            RegisterBenchmark("baseline/analyse/" + b.name, [&b](State& state) {
                 bench_analyse<baseline::CodeAnalysis, baseline_analyse>(
                     state, default_revision, b.code);
             })->Unit(kMicrosecond);
@@ -138,7 +138,7 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
             if (advanced_vm != nullptr)
             {
                 const auto name = "advanced/execute/" + case_name;
-                RegisterBenchmark(name.c_str(), [&vm = *advanced_vm, &b, &input](State& state) {
+                RegisterBenchmark(name, [&vm = *advanced_vm, &b, &input](State& state) {
                     bench_advanced_execute(state, vm, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }
@@ -146,7 +146,7 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
             if (baseline_vm != nullptr)
             {
                 const auto name = "baseline/execute/" + case_name;
-                RegisterBenchmark(name.c_str(), [&vm = *baseline_vm, &b, &input](State& state) {
+                RegisterBenchmark(name, [&vm = *baseline_vm, &b, &input](State& state) {
                     bench_baseline_execute(state, vm, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }
@@ -154,7 +154,7 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
             if (basel_cg_vm != nullptr)
             {
                 const auto name = "bnocgoto/execute/" + case_name;
-                RegisterBenchmark(name.c_str(), [&vm = *basel_cg_vm, &b, &input](State& state) {
+                RegisterBenchmark(name, [&vm = *basel_cg_vm, &b, &input](State& state) {
                     bench_baseline_execute(state, vm, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }
@@ -162,7 +162,7 @@ void register_benchmarks(std::span<const BenchmarkCase> benchmark_cases)
             for (auto& [vm_name, vm] : registered_vms)
             {
                 const auto name = std::string{vm_name} + "/total/" + case_name;
-                RegisterBenchmark(name.c_str(), [&vm_ = vm, &b, &input](State& state) {
+                RegisterBenchmark(name, [&vm_ = vm, &b, &input](State& state) {
                     bench_evmc_execute(state, vm_, b.code, input.input, input.expected_output);
                 })->Unit(kMicrosecond);
             }

--- a/test/bench/synthetic_benchmarks.cpp
+++ b/test/bench/synthetic_benchmarks.cpp
@@ -256,9 +256,10 @@ void register_synthetic_benchmarks()
 
     for (auto& [vm_name, vm] : registered_vms)
     {
-        RegisterBenchmark((std::string{vm_name} + "/total/synth/loop_v1").c_str(),
+        // TODO(clang16): Simplify lambda capture [&vm].
+        RegisterBenchmark(std::string{vm_name} + "/total/synth/loop_v1",
             [&vm_ = vm](State& state) { bench_evmc_execute(state, vm_, generate_loop_v1({})); });
-        RegisterBenchmark((std::string{vm_name} + "/total/synth/loop_v2").c_str(),
+        RegisterBenchmark(std::string{vm_name} + "/total/synth/loop_v2",
             [&vm_ = vm](State& state) { bench_evmc_execute(state, vm_, generate_loop_v2({})); });
     }
 
@@ -266,7 +267,7 @@ void register_synthetic_benchmarks()
     {
         for (auto& [vm_name, vm] : registered_vms)
         {
-            RegisterBenchmark((std::string{vm_name} + "/total/synth/" + to_string(params)).c_str(),
+            RegisterBenchmark(std::string{vm_name} + "/total/synth/" + to_string(params),
                 [&vm_ = vm, params](
                     State& state) { bench_evmc_execute(state, vm_, generate_code(params)); })
                 ->Unit(kMicrosecond);

--- a/test/internal_benchmarks/.clang-tidy
+++ b/test/internal_benchmarks/.clang-tidy
@@ -1,0 +1,3 @@
+InheritParentConfig: true
+Checks: >
+  -clang-analyzer-unix.Malloc

--- a/test/internal_benchmarks/memory_allocation.cpp
+++ b/test/internal_benchmarks/memory_allocation.cpp
@@ -13,14 +13,14 @@ namespace
 {
 void malloc_(size_t size) noexcept
 {
-    const auto m = std::malloc(size);
+    auto m = std::malloc(size);
     benchmark::DoNotOptimize(m);
     std::free(m);
 }
 
 void calloc_(size_t size) noexcept
 {
-    const auto m = std::calloc(1, size);
+    auto m = std::calloc(1, size);
     benchmark::DoNotOptimize(m);
     std::free(m);
 }
@@ -28,7 +28,7 @@ void calloc_(size_t size) noexcept
 void os_specific(size_t size) noexcept
 {
 #if defined(__unix__) || defined(__APPLE__)
-    const auto m = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
+    auto m = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS, -1, 0);
     benchmark::DoNotOptimize(m);
     munmap(m, size);
 #else


### PR DESCRIPTION
Bump max CMake compatible version to 3.27. Upgrade Hunter to get new dependencies and fix CMake 3.27 warnings. Clean up compiler warning flags.