### PR TITLE
Minor cleanup of RETF stack validation

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -406,14 +406,14 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
                     static_cast<int8_t>(code_types[func_index].outputs + code_types[fid].inputs -
                                         code_types[fid].outputs);
                 if (stack_heights[i] > stack_height_required)
-                    return EOFValidationError::code_section_outputs_mismatch;
+                    return EOFValidationError::stack_higher_than_outputs_required;
             }
         }
         else if (opcode == OP_RETF)
         {
             stack_height_required = static_cast<int8_t>(code_types[func_index].outputs);
             if (stack_height > code_types[func_index].outputs)
-                return EOFValidationError::code_section_outputs_mismatch;
+                return EOFValidationError::stack_higher_than_outputs_required;
         }
 
         if (stack_height < stack_height_required)
@@ -679,8 +679,8 @@ std::string_view get_error_message(EOFValidationError err) noexcept
         return "no_terminating_instruction";
     case EOFValidationError::stack_height_mismatch:
         return "stack_height_mismatch";
-    case EOFValidationError::code_section_outputs_mismatch:
-        return "code_section_outputs_mismatch";
+    case EOFValidationError::stack_higher_than_outputs_required:
+        return "stack_higher_than_outputs_required";
     case EOFValidationError::unreachable_instructions:
         return "unreachable_instructions";
     case EOFValidationError::stack_underflow:

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -409,6 +409,12 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
                     return EOFValidationError::code_section_outputs_mismatch;
             }
         }
+        else if (opcode == OP_RETF)
+        {
+            stack_height_required = static_cast<int8_t>(code_types[func_index].outputs);
+            if (stack_height > code_types[func_index].outputs)
+                return EOFValidationError::code_section_outputs_mismatch;
+        }
 
         if (stack_height < stack_height_required)
             return EOFValidationError::stack_underflow;
@@ -469,8 +475,6 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
                     return EOFValidationError::stack_height_mismatch;
             }
         }
-        else if (opcode == OP_RETF && stack_height != code_types[func_index].outputs)
-            return EOFValidationError::code_section_outputs_mismatch;
     }
 
     const auto max_stack_height = *std::max_element(stack_heights.begin(), stack_heights.end());

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -91,7 +91,7 @@ enum class EOFValidationError
     invalid_max_stack_height,
     no_terminating_instruction,
     stack_height_mismatch,
-    code_section_outputs_mismatch,
+    stack_higher_than_outputs_required,
     max_stack_height_above_limit,
     inputs_outputs_num_above_limit,
     unreachable_instructions,

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -909,7 +909,7 @@ TEST(eof_validation, callf_stack_validation)
         validate_eof(eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 1)
                          .code(push0() + push0() + push0() + OP_CALLF + "0002" + OP_RETF, 0, 1, 3)
                          .code(bytecode(OP_POP) + OP_RETF, 2, 1, 2)),
-        EOFValidationError::code_section_outputs_mismatch);
+        EOFValidationError::stack_higher_than_outputs_required);
 
     EXPECT_EQ(validate_eof(eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 1)
                                .code(push0() + OP_CALLF + "0002" + OP_RETF, 0, 1, 1)
@@ -931,7 +931,7 @@ TEST(eof_validation, retf_stack_validation)
     // 2 outputs, RETF has 3 values on stack
     code = eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 2)
                .code(push0() + push0() + push0() + OP_RETF, 0, 2, 3);
-    EXPECT_EQ(validate_eof(code), EOFValidationError::code_section_outputs_mismatch);
+    EXPECT_EQ(validate_eof(code), EOFValidationError::stack_higher_than_outputs_required);
 }
 
 TEST(eof_validation, non_returning_status)
@@ -1049,7 +1049,7 @@ TEST(eof_validation, jumpf_into_returning_stack_validation)
         validate_eof(eof_bytecode(bytecode{OP_STOP})
                          .code(push0() + push0() + push0() + push0() + OP_JUMPF + "0002", 0, 2, 4)
                          .code(bytecode(OP_POP) + OP_RETF, 3, 2, 3)),
-        EOFValidationError::code_section_outputs_mismatch);
+        EOFValidationError::stack_higher_than_outputs_required);
 
     // Not enough inputs on stack at JUMPF
     EXPECT_EQ(validate_eof(eof_bytecode(bytecode{OP_STOP})
@@ -1073,7 +1073,7 @@ TEST(eof_validation, jumpf_into_returning_stack_validation)
             eof_bytecode(bytecode{OP_STOP})
                 .code(push0() + push0() + push0() + push0() + push0() + OP_JUMPF + "0002", 0, 2, 5)
                 .code(bytecode(OP_POP) + OP_POP + OP_RETF, 3, 1, 3)),
-        EOFValidationError::code_section_outputs_mismatch);
+        EOFValidationError::stack_higher_than_outputs_required);
 
     // Not enough inputs on stack at JUMPF
     EXPECT_EQ(validate_eof(eof_bytecode(bytecode{OP_STOP})

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -917,6 +917,23 @@ TEST(eof_validation, callf_stack_validation)
         EOFValidationError::stack_underflow);
 }
 
+TEST(eof_validation, retf_stack_validation)
+{
+    // 2 outputs, RETF has 2 values on stack
+    auto code = eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 2)
+                    .code(push0() + push0() + OP_RETF, 0, 2, 2);
+    EXPECT_EQ(validate_eof(code), EOFValidationError::success);
+
+    // 2 outputs, RETF has 1 value on stack
+    code = eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 2).code(push0() + OP_RETF, 0, 2, 1);
+    EXPECT_EQ(validate_eof(code), EOFValidationError::code_section_outputs_mismatch);
+
+    // 2 outputs, RETF has 3 values on stack
+    code = eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 2)
+               .code(push0() + push0() + push0() + OP_RETF, 0, 2, 3);
+    EXPECT_EQ(validate_eof(code), EOFValidationError::code_section_outputs_mismatch);
+}
+
 TEST(eof_validation, non_returning_status)
 {
     // Non-returning with no JUMPF and no RETF

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -926,7 +926,7 @@ TEST(eof_validation, retf_stack_validation)
 
     // 2 outputs, RETF has 1 value on stack
     code = eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 2).code(push0() + OP_RETF, 0, 2, 1);
-    EXPECT_EQ(validate_eof(code), EOFValidationError::code_section_outputs_mismatch);
+    EXPECT_EQ(validate_eof(code), EOFValidationError::stack_underflow);
 
     // 2 outputs, RETF has 3 values on stack
     code = eof_bytecode(bytecode{OP_CALLF} + "0001" + OP_STOP, 2)


### PR DESCRIPTION
The only observable change here is that now stack height / outputs mismatch at `RETF` can produce two different errors:
- `stack_underflow` when not enough outputs
- `stack_higher_than_outputs_required` when extra items left on stack.

Before both cases produced `code_section_outputs_mismatch` error.

This makes it consistent with similar cases for `JUMPF`, which already produce these two different errors.