### PR TITLE
MPT refactoring

### DIFF
--- a/test/state/mpt.cpp
+++ b/test/state/mpt.cpp
@@ -12,55 +12,69 @@ namespace evmone::state
 namespace
 {
 /// The collection of nibbles (4-bit values) representing a path in a MPT.
-struct Path
+///
+/// TODO(c++26): This is an instance of std::inplace_vector.
+class Path
 {
-    size_t length = 0;  // TODO: Can be converted to uint8_t.
-    uint8_t nibbles[64]{};
+    static constexpr size_t max_size = 64;
 
+    size_t m_size = 0;  // TODO: Can be converted to uint8_t.
+    uint8_t m_nibbles[max_size]{};
+
+public:
     Path() = default;
 
-    explicit Path(bytes_view key) noexcept : length{2 * key.size()}
+    /// Constructs a path from a pair of iterators.
+    Path(const uint8_t* first, const uint8_t* last) noexcept
+      : m_size(static_cast<size_t>(last - first))
     {
-        assert(length <= std::size(nibbles));
+        assert(m_size <= std::size(m_nibbles));
+        std::copy(first, last, m_nibbles);
+    }
+
+    /// Constructs a path from bytes - each byte will produce 2 nibbles in the path.
+    explicit Path(bytes_view key) noexcept : m_size{2 * key.size()}
+    {
+        assert(m_size <= std::size(m_nibbles) && "a keys must not be longer than 32 bytes");
         size_t i = 0;
         for (const auto b : key)
         {
-            // static_cast is only needed in GCC <= 8.
-            nibbles[i++] = static_cast<uint8_t>(b >> 4);
-            nibbles[i++] = static_cast<uint8_t>(b & 0x0f);
+            m_nibbles[i++] = b >> 4;
+            m_nibbles[i++] = b & 0x0f;
         }
     }
 
+    [[nodiscard]] static constexpr size_t capacity() noexcept { return max_size; }
+    [[nodiscard]] size_t size() const noexcept { return m_size; }
+    [[nodiscard]] bool empty() const noexcept { return m_size == 0; }
+    [[nodiscard]] uint8_t operator[](size_t index) const noexcept { return m_nibbles[index]; }
+    [[nodiscard]] const uint8_t* begin() const noexcept { return m_nibbles; }
+    [[nodiscard]] const uint8_t* end() const noexcept { return m_nibbles + m_size; }
+
     [[nodiscard]] Path tail(size_t pos) const noexcept
     {
-        assert(pos > 0 && pos <= length);  // MPT never requests whole path copy (pos == 0).
-        Path p;
-        p.length = length - pos;
-        std::copy_n(&nibbles[pos], p.length, p.nibbles);
-        return p;
+        assert(pos > 0 && pos <= m_size);  // MPT never requests whole path copy (pos == 0).
+        return {begin() + pos, end()};
     }
 
     [[nodiscard]] Path head(size_t size) const noexcept
     {
-        assert(size < length);  // MPT never requests whole path copy (size == length).
-        Path p;
-        p.length = size;
-        std::copy_n(nibbles, size, p.nibbles);
-        return p;
+        assert(size < m_size);  // MPT never requests whole path copy (size == length).
+        return {begin(), begin() + size};
     }
 
     [[nodiscard]] bytes encode(bool extended) const
     {
         bytes bs;
-        const auto is_even = length % 2 == 0;
+        const auto is_even = m_size % 2 == 0;
         if (is_even)
             bs.push_back(0x00);
         else
-            bs.push_back(0x10 | nibbles[0]);
-        for (size_t i = is_even ? 0 : 1; i < length; ++i)
+            bs.push_back(0x10 | m_nibbles[0]);
+        for (size_t i = is_even ? 0 : 1; i < m_size; ++i)
         {
-            const auto h = nibbles[i++];
-            const auto l = nibbles[i];
+            const auto h = m_nibbles[i++];
+            const auto l = m_nibbles[i];
             assert(h <= 0x0f);
             assert(l <= 0x0f);
             bs.push_back(static_cast<uint8_t>((h << 4) | l));
@@ -111,8 +125,8 @@ class MPTNode
     static std::unique_ptr<MPTNode> optional_ext(
         const Path& path, std::unique_ptr<MPTNode> child) noexcept
     {
-        return (path.length != 0) ? std::make_unique<MPTNode>(ext(path, std::move(child))) :
-                                    std::move(child);
+        return (!path.empty()) ? std::make_unique<MPTNode>(ext(path, std::move(child))) :
+                                 std::move(child);
     }
 
     /// Creates a branch node out of two children and optionally extends it with an extended
@@ -128,16 +142,15 @@ class MPTNode
         br.m_children[idx1] = std::move(child1);
         br.m_children[idx2] = std::move(child2);
 
-        return (path.length != 0) ? ext(path, std::make_unique<MPTNode>(std::move(br))) :
-                                    std::move(br);
+        return (!path.empty()) ? ext(path, std::make_unique<MPTNode>(std::move(br))) :
+                                 std::move(br);
     }
 
     /// Finds the position at witch two paths differ.
     static size_t mismatch(const Path& p1, const Path& p2) noexcept
     {
-        assert(p1.length <= p2.length);
-        return static_cast<size_t>(
-            std::mismatch(p1.nibbles, p1.nibbles + p1.length, p2.nibbles).first - p1.nibbles);
+        assert(p1.size() <= p2.size());
+        return static_cast<size_t>(std::ranges::mismatch(p1, p2).in1 - p1.begin());
     }
 
 public:
@@ -164,10 +177,9 @@ void MPTNode::insert(const Path& path, bytes&& value)  // NOLINT(misc-no-recursi
     {
     case Kind::branch:
     {
-        assert(m_path.length == 0);  // Branch has no path.
+        assert(m_path.empty());  // Branch has no path.
 
-        const auto idx = path.nibbles[0];
-        auto& child = m_children[idx];
+        auto& child = m_children[path[0]];
         if (!child)
             child = leaf(path.tail(1), std::move(value));
         else
@@ -177,15 +189,15 @@ void MPTNode::insert(const Path& path, bytes&& value)  // NOLINT(misc-no-recursi
 
     case Kind::ext:
     {
-        assert(m_path.length != 0);  // Ext must have non-empty path.
+        assert(!m_path.empty());  // Ext must have non-empty path.
 
         const auto mismatch_pos = mismatch(m_path, path);
 
-        if (mismatch_pos == m_path.length)  // Paths match: go into the child.
+        if (mismatch_pos == m_path.size())  // Paths match: go into the child.
             return m_children[0]->insert(path.tail(mismatch_pos), std::move(value));
 
-        const auto orig_idx = m_path.nibbles[mismatch_pos];
-        const auto new_idx = path.nibbles[mismatch_pos];
+        const auto orig_idx = m_path[mismatch_pos];
+        const auto new_idx = path[mismatch_pos];
 
         // The original branch node must be pushed down, possible extended with
         // the adjusted extended node if the path split point is not directly at the branch node.
@@ -200,13 +212,13 @@ void MPTNode::insert(const Path& path, bytes&& value)  // NOLINT(misc-no-recursi
 
     case Kind::leaf:
     {
-        assert(m_path.length != 0);  // Leaf must have non-empty path.
+        assert(!m_path.empty());  // Leaf must have non-empty path.
 
         const auto mismatch_pos = mismatch(m_path, path);
-        assert(mismatch_pos != m_path.length);  // Paths must be different.
+        assert(mismatch_pos != m_path.size());  // Paths must be different.
 
-        const auto orig_idx = m_path.nibbles[mismatch_pos];
-        const auto new_idx = path.nibbles[mismatch_pos];
+        const auto orig_idx = m_path[mismatch_pos];
+        const auto new_idx = path[mismatch_pos];
         auto orig_leaf = leaf(m_path.tail(mismatch_pos + 1), std::move(m_value));
         auto new_leaf = leaf(path.tail(mismatch_pos + 1), std::move(value));
         *this = ext_branch(m_path.head(mismatch_pos), orig_idx, std::move(orig_leaf), new_idx,
@@ -241,7 +253,7 @@ bytes MPTNode::encode() const  // NOLINT(misc-no-recursion)
     }
     case Kind::branch:
     {
-        assert(m_path.length == 0);
+        assert(m_path.empty());
         static constexpr uint8_t empty = 0x80;  // encoded empty child
 
         for (const auto& child : m_children)

--- a/test/state/mpt.cpp
+++ b/test/state/mpt.cpp
@@ -11,6 +11,14 @@ namespace evmone::state
 {
 namespace
 {
+/// The MPT node kind.
+enum class Kind : uint8_t
+{
+    leaf,
+    ext,
+    branch
+};
+
 /// The collection of nibbles (4-bit values) representing a path in a MPT.
 ///
 /// TODO(c++26): This is an instance of std::inplace_vector.
@@ -63,25 +71,17 @@ public:
         return {begin(), begin() + size};
     }
 
-    [[nodiscard]] bytes encode(bool extended) const
+    [[nodiscard]] bytes encode(Kind kind) const
     {
-        bytes bs;
-        const auto is_even = m_size % 2 == 0;
-        if (is_even)
-            bs.push_back(0x00);
-        else
-            bs.push_back(0x10 | m_nibbles[0]);
-        for (size_t i = is_even ? 0 : 1; i < m_size; ++i)
-        {
-            const auto h = m_nibbles[i++];
-            const auto l = m_nibbles[i];
-            assert(h <= 0x0f);
-            assert(l <= 0x0f);
-            bs.push_back(static_cast<uint8_t>((h << 4) | l));
-        }
-        if (!extended)
-            bs[0] |= 0x20;
-        return bs;
+        assert(kind == Kind::leaf || kind == Kind::ext);
+        const auto kind_prefix = kind == Kind::leaf ? 0x20 : 0x00;
+        const auto has_odd_size = m_size % 2 != 0;
+        const auto nibble_prefix = has_odd_size ? (0x10 | m_nibbles[0]) : 0x00;
+
+        bytes encoded{static_cast<uint8_t>(kind_prefix | nibble_prefix)};
+        for (auto i = size_t{has_odd_size}; i < m_size; i += 2)
+            encoded.push_back(static_cast<uint8_t>((m_nibbles[i] << 4) | m_nibbles[i + 1]));
+        return encoded;
     }
 };
 }  // namespace
@@ -89,17 +89,10 @@ public:
 /// The MPT Node.
 ///
 /// The implementation is based on StackTrie from go-ethereum.
-// clang-tidy bug: https://github.com/llvm/llvm-project/issues/50006
+// TODO(clang-tidy-17): bug https://github.com/llvm/llvm-project/issues/50006
 // NOLINTNEXTLINE(bugprone-reserved-identifier)
 class MPTNode
 {
-    enum class Kind : uint8_t
-    {
-        leaf,
-        ext,
-        branch
-    };
-
     static constexpr size_t num_children = 16;
 
     Kind m_kind = Kind::leaf;
@@ -248,7 +241,7 @@ bytes MPTNode::encode() const  // NOLINT(misc-no-recursion)
     {
     case Kind::leaf:
     {
-        encoded = rlp::encode(m_path.encode(false)) + rlp::encode(m_value);
+        encoded = rlp::encode(m_path.encode(m_kind)) + rlp::encode(m_value);
         break;
     }
     case Kind::branch:
@@ -268,7 +261,7 @@ bytes MPTNode::encode() const  // NOLINT(misc-no-recursion)
     }
     case Kind::ext:
     {
-        encoded = rlp::encode(m_path.encode(true)) + encode_child(*m_children[0]);
+        encoded = rlp::encode(m_path.encode(m_kind)) + encode_child(*m_children[0]);
         break;
     }
     }

--- a/test/state/mpt.hpp
+++ b/test/state/mpt.hpp
@@ -13,6 +13,14 @@ constexpr auto emptyMPTHash =
 
 /// Insert-only Merkle Patricia Trie implementation for getting the root hash
 /// out of (key, value) pairs.
+///
+/// Limitations:
+/// 1. A key must not be longer than 32 bytes. Protected by debug assert.
+/// 2. A key must not be a prefix of another key. Protected by debug assert.
+///    This comes from the spec (Yellow Paper Appendix D) - a branch node cannot store a value.
+/// 3. A key must be unique. Protected by debug assert.
+///    I.e. inserted values cannot be updated by inserting with the same key again.
+/// 4. Inserted values cannot be erased. There is no method for this.
 class MPT
 {
     std::unique_ptr<class MPTNode> m_root;


### PR DESCRIPTION
Some refactoring and improvements to the MPT implementation:
- Refactor Path to behave like standard container.
- Refactor the `Kind` enum and path encoding.
- Change path mismatch handling by using iterators.