### PR TITLE
statetest: Disable sync with stdio when tracing

### DIFF
--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -94,7 +94,10 @@ int main(int argc, char* argv[])
         evmc::VM vm{evmc_create_evmone(), {{"O", "0"}}};
 
         if (trace)
+        {
+            std::ios::sync_with_stdio(false);
             vm.set_option("trace", "1");
+        }
 
         for (const auto& p : paths)
             register_test_files(p, vm, trace || trace_summary);


### PR DESCRIPTION
This increase the tracing performance. More info in the C++ spec: https://en.cppreference.com/w/cpp/io/ios_base/sync_with_stdio