### PR TITLE
ci: Bump minimum supported Clang to 15 (from 13)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,7 +45,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
   linux-clang-min:
     docker:
-      - image: ethereum/cpp-build-env:18-clang-13
+      - image: ethereum/cpp-build-env:19-clang-15
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2


### PR DESCRIPTION
We need better C++20 support. Clang 15 is also the minimal version for Silkworm currently.