### PR TITLE
Refactor EOF1Header::can_init

### DIFF
--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -32,6 +32,9 @@ struct EOF1Header
     /// The EOF version, 0 means legacy code.
     uint8_t version = 0;
 
+    /// Overall size of container. NOTE: Not part of EOFv1 container header.
+    size_t size;
+
     /// Size of every code section.
     std::vector<uint16_t> code_sizes;
 
@@ -66,11 +69,10 @@ struct EOF1Header
     }
 
     /// A helper to check whether the container can be an initcontainer.
-    [[nodiscard]] bool can_init(bytes_view container) const noexcept
+    [[nodiscard]] bool can_init() const noexcept
     {
         // Containers with truncated data section cannot be initcontainers.
-        const auto truncated_data =
-            static_cast<size_t>(data_offset + data_size) != container.size();
+        const auto truncated_data = static_cast<size_t>(data_offset + data_size) != size;
         return !truncated_data;
     }
 

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -250,7 +250,7 @@ Result create_eof_impl(
             return {EVMC_SUCCESS, gas_left};  // "Light" failure.
 
         const auto initcontainer_header = read_valid_eof1_header(initcontainer);
-        if (!initcontainer_header.can_init(initcontainer))
+        if (!initcontainer_header.can_init())
             return {EVMC_SUCCESS, gas_left};  // "Light" failure.
     }
 


### PR DESCRIPTION
I noticed we had separate implementations of `EOF1Header::can_init` check (for CREATE3 and 4) so I merged them. Unfortunately, the clean version of this makes me include the container size as a `EOF1Header` field. This smells a little.

The alternative I had was to have `can_init(size_t container_size)` instead, but I didn't like it either. Any thoughts?