### PR TITLE
Enable EOF validation before execution in `evmc run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ with it.
 docker run --entrypoint evmone-bench ethereum/evmone /src/test/benchmarks
 ```
 
+### EVM Object Format (EOF) support
+
+evmone supports EOFv1. Since EOF validation is done once during deploy-time, evmone does not revalidate during execution of bytecode. To force EOF revalidation, you can use the `validate_eof` option, example:
+
+```
+evmc run --vm libevmone.so,validate_eof --rev 13 "EF00"
+```
+
 ## References
 
 1. [Efficient gas calculation algorithm for EVM](docs/efficient_gas_calculation_algorithm.md)

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -366,6 +366,13 @@ evmc_result execute(evmc_vm* c_vm, const evmc_host_interface* host, evmc_host_co
 {
     auto vm = static_cast<VM*>(c_vm);
     const bytes_view container{code, code_size};
+
+    if (vm->validate_eof && rev >= EVMC_PRAGUE && is_eof_container(container))
+    {
+        if (validate_eof(rev, container) != EOFValidationError::success)
+            return evmc_make_result(EVMC_CONTRACT_VALIDATION_FAILURE, 0, 0, nullptr, 0);
+    }
+
     const auto code_analysis = analyze(rev, container);
     const auto data = code_analysis.eof_header.get_data(container);
     auto state = std::make_unique<ExecutionState>(*msg, rev, *host, ctx, container, data);

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -61,6 +61,11 @@ evmc_set_option_result set_option(evmc_vm* c_vm, char const* c_name, char const*
         vm.add_tracer(create_histogram_tracer(std::clog));
         return EVMC_SET_OPTION_SUCCESS;
     }
+    else if (name == "validate_eof")
+    {
+        vm.validate_eof = true;
+        return EVMC_SET_OPTION_SUCCESS;
+    }
     return EVMC_SET_OPTION_INVALID_NAME;
 }
 

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -19,6 +19,7 @@ class VM : public evmc_vm
 {
 public:
     bool cgoto = EVMONE_CGOTO_SUPPORTED;
+    bool validate_eof = false;
 
 private:
     std::unique_ptr<Tracer> m_first_tracer;

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -29,6 +29,11 @@ DUP1,4
 {\"pc\":6,\"op\":3,\"gas\":\"0xf4234\",\"gasCost\":\"0x3\",\"memSize\":0,\"stack\":\\[\"0x0\",\"0x4\"\\],\"depth\":1,\"refund\":0,\"opName\":\"SUB\"}
 ")
 
+    add_test(NAME ${PREFIX}/validate_eof COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 13 EF0001)
+    set_tests_properties(
+        ${PREFIX}/validate_eof PROPERTIES PASS_REGULAR_EXPRESSION
+        "contract validation failure")
+
 endif()
 
 add_subdirectory(statetest)


### PR DESCRIPTION
Closes #585 

Not sure about placement and API. I assumed it should be off by default, and not concern `evmc` code, this is what I've got as a result.