### PR TITLE
CI: Build with clang-17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,16 @@ find_package(ethash CONFIG REQUIRED)
 
 option(EVMC_TOOLS "Build EVMC test tools" ${EVMONE_TESTING})
 option(EVMC_INSTALL "Install EVMC" OFF)
-add_subdirectory(evmc)
+
+if(COMMAND block) # TODO(cmake-3.25)
+    block()
+        set(CMAKE_C_CLANG_TIDY "")
+        set(CMAKE_CXX_CLANG_TIDY "")
+        add_subdirectory(evmc)
+    endblock()
+else()
+    add_subdirectory(evmc)
+endif()
 
 cable_configure_compiler(NO_STACK_PROTECTION)
 if(CABLE_COMPILER_GNULIKE)

--- a/circle.yml
+++ b/circle.yml
@@ -5,30 +5,30 @@ orbs:
 executors:
   lint:
     docker:
-      - image: ethereum/cpp-build-env:20-lint
+      - image: ethereum/cpp-build-env:21-lint
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   linux-gcc-latest:
     docker:
-      - image: ethereum/cpp-build-env:20-gcc-13
+      - image: ethereum/cpp-build-env:21-gcc-13
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
   linux-gcc-multilib:
     docker:
-      - image: ethereum/cpp-build-env:20-gcc-13-multilib
+      - image: ethereum/cpp-build-env:21-gcc-13-multilib
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   blockchain-tests:
     docker:
-      - image: ethereum/cpp-build-env:20-gcc-13
+      - image: ethereum/cpp-build-env:21-gcc-13
     resource_class: xlarge
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
   linux-clang-xlarge:
     docker:
-      - image: ethereum/cpp-build-env:20-clang-16
+      - image: ethereum/cpp-build-env:21-clang-17
     resource_class: xlarge
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
@@ -40,7 +40,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   linux-clang-latest:
     docker:
-      - image: ethereum/cpp-build-env:20-clang-16
+      - image: ethereum/cpp-build-env:21-clang-17
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
   linux-clang-min:
@@ -260,7 +260,7 @@ commands:
           name: "Collect coverage data (GCC)"
           working_directory: ~/build
           command: |
-            lcov --capture --directory . --output-file coverage.lcov --exclude='/usr/*' --exclude="$HOME/.hunter/*" --exclude="$PWD/_deps/*"
+            lcov --capture --directory . --output-file coverage.lcov -j $CMAKE_BUILD_PARALLEL_LEVEL --ignore-errors mismatch,unused --exclude='/usr/*' --exclude="$HOME/.hunter/*" --exclude="$PWD/_deps/*"
             lcov --zerocounters --directory .
             rm -rf ~/coverage
             genhtml coverage.lcov --output-directory ~/coverage --title $CIRCLE_PROJECT_REPONAME
@@ -277,11 +277,12 @@ commands:
       - run:
           name: "Install codecov"
           command: |
-            export CODECOV_VERSION=v0.5.0
+            export CODECOV_VERSION=v0.7.1
             curl -Os https://uploader.codecov.io/$CODECOV_VERSION/linux/codecov
             curl -Os https://uploader.codecov.io/$CODECOV_VERSION/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/$CODECOV_VERSION/linux/codecov.SHA256SUM.sig
             
+            gpg --no-default-keyring --keyring trustedkeys.gpg --keyserver keyserver.ubuntu.com --receive-keys 27034E7FDB850E0BBC2C62FF806BB28AED779869
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -c codecov.SHA256SUM
             


### PR DESCRIPTION
- Upgrade docker images for CI
- Update code coverage tools and scripts
- Use clang-17 as the latest LLVM compiler

Closes #767 