### PR TITLE
state: Move pieces of State implemetation

### DIFF
--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -104,6 +104,20 @@ public:
         return insert(addr, std::move(account));
     }
 
+    [[nodiscard]] auto& get_accounts() noexcept { return m_accounts; }
+
+    [[nodiscard]] const auto& get_accounts() const noexcept { return m_accounts; }
+
+    /// Returns the state journal checkpoint. It can be later used to in rollback()
+    /// to revert changes newer than the checkpoint.
+    size_t checkpoint() const noexcept { return m_journal.size(); }
+
+    /// Reverts state changes made after the checkpoint.
+    void rollback(size_t checkpoint);
+
+    /// Methods performing changes to the state which can be reverted by rollback().
+    /// @{
+
     /// Touches (as in EIP-161) an existing account or inserts new erasable account.
     Account& touch(const address& addr)
     {
@@ -115,10 +129,6 @@ public:
         }
         return acc;
     }
-
-    [[nodiscard]] auto& get_accounts() noexcept { return m_accounts; }
-
-    [[nodiscard]] const auto& get_accounts() const noexcept { return m_accounts; }
 
     void journal_balance_change(const address& addr, const intx::uint256& prev_balance)
     {
@@ -151,12 +161,7 @@ public:
         m_journal.emplace_back(JournalAccessAccount{addr});
     }
 
-    /// Returns the state journal checkpoint. It can be later used to in rollback()
-    /// to revert changes newer than the checkpoint.
-    size_t checkpoint() const noexcept { return m_journal.size(); }
-
-    /// Reverts state changes made after the checkpoint.
-    void rollback(size_t checkpoint);
+    /// @}
 };
 
 struct Ommer

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -14,55 +14,55 @@
 
 namespace evmone::state
 {
-struct JournalBase
-{
-    address addr;
-};
-
-struct JournalBalanceChange : JournalBase
-{
-    intx::uint256 prev_balance;
-};
-
-struct JournalTouched : JournalBase
-{};
-
-struct JournalStorageChange : JournalBase
-{
-    bytes32 key;
-    bytes32 prev_value;
-    evmc_access_status prev_access_status;
-};
-
-struct JournalTransientStorageChange : JournalBase
-{
-    bytes32 key;
-    bytes32 prev_value;
-};
-
-struct JournalNonceBump : JournalBase
-{};
-
-struct JournalCreate : JournalBase
-{
-    bool existed;
-};
-
-struct JournalDestruct : JournalBase
-{};
-
-struct JournalAccessAccount : JournalBase
-{};
-
-using JournalEntry =
-    std::variant<JournalBalanceChange, JournalTouched, JournalStorageChange, JournalNonceBump,
-        JournalCreate, JournalTransientStorageChange, JournalDestruct, JournalAccessAccount>;
-
 /// The Ethereum State: the collection of accounts mapped by their addresses.
 ///
 /// TODO: This class is copyable for testing. Consider making it non-copyable.
 class State
 {
+    struct JournalBase
+    {
+        address addr;
+    };
+
+    struct JournalBalanceChange : JournalBase
+    {
+        intx::uint256 prev_balance;
+    };
+
+    struct JournalTouched : JournalBase
+    {};
+
+    struct JournalStorageChange : JournalBase
+    {
+        bytes32 key;
+        bytes32 prev_value;
+        evmc_access_status prev_access_status;
+    };
+
+    struct JournalTransientStorageChange : JournalBase
+    {
+        bytes32 key;
+        bytes32 prev_value;
+    };
+
+    struct JournalNonceBump : JournalBase
+    {};
+
+    struct JournalCreate : JournalBase
+    {
+        bool existed;
+    };
+
+    struct JournalDestruct : JournalBase
+    {};
+
+    struct JournalAccessAccount : JournalBase
+    {};
+
+    using JournalEntry =
+        std::variant<JournalBalanceChange, JournalTouched, JournalStorageChange, JournalNonceBump,
+            JournalCreate, JournalTransientStorageChange, JournalDestruct, JournalAccessAccount>;
+
     std::unordered_map<address, Account> m_accounts;
 
     /// The state journal: the list of changes made in the state

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -72,37 +72,16 @@ class State
 public:
     /// Inserts the new account at the address.
     /// There must not exist any account under this address before.
-    Account& insert(const address& addr, Account account = {})
-    {
-        const auto r = m_accounts.insert({addr, std::move(account)});
-        assert(r.second);
-        return r.first->second;
-    }
+    Account& insert(const address& addr, Account account = {});
 
     /// Returns the pointer to the account at the address if the account exists. Null otherwise.
-    Account* find(const address& addr) noexcept
-    {
-        const auto it = m_accounts.find(addr);
-        if (it != m_accounts.end())
-            return &it->second;
-        return nullptr;
-    }
+    Account* find(const address& addr) noexcept;
 
     /// Gets the account at the address (the account must exist).
-    Account& get(const address& addr) noexcept
-    {
-        auto acc = find(addr);
-        assert(acc != nullptr);
-        return *acc;
-    }
+    Account& get(const address& addr) noexcept;
 
     /// Gets an existing account or inserts new account.
-    Account& get_or_insert(const address& addr, Account account = {})
-    {
-        if (const auto acc = find(addr); acc != nullptr)
-            return *acc;
-        return insert(addr, std::move(account));
-    }
+    Account& get_or_insert(const address& addr, Account account = {});
 
     [[nodiscard]] auto& get_accounts() noexcept { return m_accounts; }
 
@@ -110,7 +89,7 @@ public:
 
     /// Returns the state journal checkpoint. It can be later used to in rollback()
     /// to revert changes newer than the checkpoint.
-    size_t checkpoint() const noexcept { return m_journal.size(); }
+    [[nodiscard]] size_t checkpoint() const noexcept { return m_journal.size(); }
 
     /// Reverts state changes made after the checkpoint.
     void rollback(size_t checkpoint);
@@ -119,47 +98,22 @@ public:
     /// @{
 
     /// Touches (as in EIP-161) an existing account or inserts new erasable account.
-    Account& touch(const address& addr)
-    {
-        auto& acc = get_or_insert(addr);
-        if (!acc.erase_if_empty)
-        {
-            acc.erase_if_empty = true;
-            m_journal.emplace_back(JournalTouched{addr});
-        }
-        return acc;
-    }
+    Account& touch(const address& addr);
 
-    void journal_balance_change(const address& addr, const intx::uint256& prev_balance)
-    {
-        m_journal.emplace_back(JournalBalanceChange{{addr}, prev_balance});
-    }
+    void journal_balance_change(const address& addr, const intx::uint256& prev_balance);
 
-    void journal_storage_change(const address& addr, const bytes32& key, const StorageValue& value)
-    {
-        m_journal.emplace_back(
-            JournalStorageChange{{addr}, key, value.current, value.access_status});
-    }
+    void journal_storage_change(const address& addr, const bytes32& key, const StorageValue& value);
 
     void journal_transient_storage_change(
-        const address& addr, const bytes32& key, const bytes32& value)
-    {
-        m_journal.emplace_back(JournalTransientStorageChange{{addr}, key, value});
-    }
+        const address& addr, const bytes32& key, const bytes32& value);
 
-    void journal_bump_nonce(const address& addr) { m_journal.emplace_back(JournalNonceBump{addr}); }
+    void journal_bump_nonce(const address& addr);
 
-    void journal_create(const address& addr, bool existed)
-    {
-        m_journal.emplace_back(JournalCreate{{addr}, existed});
-    }
+    void journal_create(const address& addr, bool existed);
 
-    void journal_destruct(const address& addr) { m_journal.emplace_back(JournalDestruct{addr}); }
+    void journal_destruct(const address& addr);
 
-    void journal_access_account(const address& addr)
-    {
-        m_journal.emplace_back(JournalAccessAccount{addr});
-    }
+    void journal_access_account(const address& addr);
 
     /// @}
 };


### PR DESCRIPTION
- Group methods revertible by `rollback()` (only `touch()` for now). We later want to hide the journal from users by providing revertible state modification methods.
- Move `State` methods implementations to the `state.cpp` file. This hides the implementation and allows faster builds.
- Move types related to Journal implementation to the `class State` scope.