### PR TITLE
state: Only mark touch of empty accounts

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -103,8 +103,8 @@ Account& State::get_or_insert(const address& addr, Account account)
 
 Account& State::touch(const address& addr)
 {
-    auto& acc = get_or_insert(addr);
-    if (!acc.erase_if_empty)
+    auto& acc = get_or_insert(addr, {.erase_if_empty = true});
+    if (!acc.erase_if_empty && acc.is_empty())
     {
         acc.erase_if_empty = true;
         m_journal.emplace_back(JournalTouched{addr});


### PR DESCRIPTION
If an account is being touched but is not empty it doesn't make sense to mark it as touched. Touching only affects deleting empty accounts but an account cannot become empty later during transaction execution (except for selfdestruct, but this is tracked separately).

When executing all state tests from https://github.com/ethereum/tests, this optimization reduces number of registered touch events by 99.2% (from 1673250 to 13806) and number of reverted touch events by 99.7% (from 1345463 to 401).

Moreover, considering current Mainnet status and
[EIP-7523: Empty accounts deprecation](https://eips.ethereum.org/EIPS/eip-7523) empty accounts cannot be encountered after the Paris revision. Therefore, this change total disables unnecessary touch handling in current PoS networks.