### PR TITLE
DUPN and SWAPN in EOF only + EOF stack validation

### DIFF
--- a/lib/evmone/advanced_analysis.hpp
+++ b/lib/evmone/advanced_analysis.hpp
@@ -149,7 +149,7 @@ struct OpTableEntry
 {
     instruction_exec_fn fn;
     int16_t gas_cost;
-    int8_t stack_req;
+    uint8_t stack_req;
     int8_t stack_change;
 };
 

--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -70,6 +70,14 @@ inline code_iterator impl(AdvancedExecutionState& state, code_iterator pos) noex
     state.stack.top_item += instr::traits[Op].stack_height_change;
     return new_pos;
 }
+
+template <Opcode Op, code_iterator CoreFn(StackTop, code_iterator) noexcept = core::impl<Op>>
+inline code_iterator impl(AdvancedExecutionState& state, code_iterator pos) noexcept
+{
+    const auto new_pos = CoreFn(state.stack.top_item, pos);
+    state.stack.top_item += instr::traits[Op].stack_height_change;
+    return new_pos;
+}
 /// @}
 }  // namespace instr
 

--- a/lib/evmone/baseline.cpp
+++ b/lib/evmone/baseline.cpp
@@ -195,6 +195,13 @@ struct Position
 }
 
 [[release_inline]] inline code_iterator invoke(
+    code_iterator (*instr_fn)(StackTop, code_iterator) noexcept, Position pos, int64_t& /*gas*/,
+    ExecutionState& /*state*/) noexcept
+{
+    return instr_fn(pos.stack_top, pos.code_it);
+}
+
+[[release_inline]] inline code_iterator invoke(
     TermResult (*instr_fn)(StackTop, int64_t, ExecutionState&) noexcept, Position pos, int64_t& gas,
     ExecutionState& state) noexcept
 {

--- a/lib/evmone/baseline_instruction_table.cpp
+++ b/lib/evmone/baseline_instruction_table.cpp
@@ -34,6 +34,8 @@ constexpr auto legacy_cost_tables = []() noexcept {
     tables[EVMC_PRAGUE][OP_DATALOADN] = instr::undefined;
     tables[EVMC_PRAGUE][OP_DATASIZE] = instr::undefined;
     tables[EVMC_PRAGUE][OP_DATACOPY] = instr::undefined;
+    tables[EVMC_PRAGUE][OP_DUPN] = instr::undefined;
+    tables[EVMC_PRAGUE][OP_SWAPN] = instr::undefined;
     return tables;
 }();
 

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -902,38 +902,16 @@ inline void swap(StackTop stack) noexcept
     a[3] = t3;
 }
 
-inline code_iterator dupn(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
+inline code_iterator dupn(StackTop stack, code_iterator pos) noexcept
 {
-    const auto n = pos[1] + 1;
-
-    const auto stack_size = &stack.top() - state.stack_space.bottom();
-
-    if (stack_size < n)
-    {
-        state.status = EVMC_STACK_UNDERFLOW;
-        return nullptr;
-    }
-
-    stack.push(stack[n - 1]);
-
+    stack.push(stack[pos[1]]);
     return pos + 2;
 }
 
-inline code_iterator swapn(StackTop stack, ExecutionState& state, code_iterator pos) noexcept
+inline code_iterator swapn(StackTop stack, code_iterator pos) noexcept
 {
-    const auto n = pos[1] + 1;
-
-    const auto stack_size = &stack.top() - state.stack_space.bottom();
-
-    if (stack_size <= n)
-    {
-        state.status = EVMC_STACK_UNDERFLOW;
-        return nullptr;
-    }
-
     // TODO: This may not be optimal, see instr::core::swap().
-    std::swap(stack.top(), stack[n]);
-
+    std::swap(stack.top(), stack[pos[1] + 1]);
     return pos + 2;
 }
 

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -204,7 +204,7 @@ struct Traits
     bool is_terminating = false;
 
     /// The number of stack items the instruction accesses during execution.
-    int8_t stack_height_required = 0;
+    uint8_t stack_height_required = 0;
 
     /// The stack height change caused by the instruction execution. Can be negative.
     int8_t stack_height_change = 0;

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -982,6 +982,40 @@ TEST(eof_validation, retf_stack_validation)
     EXPECT_EQ(validate_eof(code), EOFValidationError::stack_higher_than_outputs_required);
 }
 
+TEST(eof_validation, dupn_stack_validation)
+{
+    const auto pushes = 20 * push(1);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_DUPN + "00" + OP_STOP, 21)),
+        EOFValidationError::success);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_DUPN + "13" + OP_STOP, 21)),
+        EOFValidationError::success);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_DUPN + "14" + OP_STOP, 21)),
+        EOFValidationError::stack_underflow);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_DUPN + "d0" + OP_STOP, 21)),
+        EOFValidationError::stack_underflow);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_DUPN + "fe" + OP_STOP, 21)),
+        EOFValidationError::stack_underflow);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_DUPN + "ff" + OP_STOP, 21)),
+        EOFValidationError::stack_underflow);
+}
+
+TEST(eof_validation, swapn_stack_validation)
+{
+    const auto pushes = 20 * push(1);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_SWAPN + "00" + OP_STOP, 20)),
+        EOFValidationError::success);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_SWAPN + "12" + OP_STOP, 20)),
+        EOFValidationError::success);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_SWAPN + "13" + OP_STOP, 20)),
+        EOFValidationError::stack_underflow);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_SWAPN + "d0" + OP_STOP, 20)),
+        EOFValidationError::stack_underflow);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_SWAPN + "fe" + OP_STOP, 20)),
+        EOFValidationError::stack_underflow);
+    EXPECT_EQ(validate_eof(eof_bytecode(pushes + OP_SWAPN + "ff" + OP_STOP, 20)),
+        EOFValidationError::stack_underflow);
+}
+
 TEST(eof_validation, non_returning_status)
 {
     // Non-returning with no JUMPF and no RETF

--- a/test/unittests/evm_eip663_dupn_swapn_test.cpp
+++ b/test/unittests/evm_eip663_dupn_swapn_test.cpp
@@ -22,20 +22,17 @@ TEST_P(evm, dupn)
     for (uint64_t i = 1; i <= 20; ++i)
         pushes += push(i);
 
-    execute(pushes + OP_DUPN + "00" + ret_top());
+    execute(eof_bytecode(pushes + OP_DUPN + "00" + ret_top(), 22));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(20);
 
-    execute(pushes + OP_DUPN + "02" + ret_top());
+    execute(eof_bytecode(pushes + OP_DUPN + "02" + ret_top(), 22));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(18);
 
-    execute(pushes + OP_DUPN + "13" + ret_top());
+    execute(eof_bytecode(pushes + OP_DUPN + "13" + ret_top(), 22));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(1);
-
-    execute(pushes + OP_DUPN + "14" + ret_top());
-    EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
 }
 
 TEST_P(evm, swapn)
@@ -50,32 +47,29 @@ TEST_P(evm, swapn)
     for (uint64_t i = 1; i <= 20; ++i)
         pushes += push(i);
 
-    execute(pushes + OP_SWAPN + "00" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "00" + ret_top(), 21));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(19);
 
-    execute(pushes + OP_SWAPN + "00" + OP_DUPN + "01" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "00" + OP_DUPN + "01" + ret_top(), 22));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(20);
 
-    execute(pushes + OP_SWAPN + "01" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "01" + ret_top(), 21));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(18);
 
-    execute(pushes + OP_SWAPN + "01" + OP_DUPN + "02" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "01" + OP_DUPN + "02" + ret_top(), 22));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(20);
 
-    execute(pushes + OP_SWAPN + "12" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "12" + ret_top(), 21));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(1);
 
-    execute(pushes + OP_SWAPN + "12" + OP_DUPN + "13" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "12" + OP_DUPN + "13" + ret_top(), 22));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(20);
-
-    execute(pushes + OP_SWAPN + "13" + ret_top());
-    EXPECT_STATUS(EVMC_STACK_UNDERFLOW);
 }
 
 TEST_P(evm, dupn_full_stack)
@@ -86,23 +80,20 @@ TEST_P(evm, dupn_full_stack)
 
     rev = EVMC_PRAGUE;
     auto full_stack_code = bytecode{};
-    for (uint64_t i = 1023; i >= 1; --i)
+    for (uint64_t i = 1022; i >= 1; --i)
         full_stack_code += push(i);
 
-    execute(full_stack_code + OP_POP + OP_DUPN + "00" + ret_top());
+    execute(eof_bytecode(full_stack_code + OP_POP + OP_DUPN + "00" + ret_top(), 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(2);
 
-    execute(full_stack_code + OP_POP + OP_DUPN + "ff" + ret_top());
+    execute(eof_bytecode(full_stack_code + OP_POP + OP_DUPN + "ff" + ret_top(), 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(257);
 
-    execute(full_stack_code + OP_POP + OP_DUPN + "fe" + ret_top());
+    execute(eof_bytecode(full_stack_code + OP_POP + OP_DUPN + "fe" + ret_top(), 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(256);
-
-    execute(full_stack_code + OP_DUPN + "fe" + OP_DUPN + "ff");
-    EXPECT_STATUS(EVMC_STACK_OVERFLOW);
 }
 
 TEST_P(evm, swapn_full_stack)
@@ -113,22 +104,22 @@ TEST_P(evm, swapn_full_stack)
 
     rev = EVMC_PRAGUE;
     auto full_stack_code = bytecode{};
-    for (uint64_t i = 1024; i >= 1; --i)
+    for (uint64_t i = 1023; i >= 1; --i)
         full_stack_code += push(i);
 
-    execute(full_stack_code + OP_POP + OP_SWAPN + "00" + ret_top());
+    execute(eof_bytecode(full_stack_code + OP_POP + OP_SWAPN + "00" + ret_top(), 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(3);
 
-    execute(full_stack_code + OP_POP + OP_SWAPN + "ff" + ret_top());
+    execute(eof_bytecode(full_stack_code + OP_POP + OP_SWAPN + "ff" + ret_top(), 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(255 + 3);
 
-    execute(full_stack_code + OP_POP + OP_SWAPN + "fe" + ret_top());
+    execute(eof_bytecode(full_stack_code + OP_POP + OP_SWAPN + "fe" + ret_top(), 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(254 + 3);
 
-    execute(full_stack_code + OP_SWAPN + "ff" + OP_SWAPN + "00" + OP_RETURN);
+    execute(eof_bytecode(full_stack_code + OP_SWAPN + "ff" + OP_SWAPN + "00" + OP_RETURN, 1023));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(result.output_size, 255 + 2);
 }
@@ -144,19 +135,19 @@ TEST_P(evm, dupn_dup_consistency)
     for (uint64_t i = 32; i >= 1; --i)
         pushes += push(i);
 
-    execute(pushes + OP_DUP1 + ret_top());
+    execute(eof_bytecode(pushes + OP_DUP1 + ret_top(), 34));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(1);
 
-    execute(pushes + OP_DUPN + "00" + ret_top());
+    execute(eof_bytecode(pushes + OP_DUPN + "00" + ret_top(), 34));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(1);
 
-    execute(pushes + OP_DUP16 + ret_top());
+    execute(eof_bytecode(pushes + OP_DUP16 + ret_top(), 34));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(16);
 
-    execute(pushes + OP_DUPN + "0f" + ret_top());
+    execute(eof_bytecode(pushes + OP_DUPN + "0f" + ret_top(), 34));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(16);
 }
@@ -172,19 +163,30 @@ TEST_P(evm, swapn_swap_consistency)
     for (uint64_t i = 32; i >= 1; --i)
         pushes += push(i);
 
-    execute(pushes + OP_SWAP1 + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAP1 + ret_top(), 33));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(2);
 
-    execute(pushes + OP_SWAPN + "00" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "00" + ret_top(), 33));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(2);
 
-    execute(pushes + OP_SWAP16 + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAP16 + ret_top(), 33));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(17);
 
-    execute(pushes + OP_SWAPN + "0f" + ret_top());
+    execute(eof_bytecode(pushes + OP_SWAPN + "0f" + ret_top(), 33));
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(17);
+}
+
+TEST_P(evm, dupn_swapn_undefined_in_legacy)
+{
+    rev = EVMC_PRAGUE;
+
+    execute(push(1) + push(2) + OP_SWAPN + "00");
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+
+    execute(push(1) + OP_DUPN + "00");
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 }


### PR DESCRIPTION
Closes #538 

Please take an extra look if the `invoke` specializations added are ok and have no undesired side effects, esp. the `advanced` counterpart. The compiler made me add the latter, even if it's not used.