### PR TITLE
test: Reposition `validate_deployed_code()`

### DIFF
--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -131,6 +131,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
         SCOPED_TRACE(std::string{evmc::to_string(c.rev.get_revision(0))} + '/' +
                      std::to_string(case_index) + '/' + c.name);
 
+        validate_deployed_code(c.pre_state, c.rev.get_revision(0));
         auto state = c.pre_state;
 
         const state::BlockInfo genesis{

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -13,6 +13,8 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
 {
     for (const auto& [rev, cases] : test.cases)
     {
+        validate_deployed_code(test.pre_state, rev);
+
         for (size_t case_index = 0; case_index != cases.size(); ++case_index)
         {
             SCOPED_TRACE(std::string{evmc::to_string(rev)} + '/' + std::to_string(case_index));
@@ -24,8 +26,6 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             const auto& expected = cases[case_index];
             const auto tx = test.multi_tx.get(expected.indexes);
             auto state = test.pre_state;
-
-            validate_deployed_code(state, rev);
 
             const auto res = state::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
                 state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -78,6 +78,8 @@ int main(int argc, const char* argv[])
         {
             const auto j = json::json::parse(std::ifstream{alloc_file}, nullptr, false);
             state = test::from_json<state::State>(j);
+            if (rev >= EVMC_PRAGUE)  // Validate EOF code in the pre-state
+                validate_deployed_code(state, rev);
         }
         if (!env_file.empty())
         {
@@ -111,10 +113,6 @@ int main(int argc, const char* argv[])
         std::vector<state::Transaction> transactions;
         std::vector<state::TransactionReceipt> receipts;
         int64_t block_gas_left = block.gas_limit;
-
-        // Validate eof code in pre-state
-        if (rev >= EVMC_PRAGUE)
-            validate_deployed_code(state, rev);
 
         // Parse and execute transactions
         if (!txs_file.empty())


### PR DESCRIPTION
Use `validate_deployed_code()` only to validate a test pre-state. Also check the blockchain tests.