### PR TITLE
test: Generalize `validate_state()`

### DIFF
--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -95,9 +95,11 @@ json::json to_json(const std::unordered_map<address, state::Account>& accounts);
 
 StateTransitionTest load_state_test(std::istream& input);
 
-/// Validates deployed EOF containers before running state test.
-/// Throws exception on any invalid EOF in state.
-void validate_deployed_code(const state::State& state, evmc_revision rev);
+/// Validates an Ethereum state:
+/// - checks that there are no zero-value storage entries,
+/// - checks that there are no invalid EOF codes.
+/// Throws std::invalid_argument exception.
+void validate_state(const state::State& state, evmc_revision rev);
 
 /// Execute the state @p test using the @p vm.
 ///

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -25,7 +25,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             const auto tx = test.multi_tx.get(expected.indexes);
             auto state = test.pre_state;
 
-            validate_deployed_code(state, rev);
+            validate_state(state, rev);
 
             const auto res = state::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
                 state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -114,7 +114,7 @@ int main(int argc, const char* argv[])
 
         // Validate eof code in pre-state
         if (rev >= EVMC_PRAGUE)
-            validate_deployed_code(state, rev);
+            validate_state(state, rev);
 
         // Parse and execute transactions
         if (!txs_file.empty())

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -133,14 +133,27 @@ TEST(statetest_loader, load_minimal_test)
     EXPECT_EQ(st.input_labels.size(), 0);
 }
 
-TEST(statetest_loader, validate_deployed_code_test)
+TEST(statetest_loader, validate_state_invalid_eof)
 {
     {
         state::State state;
         state.insert(0xadd4_address, {.code = "EF0001010000020001000103000100FEDA"_hex});
-        EXPECT_THAT([&] { validate_deployed_code(state, EVMC_PRAGUE); },
+        EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
             ThrowsMessage<std::invalid_argument>(
                 "EOF container at 0x000000000000000000000000000000000000add4 is invalid: "
                 "zero_section_size"));
+    }
+}
+
+TEST(statetest_loader, validate_state_zero_storage_slot)
+{
+    {
+        state::State state;
+        state.insert(0xadd4_address, {.storage = {{0x01_bytes32, {0x00_bytes32}}}});
+        EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
+            ThrowsMessage<std::invalid_argument>(
+                "account 0x000000000000000000000000000000000000add4 contains invalid zero-value "
+                "storage entry "
+                "0x0000000000000000000000000000000000000000000000000000000000000001"));
     }
 }


### PR DESCRIPTION
Generalize `validate_deployed_code()` to `validate_state()`. It validates an Ethereum state (likely a test pre-state). New added check: disallow zero-value storage entries.