### PR TITLE
host: Split compute_new_account_address()

### DIFF
--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -15,18 +15,28 @@ using evmc::uint256be;
 inline constexpr size_t max_code_size = 0x6000;
 inline constexpr size_t max_initcode_size = 2 * max_code_size;
 
-/// Computes the address of to-be-created contract.
+/// Computes the address of to-be-created contract with the CREATE scheme.
 ///
-/// Computes the new account address for the contract creation context
-/// as defined by 𝐀𝐃𝐃𝐑 in Yellow Paper, 7. Contract Creation, (86).
+/// Computes the new account address for the contract creation context of the CREATE instruction
+/// or a create transaction.
+/// This is defined by 𝐀𝐃𝐃𝐑 in Yellow Paper, 7. Contract Creation, (88-90), the case for ζ = ∅.
 ///
 /// @param sender        The address of the message sender. YP: 𝑠.
 /// @param sender_nonce  The sender's nonce before the increase. YP: 𝑛.
-/// @param salt          The salt for CREATE2. If null, CREATE address is computed. YP: ζ.
-/// @param init_code     The contract creation init code. Value only affects CREATE2. YP: 𝐢.
-/// @return              The computed address for CREATE or CREATE2 scheme.
-address compute_new_account_address(const address& sender, uint64_t sender_nonce,
-    const std::optional<bytes32>& salt, bytes_view init_code) noexcept;
+/// @return              The address computed with the CREATE scheme.
+[[nodiscard]] address compute_create_address(const address& sender, uint64_t sender_nonce) noexcept;
+
+/// Computes the address of to-be-created contract with the CREATE2 scheme.
+///
+/// Computes the new account address for the contract creation context of the CREATE2 instruction.
+/// This is defined by 𝐀𝐃𝐃𝐑 in Yellow Paper, 7. Contract Creation, (88-90), the case for ζ ≠ ∅.
+///
+/// @param sender        The address of the message sender. YP: 𝑠.
+/// @param salt          The salt. YP: ζ.
+/// @param init_code     The contract creation init code. YP: 𝐢.
+/// @return              The address computed with the CREATE2 scheme.
+[[nodiscard]] address compute_create2_address(
+    const address& sender, const bytes32& salt, bytes_view init_code) noexcept;
 
 class Host : public evmc::Host
 {

--- a/test/unittests/state_new_account_address_test.cpp
+++ b/test/unittests/state_new_account_address_test.cpp
@@ -7,53 +7,46 @@
 
 using namespace evmc;
 using namespace evmc::literals;
-inline constexpr auto addr = evmone::state::compute_new_account_address;
 
 inline constexpr uint64_t nonces[] = {0, 1, 0x80, 0xffffffffffffffff};
 inline constexpr address senders[] = {
     0x00_address, 0x01_address, 0x8000000000000000000000000000000000000000_address};
-inline const bytes init_codes[] = {bytes{}, bytes{0xFE}};
-inline constexpr bytes32 salts[] = {
-    0x00_bytes32, 0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0_bytes32};
 
 TEST(state_new_account_address, create)
 {
-    for (const auto& ic : init_codes)  // Init-code doesn't affect CREATE.
-    {
-        auto s = senders[0];
-        EXPECT_EQ(addr(s, nonces[0], {}, ic), 0xbd770416a3345f91e4b34576cb804a576fa48eb1_address);
-        EXPECT_EQ(addr(s, nonces[3], {}, ic), 0x1262d73ea59d3a661bf8751d16cf1a5377149e75_address);
+    constexpr auto addr = evmone::state::compute_create_address;
 
-        s = senders[1];
-        EXPECT_EQ(addr(s, nonces[0], {}, ic), 0x522b3294e6d06aa25ad0f1b8891242e335d3b459_address);
-        EXPECT_EQ(addr(s, nonces[1], {}, ic), 0x535b3d7a252fa034ed71f0c53ec0c6f784cb64e1_address);
-        EXPECT_EQ(addr(s, nonces[2], {}, ic), 0x09c1ef8f55c61b94e8b92a55d0891d408a991e18_address);
-        EXPECT_EQ(addr(s, nonces[3], {}, ic), 0x001567239734aeadea21023c2a7c0d9bb9ae4af9_address);
+    auto s = senders[0];
+    EXPECT_EQ(addr(s, nonces[0]), 0xbd770416a3345f91e4b34576cb804a576fa48eb1_address);
+    EXPECT_EQ(addr(s, nonces[3]), 0x1262d73ea59d3a661bf8751d16cf1a5377149e75_address);
 
-        s = senders[2];
-        EXPECT_EQ(addr(s, nonces[0], {}, ic), 0x3cb1045aee4a06f522ea2b69e4f3d21ed3c135d1_address);
-        EXPECT_EQ(addr(s, nonces[3], {}, ic), 0xe1aa03e4a7b6991d69aff8ece53ceafdf347082e_address);
+    s = senders[1];
+    EXPECT_EQ(addr(s, nonces[0]), 0x522b3294e6d06aa25ad0f1b8891242e335d3b459_address);
+    EXPECT_EQ(addr(s, nonces[1]), 0x535b3d7a252fa034ed71f0c53ec0c6f784cb64e1_address);
+    EXPECT_EQ(addr(s, nonces[2]), 0x09c1ef8f55c61b94e8b92a55d0891d408a991e18_address);
+    EXPECT_EQ(addr(s, nonces[3]), 0x001567239734aeadea21023c2a7c0d9bb9ae4af9_address);
 
-        const auto beacon_deposit_address =
-            addr(0xb20a608c624Ca5003905aA834De7156C68b2E1d0_address, 0, {}, ic);
-        EXPECT_EQ(beacon_deposit_address, 0x00000000219ab540356cbb839cbe05303d7705fa_address);
-    }
+    s = senders[2];
+    EXPECT_EQ(addr(s, nonces[0]), 0x3cb1045aee4a06f522ea2b69e4f3d21ed3c135d1_address);
+    EXPECT_EQ(addr(s, nonces[3]), 0xe1aa03e4a7b6991d69aff8ece53ceafdf347082e_address);
+
+    const auto beacon_roots1 = addr(0xb20a608c624Ca5003905aA834De7156C68b2E1d0_address, 0);
+    EXPECT_EQ(beacon_roots1, 0x00000000219ab540356cbb839cbe05303d7705fa_address);
+
+    const auto beacon_roots2 = addr(0x0B799C86a49DEeb90402691F1041aa3AF2d3C875_address, 0);
+    EXPECT_EQ(beacon_roots2, 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address);
 }
 
 TEST(state_new_account_address, create2)
 {
-    for (const auto n : nonces)  // Nonce doesn't affect CREATE2.
-    {
-        EXPECT_EQ(addr(senders[0], n, salts[0], init_codes[0]),
-            0xe33c0c7f7df4809055c3eba6c09cfe4baf1bd9e0_address);
+    constexpr auto addr = evmone::state::compute_create2_address;
+    constexpr auto z0 = 0x00_bytes32;
+    constexpr auto z1 = 0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0_bytes32;
+    const auto i0 = bytes{};
+    const auto i1 = bytes{0xFE};
 
-        EXPECT_EQ(addr(senders[2], n, salts[0], init_codes[1]),
-            0x3517dea701ed18fc4a99dc111c5946e1f1541dad_address);
-
-        EXPECT_EQ(addr(senders[1], n, salts[1], init_codes[0]),
-            0x7be1c1cb3b8298f21c56add66defce03e2d32604_address);
-
-        EXPECT_EQ(addr(senders[2], n, salts[1], init_codes[1]),
-            0x8f459e65c8f00a9c0c0493de7b0c61c3c27f7384_address);
-    }
+    EXPECT_EQ(addr(senders[0], z0, i0), 0xe33c0c7f7df4809055c3eba6c09cfe4baf1bd9e0_address);
+    EXPECT_EQ(addr(senders[2], z0, i1), 0x3517dea701ed18fc4a99dc111c5946e1f1541dad_address);
+    EXPECT_EQ(addr(senders[1], z1, i0), 0x7be1c1cb3b8298f21c56add66defce03e2d32604_address);
+    EXPECT_EQ(addr(senders[2], z1, i1), 0x8f459e65c8f00a9c0c0493de7b0c61c3c27f7384_address);
 }

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -295,7 +295,7 @@ TEST_F(tracing, trace_eof)
 )");
 }
 
-TEST_F(tracing, trace_create_intrcution)
+TEST_F(tracing, trace_create_instruction)
 {
     using namespace intx;
     using evmc::operator""_address;


### PR DESCRIPTION
Split the function `compute_new_account_address()` into two:
- `compute_create_address()`
- `compute_create2_address()`.

Use these in the state transition tests to predict the created accounts.

Fixes https://github.com/ethereum/evmone/issues/782.
