### PR TITLE
test: Option to check state root hash

### DIFF
--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -135,6 +135,11 @@ void state_transition::TearDown()
         }
     }
 
+    if (expect.state_hash)
+    {
+        EXPECT_EQ(mpt_hash(state.get_accounts()), *expect.state_hash);
+    }
+
     for (const auto& [addr, _] : state.get_accounts())
     {
         EXPECT_TRUE(expect.post.contains(addr)) << "unexpected account " << addr;

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -60,6 +60,8 @@ protected:
         /// The expected post-execution state.
         std::unordered_map<address, ExpectedAccount> post;
 
+        std::optional<hash256> state_hash;
+
         /// The expected EVM execution trace. If not empty transaction execution will be performed
         /// with tracing enabled and the output compared.
         std::string_view trace;

--- a/test/unittests/state_transition_create_test.cpp
+++ b/test/unittests/state_transition_create_test.cpp
@@ -23,6 +23,17 @@ TEST_F(state_transition, create2_factory)
     expect.post[create_address].code = bytes{0xFE};
 }
 
+TEST_F(state_transition, create_tx_empty)
+{
+    // The default transaction without "to" address is a create transaction.
+
+    expect.post[compute_create_address(Sender, pre.get(Sender).nonce)] = {
+        .nonce = 1, .code = bytes{}};
+
+    // Example of checking the expected the post state MPT root hash.
+    expect.state_hash = 0x8ae438f7a4a14dbc25410dfaa12e95e7b36f311ab904b4358c3b544e06df4c50_bytes32;
+}
+
 TEST_F(state_transition, create_tx)
 {
     tx.data = mstore8(0, push(0xFE)) + ret(0, 1);


### PR DESCRIPTION
Add option to check the expected post state MPT root hash of the state_transition tests.