### PR TITLE
test: Add some mising State Test export features

### DIFF
--- a/test/integration/statetest/CMakeLists.txt
+++ b/test/integration/statetest/CMakeLists.txt
@@ -143,7 +143,7 @@ set_tests_properties(
 add_test(
     NAME ${PREFIX}/execute_exported_tests
     # TODO: Broken exported tests are filtered out.
-    COMMAND evmone-statetest ${EXPORT_DIR}/state_transition --gtest_filter=-*block.*:*tx.tx_non_existing_sender
+    COMMAND evmone-statetest ${EXPORT_DIR}/state_transition --gtest_filter=-*block.*
 )
 set_tests_properties(
     ${PREFIX}/execute_exported_tests PROPERTIES

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -201,6 +201,20 @@ void state_transition::export_state_test(const TransactionReceipt& receipt, cons
     jtx["gasLimit"][0] = hex0x(tx.gas_limit);
     jtx["value"][0] = hex0x(tx.value);
 
+    if (!tx.access_list.empty())
+    {
+        auto& ja = jtx["accessLists"][0];
+        for (const auto& [addr, storage_keys] : tx.access_list)
+        {
+            json::json je;
+            je["address"] = hex0x(addr);
+            auto& jstorage_keys = je["storageKeys"] = json::json::array();
+            for (const auto& k : storage_keys)
+                jstorage_keys.emplace_back(hex0x(k));
+            ja.emplace_back(std::move(je));
+        }
+    }
+
     auto& jpost = jt["post"][to_test_fork_name(rev)][0];
     jpost["indexes"] = {{"data", 0}, {"gas", 0}, {"value", 0}};
     jpost["hash"] = hex0x(mpt_hash(post.get_accounts()));

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -79,7 +79,7 @@ protected:
     Transaction tx{
         .gas_limit = block.gas_limit,
         .max_gas_price = block.base_fee + 1,
-        .max_priority_gas_price = 1,
+        .max_priority_gas_price = block.base_fee + 1,
         .sender = Sender,
         .nonce = 1,
     };

--- a/test/unittests/state_transition_eof_test.cpp
+++ b/test/unittests/state_transition_eof_test.cpp
@@ -28,8 +28,7 @@ TEST_F(state_transition, eof_invalid_initcode)
 
     expect.post[tx.sender].nonce = pre.get(tx.sender).nonce + 1;
     expect.post[tx.sender].balance =
-        pre.get(tx.sender).balance -
-        (block.base_fee + tx.max_priority_gas_price) * static_cast<uint64_t>(*expect.gas_used);
+        pre.get(tx.sender).balance - tx.max_gas_price * static_cast<uint64_t>(*expect.gas_used);
     expect.post[*tx.to].nonce = pre.get(*tx.to).nonce + 1;  // CREATE caller's nonce must be bumped
     expect.post[*tx.to].storage[0x01_bytes32] = 0x00_bytes32;  // CREATE must fail
     expect.post[create_address].exists = false;

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -7,6 +7,14 @@
 using namespace evmc::literals;
 using namespace evmone::test;
 
+TEST_F(state_transition, tx_legacy)
+{
+    rev = EVMC_ISTANBUL;
+    tx.to = To;
+
+    expect.post.at(Sender).nonce = pre.get(Sender).nonce + 1;
+}
+
 TEST_F(state_transition, tx_non_existing_sender)
 {
     tx.to = To;

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "state_transition.hpp"
+#include <test/utils/bytecode.hpp>
 
 using namespace evmc::literals;
 using namespace evmone::test;
@@ -87,4 +88,17 @@ TEST_F(state_transition, empty_coinbase_fee_0_tw)
     pre.insert(Coinbase, {});
     expect.post[To].exists = true;
     expect.post[Coinbase].balance = 0;
+}
+
+TEST_F(state_transition, access_list_storage)
+{
+    tx.to = To;
+    tx.access_list = {{To, {0x01_bytes32}}};
+
+    pre.insert(To,
+        {.storage = {{0x01_bytes32, {0x01_bytes32, 0x01_bytes32}}}, .code = sstore(2, sload(1))});
+
+    expect.post[To].storage[0x01_bytes32] = 0x01_bytes32;
+    expect.post[To].storage[0x02_bytes32] = 0x01_bytes32;
+    expect.gas_used = 47506;  // Without access list: 45206
 }

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -13,9 +13,9 @@ evmc_revision to_rev(std::string_view s)
         return EVMC_FRONTIER;
     if (s == "Homestead")
         return EVMC_HOMESTEAD;
-    if (s == "EIP150")
+    if (s == "Tangerine Whistle" || s == "EIP150")
         return EVMC_TANGERINE_WHISTLE;
-    if (s == "EIP158")
+    if (s == "Spurious Dragon" || s == "EIP158")
         return EVMC_SPURIOUS_DRAGON;
     if (s == "Byzantium")
         return EVMC_BYZANTIUM;


### PR DESCRIPTION
Add support for exporting state transition tests:
- with legacy transactions (pre EIP-1559)
- with access list
- support EVMC spelling of revisions