### PR TITLE
test: Check for unexpected EOF prefix in tests

### DIFF
--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -452,6 +452,10 @@ void validate_state(const state::State& state, evmc_revision rev)
                         " is invalid: " + std::string(get_error_message(result)));
                 }
             }
+            else
+            {
+                throw std::invalid_argument("unexpected code with EOF prefix at " + hex0x(addr));
+            }
         }
 
         for (const auto& [key, value] : acc.storage)

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -135,25 +135,30 @@ TEST(statetest_loader, load_minimal_test)
 
 TEST(statetest_loader, validate_state_invalid_eof)
 {
-    {
-        state::State state;
-        state.insert(0xadd4_address, {.code = "EF0001010000020001000103000100FEDA"_hex});
-        EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
-            ThrowsMessage<std::invalid_argument>(
-                "EOF container at 0x000000000000000000000000000000000000add4 is invalid: "
-                "zero_section_size"));
-    }
+    state::State state;
+    state.insert(0xadd4_address, {.code = "EF0001010000020001000103000100FEDA"_hex});
+    EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
+        ThrowsMessage<std::invalid_argument>(
+            "EOF container at 0x000000000000000000000000000000000000add4 is invalid: "
+            "zero_section_size"));
+}
+
+TEST(statetest_loader, validate_state_unexpected_eof)
+{
+    state::State state;
+    state.insert(0xadd4_address, {.code = "EF00"_hex});
+    EXPECT_THAT([&] { validate_state(state, EVMC_CANCUN); },
+        ThrowsMessage<std::invalid_argument>(
+            "unexpected code with EOF prefix at 0x000000000000000000000000000000000000add4"));
 }
 
 TEST(statetest_loader, validate_state_zero_storage_slot)
 {
-    {
-        state::State state;
-        state.insert(0xadd4_address, {.storage = {{0x01_bytes32, {0x00_bytes32}}}});
-        EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
-            ThrowsMessage<std::invalid_argument>(
-                "account 0x000000000000000000000000000000000000add4 contains invalid zero-value "
-                "storage entry "
-                "0x0000000000000000000000000000000000000000000000000000000000000001"));
-    }
+    state::State state;
+    state.insert(0xadd4_address, {.storage = {{0x01_bytes32, {0x00_bytes32}}}});
+    EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
+        ThrowsMessage<std::invalid_argument>(
+            "account 0x000000000000000000000000000000000000add4 contains invalid zero-value "
+            "storage entry "
+            "0x0000000000000000000000000000000000000000000000000000000000000001"));
 }


### PR DESCRIPTION
In the `validate_state()` also check for unexpected code with EOF prefix before EOF is enabled. The EIP-3541 prevents such code to be deployed.