### PR TITLE
test: Introduce TestState and TestAccount

### DIFF
--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -5,6 +5,7 @@
 
 #include "../state/bloom_filter.hpp"
 #include "../state/state.hpp"
+#include "../state/test_state.hpp"
 #include "../utils/utils.hpp"
 #include <evmc/evmc.hpp>
 #include <span>
@@ -43,7 +44,6 @@ struct BlockHeader
 struct TestBlock
 {
     state::BlockInfo block_info;
-    state::State pre_state;
     std::vector<state::Transaction> transactions;
 
     BlockHeader expected_block_header;
@@ -54,14 +54,14 @@ struct BlockchainTest
     struct Expectation
     {
         hash256 last_block_hash;
-        std::variant<state::State, hash256> post_state;
+        std::variant<TestState, hash256> post_state;
     };
 
     std::string name;
 
     std::vector<TestBlock> test_blocks;
     BlockHeader genesis_block_header;
-    state::State pre_state;
+    TestState pre_state;
     RevisionSchedule rev;
 
     Expectation expectation;

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -119,7 +119,7 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
     BlockchainTest bt;
     bt.name = name;
     bt.genesis_block_header = from_json<BlockHeader>(j.at("genesisBlockHeader"));
-    bt.pre_state = from_json<State>(j.at("pre"));
+    bt.pre_state = from_json<TestState>(j.at("pre"));
     bt.rev = to_rev_schedule(j.at("network").get<std::string>());
 
     for (const auto& el : j.at("blocks"))
@@ -128,7 +128,7 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
     bt.expectation.last_block_hash = from_json<hash256>(j.at("lastblockhash"));
 
     if (const auto it = j.find("postState"); it != j.end())
-        bt.expectation.post_state = from_json<State>(*it);
+        bt.expectation.post_state = from_json<TestState>(*it);
     else if (const auto it_hash = j.find("postStateHash"); it_hash != j.end())
         bt.expectation.post_state = from_json<hash256>(*it_hash);
 

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -30,6 +30,8 @@ target_sources(
     rlp.hpp
     state.hpp
     state.cpp
+    test_state.hpp
+    test_state.cpp
 )
 
 option(EVMONE_PRECOMPILES_SILKPRE "Enable precompiles support via silkpre library" OFF)

--- a/test/state/mpt_hash.cpp
+++ b/test/state/mpt_hash.cpp
@@ -3,31 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "mpt_hash.hpp"
-#include "account.hpp"
 #include "mpt.hpp"
 #include "rlp.hpp"
 #include "state.hpp"
+#include "test_state.hpp"
 
 namespace evmone::state
 {
 namespace
 {
-hash256 mpt_hash(const std::unordered_map<hash256, StorageValue>& storage)
+hash256 mpt_hash(const std::map<bytes32, bytes32>& storage)
 {
     MPT trie;
     for (const auto& [key, value] : storage)
     {
-        if (!is_zero(value.current))  // Skip "deleted" values.
-            trie.insert(keccak256(key), rlp::encode(rlp::trim(value.current)));
+        if (!is_zero(value))  // Skip "deleted" values.
+            trie.insert(keccak256(key), rlp::encode(rlp::trim(value)));
     }
     return trie.hash();
 }
 }  // namespace
 
-hash256 mpt_hash(const std::unordered_map<address, Account>& accounts)
+hash256 mpt_hash(const test::TestState& state)
 {
     MPT trie;
-    for (const auto& [addr, acc] : accounts)
+    for (const auto& [addr, acc] : state)
     {
         trie.insert(keccak256(addr),
             rlp::encode_tuple(acc.nonce, acc.balance, mpt_hash(acc.storage), keccak256(acc.code)));

--- a/test/state/mpt_hash.hpp
+++ b/test/state/mpt_hash.hpp
@@ -7,12 +7,15 @@
 #include <span>
 #include <unordered_map>
 
+namespace evmone::test
+{
+class TestState;
+}
+
 namespace evmone::state
 {
-struct Account;
-
 /// Computes Merkle Patricia Trie root hash for the given collection of state accounts.
-hash256 mpt_hash(const std::unordered_map<address, Account>& accounts);
+hash256 mpt_hash(const test::TestState& state);
 
 /// Computes Merkle Patricia Trie root hash for the given list of structures.
 template <typename T>

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -16,8 +16,6 @@
 namespace evmone::state
 {
 /// The Ethereum State: the collection of accounts mapped by their addresses.
-///
-/// TODO: This class is copyable for testing. Consider making it non-copyable.
 class State
 {
     struct JournalBase
@@ -71,6 +69,11 @@ class State
     std::vector<JournalEntry> m_journal;
 
 public:
+    State() = default;
+    State(const State&) = delete;
+    State(State&&) = default;
+    State& operator=(State&&) = default;
+
     /// Inserts the new account at the address.
     /// There must not exist any account under this address before.
     Account& insert(const address& addr, Account account = {});

--- a/test/state/test_state.cpp
+++ b/test/state/test_state.cpp
@@ -1,0 +1,34 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#include "test_state.hpp"
+#include "state.hpp"
+
+namespace evmone::test
+{
+TestState::TestState(const state::State& intra_state)
+{
+    for (const auto& [addr, acc] : intra_state.get_accounts())
+    {
+        auto& test_acc =
+            (*this)[addr] = {.nonce = acc.nonce, .balance = acc.balance, .code = acc.code};
+        auto& test_storage = test_acc.storage;
+        for (const auto& [key, value] : acc.storage)
+            test_storage[key] = value.current;
+    }
+}
+
+state::State TestState::to_intra_state() const
+{
+    state::State intra_state;
+    for (const auto& [addr, acc] : *this)
+    {
+        auto& intra_acc = intra_state.insert(
+            addr, {.nonce = acc.nonce, .balance = acc.balance, .code = acc.code});
+        auto& storage = intra_acc.storage;
+        for (const auto& [key, value] : acc.storage)
+            storage[key] = {.current = value, .original = value};
+    }
+    return intra_state;
+}
+}  // namespace evmone::test

--- a/test/state/test_state.hpp
+++ b/test/state/test_state.hpp
@@ -1,0 +1,67 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <map>
+
+namespace evmone
+{
+namespace state
+{
+class State;
+}
+
+namespace test
+{
+using evmc::address;
+using evmc::bytes;
+using evmc::bytes32;
+using intx::uint256;
+
+/// Ethereum account representation for tests.
+struct TestAccount
+{
+    uint64_t nonce = 0;
+    uint256 balance;
+    std::map<bytes32, bytes32> storage;
+    bytes code;
+
+    bool operator==(const TestAccount&) const noexcept = default;
+};
+
+/// Ethereum State representation for tests.
+///
+/// This is a simplified variant of state::State:
+/// it hides some details related to transaction execution (e.g. original storage values)
+/// and is also easier to work with in tests.
+class TestState : public std::map<address, TestAccount>
+{
+public:
+    using map::map;
+
+    /// Inserts new account to the state.
+    ///
+    /// This method is for compatibility with state::State::insert().
+    /// Don't use it in new tests, use std::map interface instead.
+    /// TODO: deprecate this method.
+    void insert(const address& addr, TestAccount&& acc) { (*this)[addr] = std::move(acc); }
+
+    /// Gets the reference to an existing account.
+    ///
+    /// This method is for compatibility with state::State::get().
+    /// Don't use it in new tests, use std::map interface instead.
+    /// TODO: deprecate this method.
+    TestAccount& get(const address& addr) { return (*this)[addr]; }
+
+    /// Converts the intra state to TestState.
+    explicit TestState(const state::State& intra_state);
+
+    /// Converts the TestState to intra state for transaction execution.
+    [[nodiscard]] state::State to_intra_state() const;
+};
+
+}  // namespace test
+}  // namespace evmone

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "../state/state.hpp"
+#include "../state/test_state.hpp"
 #include <nlohmann/json.hpp>
 
 namespace json = nlohmann;
@@ -54,7 +55,7 @@ struct StateTransitionTest
     };
 
     std::string name;
-    state::State pre_state;
+    TestState pre_state;
     state::BlockInfo block;
     TestMultiTransaction multi_tx;
     std::vector<Case> cases;
@@ -86,13 +87,13 @@ template <>
 state::Withdrawal from_json<state::Withdrawal>(const json::json& j);
 
 template <>
-state::State from_json<state::State>(const json::json& j);
+TestState from_json<TestState>(const json::json& j);
 
 template <>
 state::Transaction from_json<state::Transaction>(const json::json& j);
 
 /// Exports the State (accounts) to JSON format (aka pre/post/alloc state).
-json::json to_json(const std::unordered_map<address, state::Account>& accounts);
+json::json to_json(const TestState& state);
 
 std::vector<StateTransitionTest> load_state_tests(std::istream& input);
 
@@ -100,7 +101,7 @@ std::vector<StateTransitionTest> load_state_tests(std::istream& input);
 /// - checks that there are no zero-value storage entries,
 /// - checks that there are no invalid EOF codes.
 /// Throws std::invalid_argument exception.
-void validate_state(const state::State& state, evmc_revision rev);
+void validate_state(const TestState& state, evmc_revision rev);
 
 /// Execute the state @p test using the @p vm.
 ///

--- a/test/statetest/statetest_export.cpp
+++ b/test/statetest/statetest_export.cpp
@@ -6,10 +6,10 @@
 
 namespace evmone::test
 {
-json::json to_json(const std::unordered_map<address, state::Account>& accounts)
+json::json to_json(const TestState& state)
 {
     json::json j;
-    for (const auto& [addr, acc] : accounts)
+    for (const auto& [addr, acc] : state)
     {
         auto& j_acc = j[hex0x(addr)];
         j_acc["nonce"] = hex0x(acc.nonce);
@@ -19,8 +19,8 @@ json::json to_json(const std::unordered_map<address, state::Account>& accounts)
         auto& j_storage = j_acc["storage"] = json::json::object();
         for (const auto& [key, val] : acc.storage)
         {
-            if (!is_zero(val.current))
-                j_storage[hex0x(key)] = hex0x(val.current);
+            if (!is_zero(val))
+                j_storage[hex0x(key)] = hex0x(val);
         }
     }
     return j;

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -270,23 +270,22 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
 }
 
 template <>
-state::State from_json<state::State>(const json::json& j)
+TestState from_json<TestState>(const json::json& j)
 {
-    state::State o;
+    TestState o;
     for (const auto& [j_addr, j_acc] : j.items())
     {
-        auto& acc = o.insert(from_json<address>(j_addr),
-            {.nonce = from_json<uint64_t>(j_acc.at("nonce")),
+        auto& acc =
+            o[from_json<address>(j_addr)] = {.nonce = from_json<uint64_t>(j_acc.at("nonce")),
                 .balance = from_json<intx::uint256>(j_acc.at("balance")),
-                .code = from_json<bytes>(j_acc.at("code"))});
+                .code = from_json<bytes>(j_acc.at("code"))};
 
         if (const auto storage_it = j_acc.find("storage"); storage_it != j_acc.end())
         {
             for (const auto& [j_key, j_value] : storage_it->items())
             {
                 if (const auto value = from_json<bytes32>(j_value); !is_zero(value))
-                    acc.storage.insert(
-                        {from_json<bytes32>(j_key), {.current = value, .original = value}});
+                    acc.storage[from_json<bytes32>(j_key)] = value;
             }
         }
     }
@@ -420,7 +419,7 @@ static void from_json(const json::json& j, StateTransitionTest::Case::Expectatio
 
 static void from_json(const json::json& j_t, StateTransitionTest& o)
 {
-    o.pre_state = from_json<state::State>(j_t.at("pre"));
+    o.pre_state = from_json<TestState>(j_t.at("pre"));
 
     o.multi_tx = j_t.at("transaction").get<TestMultiTransaction>();
 
@@ -458,9 +457,9 @@ std::vector<StateTransitionTest> load_state_tests(std::istream& input)
     return json::json::parse(input).get<std::vector<StateTransitionTest>>();
 }
 
-void validate_state(const state::State& state, evmc_revision rev)
+void validate_state(const TestState& state, evmc_revision rev)
 {
-    for (const auto& [addr, acc] : state.get_accounts())
+    for (const auto& [addr, acc] : state)
     {
         // TODO: Check for empty accounts after Paris.
         //       https://github.com/ethereum/tests/issues/1331
@@ -484,7 +483,7 @@ void validate_state(const state::State& state, evmc_revision rev)
 
         for (const auto& [key, value] : acc.storage)
         {
-            if (is_zero(value.original))
+            if (is_zero(value))
             {
                 throw std::invalid_argument{"account " + hex0x(addr) +
                                             " contains invalid zero-value storage entry " +

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -25,7 +25,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
 
             const auto& expected = cases[case_index];
             const auto tx = test.multi_tx.get(expected.indexes);
-            auto state = test.pre_state;
+            auto state = test.pre_state.to_intra_state();
 
             const auto res = state::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
                 state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
@@ -33,7 +33,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             // Finalize block with reward 0.
             state::finalize(state, rev, test.block.coinbase, 0, {}, {});
 
-            const auto state_root = state::mpt_hash(state.get_accounts());
+            const auto state_root = state::mpt_hash(TestState{state});
 
             if (trace_summary)
             {

--- a/test/unittests/state_mpt_hash_test.cpp
+++ b/test/unittests/state_mpt_hash_test.cpp
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <test/state/account.hpp>
 #include <test/state/bloom_filter.hpp>
 #include <test/state/mpt.hpp>
 #include <test/state/mpt_hash.hpp>
 #include <test/state/rlp.hpp>
 #include <test/state/state.hpp>
+#include <test/state/test_state.hpp>
 #include <test/utils/utils.hpp>
 #include <array>
 
@@ -20,7 +20,7 @@ using namespace evmone::test;
 
 TEST(state_mpt_hash, empty)
 {
-    EXPECT_EQ(mpt_hash(std::unordered_map<evmone::address, Account>()), emptyMPTHash);
+    EXPECT_EQ(mpt_hash(TestState{}), emptyMPTHash);
 }
 
 TEST(state_mpt_hash, single_account_v1)
@@ -29,22 +29,18 @@ TEST(state_mpt_hash, single_account_v1)
     constexpr auto expected =
         0x084f337237951e425716a04fb0aaa74111eda9d9c61767f2497697d0a201c92e_bytes32;
 
-    Account acc;
-    acc.balance = 1_u256;
-    const std::unordered_map<address, Account> accounts{{0x02_address, acc}};
+    const TestState accounts{{0x02_address, {.balance = 1}}};
     EXPECT_EQ(mpt_hash(accounts), expected);
 }
 
 TEST(state_mpt_hash, two_accounts)
 {
-    std::unordered_map<address, Account> accounts;
-    EXPECT_EQ(mpt_hash(accounts), emptyMPTHash);
-
-    accounts[0x00_address] = Account{};
+    TestState accounts;
+    accounts[0x00_address] = {};
     EXPECT_EQ(mpt_hash(accounts),
         0x0ce23f3c809de377b008a4a3ee94a0834aac8bec1f86e28ffe4fdb5a15b0c785_bytes32);
 
-    Account acc2;
+    TestAccount acc2;
     acc2.nonce = 1;
     acc2.balance = -2_u256;
     acc2.code = bytes{0x00};  // Note: `= {0x00}` causes GCC 12 warning at -O3.
@@ -57,11 +53,11 @@ TEST(state_mpt_hash, two_accounts)
 
 TEST(state_mpt_hash, deleted_storage)
 {
-    Account acc;
+    TestAccount acc;
     acc.storage[0x01_bytes32] = {};
     acc.storage[0x02_bytes32] = {0xfd_bytes32};
     acc.storage[0x03_bytes32] = {};
-    const std::unordered_map<address, Account> accounts{{0x07_address, acc}};
+    const TestState accounts{{0x07_address, acc}};
     EXPECT_EQ(mpt_hash(accounts),
         0x4e7338c16731491e0fb5d1623f5265c17699c970c816bab71d4d717f6071414d_bytes32);
 }

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -7,6 +7,7 @@
 #include <evmone/evmone.h>
 #include <test/state/errors.hpp>
 #include <test/state/host.hpp>
+#include <test/state/test_state.hpp>
 
 namespace evmone::test
 {
@@ -83,7 +84,7 @@ protected:
         .sender = Sender,
         .nonce = 1,
     };
-    State pre;
+    TestState pre;
     Expectation expect;
 
     void SetUp() override;
@@ -93,7 +94,7 @@ protected:
 
     /// Exports the test in the JSON State Test format to ExportableFixture::export_out.
     void export_state_test(
-        const std::variant<TransactionReceipt, std::error_code>& res, const State& post);
+        const std::variant<TransactionReceipt, std::error_code>& res, const TestState& post);
 };
 
 }  // namespace evmone::test

--- a/test/unittests/state_transition_call_test.cpp
+++ b/test/unittests/state_transition_call_test.cpp
@@ -26,25 +26,21 @@ TEST_F(state_transition, delegatecall_static_legacy)
     // Checks if DELEGATECALL forwards the "static" flag.
     constexpr auto callee1 = 0xca11ee01_address;
     constexpr auto callee2 = 0xca11ee02_address;
-    pre.insert(callee2,
-        {
-            .storage = {{0x01_bytes32, {.current = 0xdd_bytes32, .original = 0xdd_bytes32}}},
-            .code = sstore(1, 0xcc_bytes32),
-        });
-    pre.insert(callee1,
-        {
-            .storage = {{0x01_bytes32, {.current = 0xdd_bytes32, .original = 0xdd_bytes32}}},
-            .code = ret(delegatecall(callee2).gas(100'000)),
-        });
+    pre.insert(callee2, {
+                            .storage = {{0x01_bytes32, 0xdd_bytes32}},
+                            .code = sstore(1, 0xcc_bytes32),
+                        });
+    pre.insert(callee1, {
+                            .storage = {{0x01_bytes32, 0xdd_bytes32}},
+                            .code = ret(delegatecall(callee2).gas(100'000)),
+                        });
 
     tx.to = To;
-    pre.insert(
-        *tx.to, {
-                    .storage = {{0x01_bytes32, {.current = 0xdd_bytes32, .original = 0xdd_bytes32}},
-                        {0x02_bytes32, {.current = 0xdd_bytes32, .original = 0xdd_bytes32}}},
-                    .code = sstore(1, staticcall(callee1).gas(200'000)) +
-                            sstore(2, returndatacopy(0, 0, returndatasize()) + mload(0)),
-                });
+    pre.insert(*tx.to, {
+                           .storage = {{0x01_bytes32, 0xdd_bytes32}, {0x02_bytes32, 0xdd_bytes32}},
+                           .code = sstore(1, staticcall(callee1).gas(200'000)) +
+                                   sstore(2, returndatacopy(0, 0, returndatasize()) + mload(0)),
+                       });
     expect.gas_used = 131480;
     // Outer call - success.
     expect.post[*tx.to].storage[0x01_bytes32] = 0x01_bytes32;

--- a/test/unittests/state_transition_tx_test.cpp
+++ b/test/unittests/state_transition_tx_test.cpp
@@ -25,7 +25,7 @@ TEST_F(state_transition, tx_non_existing_sender)
     tx.max_gas_price = 0;
     tx.max_priority_gas_price = 0;
     tx.nonce = 0;
-    pre.get_accounts().erase(Sender);
+    pre.erase(Sender);
 
     expect.status = EVMC_SUCCESS;
     expect.post.at(Sender).nonce = 1;
@@ -40,7 +40,7 @@ TEST_F(state_transition, invalid_tx_non_existing_sender)
     tx.max_gas_price = 1;
     tx.max_priority_gas_price = 1;
     tx.nonce = 0;
-    pre.get_accounts().erase(Sender);
+    pre.erase(Sender);
 
     expect.tx_error = INSUFFICIENT_FUNDS;
     expect.post[Sender].exists = false;
@@ -96,8 +96,7 @@ TEST_F(state_transition, access_list_storage)
     tx.to = To;
     tx.access_list = {{To, {0x01_bytes32}}};
 
-    pre.insert(To,
-        {.storage = {{0x01_bytes32, {0x01_bytes32, 0x01_bytes32}}}, .code = sstore(2, sload(1))});
+    pre.insert(To, {.storage = {{0x01_bytes32, 0x01_bytes32}}, .code = sstore(2, sload(1))});
 
     expect.post[To].storage[0x01_bytes32] = 0x01_bytes32;
     expect.post[To].storage[0x02_bytes32] = 0x01_bytes32;

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -128,7 +128,7 @@ TEST(statetest_loader, load_minimal_test)
     })"};
     const auto st = std::move(load_state_tests(s).at(0));
     // TODO: should add some comparison operator to State, BlockInfo, AccessList
-    EXPECT_EQ(st.pre_state.get_accounts().size(), 0);
+    EXPECT_EQ(st.pre_state.size(), 0);
     EXPECT_EQ(st.block.number, 0);
     EXPECT_EQ(st.block.timestamp, 0);
     EXPECT_EQ(st.block.gas_limit, 0);
@@ -161,8 +161,7 @@ TEST(statetest_loader, load_minimal_test)
 
 TEST(statetest_loader, validate_state_invalid_eof)
 {
-    state::State state;
-    state.insert(0xadd4_address, {.code = "EF0001010000020001000103000100FEDA"_hex});
+    TestState state{{0xadd4_address, {.code = "EF0001010000020001000103000100FEDA"_hex}}};
     EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
         ThrowsMessage<std::invalid_argument>(
             "EOF container at 0x000000000000000000000000000000000000add4 is invalid: "
@@ -171,8 +170,7 @@ TEST(statetest_loader, validate_state_invalid_eof)
 
 TEST(statetest_loader, validate_state_unexpected_eof)
 {
-    state::State state;
-    state.insert(0xadd4_address, {.code = "EF00"_hex});
+    TestState state{{0xadd4_address, {.code = "EF00"_hex}}};
     EXPECT_THAT([&] { validate_state(state, EVMC_CANCUN); },
         ThrowsMessage<std::invalid_argument>(
             "unexpected code with EOF prefix at 0x000000000000000000000000000000000000add4"));
@@ -180,8 +178,7 @@ TEST(statetest_loader, validate_state_unexpected_eof)
 
 TEST(statetest_loader, validate_state_zero_storage_slot)
 {
-    state::State state;
-    state.insert(0xadd4_address, {.storage = {{0x01_bytes32, {0x00_bytes32}}}});
+    TestState state{{0xadd4_address, {.storage = {{0x01_bytes32, 0x00_bytes32}}}}};
     EXPECT_THAT([&] { validate_state(state, EVMC_PRAGUE); },
         ThrowsMessage<std::invalid_argument>(
             "account 0x000000000000000000000000000000000000add4 contains invalid zero-value "


### PR DESCRIPTION
This decouples the `state::State` for transaction execution from the state object for test definitions and asserts.

The `state::State` (also called "intra state") has some constructs and data related to transaction execution only (like "current" and "original" storage values). These should not be exposed to tests and make test definitions more complicated.

This separation should also help with adding new public API for EVM with transaction-level execution granularity.