### PR TITLE
state: Fix failing code deployment in Frontier

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -267,8 +267,9 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     gas_left -= cost;
     if (gas_left < 0)
     {
-        return (m_rev == EVMC_FRONTIER) ? evmc::Result{EVMC_SUCCESS, result.gas_left} :
-                                          evmc::Result{EVMC_FAILURE};
+        return (m_rev == EVMC_FRONTIER) ?
+                   evmc::Result{EVMC_SUCCESS, result.gas_left, result.gas_refund, msg.recipient} :
+                   evmc::Result{EVMC_FAILURE};
     }
 
     if (m_rev >= EVMC_PRAGUE && (is_eof_container(initcode) || is_eof_container(code)))

--- a/test/unittests/state_transition_create_test.cpp
+++ b/test/unittests/state_transition_create_test.cpp
@@ -49,3 +49,109 @@ TEST_F(state_transition, create2_max_nonce)
 
     expect.post[*tx.to].nonce = pre.get(*tx.to).nonce;  // Nonce is unchanged.
 }
+
+TEST_F(state_transition, code_deployment_out_of_gas_tw)
+{
+    rev = EVMC_TANGERINE_WHISTLE;  // 63/64 gas rule enabled
+    block.base_fee = 0;
+    const auto initcode = ret(0, 5000);  // create contract with a lot of zeros, deploy cost 1M
+
+    tx.to = To;
+    tx.gas_limit = 1000000;
+    pre.insert(To, {.code = mstore(0, push(initcode)) +
+                            sstore(0, create().input(32 - initcode.size(), initcode.size()))});
+
+    expect.post[To].storage[0x00_bytes32] = 0x00_bytes32;
+}
+
+TEST_F(state_transition, code_deployment_out_of_gas_f)
+{
+    rev = EVMC_FRONTIER;
+    block.base_fee = 0;
+    const auto initcode = ret(0, 1000);  // create contract with a lot of zeros
+
+    tx.to = To;
+    tx.gas_limit = 100000;
+    pre.insert(To, {.code = mstore(0, push(initcode)) +
+                            sstore(0, create().input(32 - initcode.size(), initcode.size()))});
+
+    const auto created = compute_create_address(To, pre.get(To).nonce);
+    expect.post[created].code = bytes{};  // code deployment failure creates empty account
+    expect.post[created].nonce = 0;
+    expect.post[To].storage[0x00_bytes32] = to_bytes32(created);  // address of created empty
+}
+
+TEST_F(state_transition, code_deployment_out_of_gas_storage_tw)
+{
+    rev = EVMC_TANGERINE_WHISTLE;  // 63/64 gas rule enabled
+    block.base_fee = 0;
+    const auto initcode = sstore(0, 1)     // set storage
+                          + ret(0, 5000);  // create contract with a lot of zeros
+
+    tx.to = To;
+    tx.gas_limit = 1000000;
+    pre.insert(To, {.code = mstore(0, push(initcode)) +
+                            sstore(0, create().input(32 - initcode.size(), initcode.size()))});
+
+    expect.post[To].storage[0x00_bytes32] = 0x00_bytes32;
+}
+
+TEST_F(state_transition, code_deployment_out_of_gas_storage_f)
+{
+    rev = EVMC_FRONTIER;
+    block.base_fee = 0;
+    const auto initcode = sstore(0, 1)     // set storage
+                          + ret(0, 1000);  // create contract with a lot of zeros
+
+    tx.to = To;
+    tx.gas_limit = 100000;
+    pre.insert(To, {.code = mstore(0, push(initcode)) +
+                            sstore(0, create().input(32 - initcode.size(), initcode.size()))});
+
+    expect.post[To].exists = true;
+    const auto created = compute_create_address(To, pre.get(To).nonce);
+    expect.post[created].code = bytes{};  // code deployment failure creates empty account
+    expect.post[created].nonce = 0;
+    expect.post[created].storage[0x00_bytes32] = 0x01_bytes32;  // storage stays
+    expect.post[To].storage[0x00_bytes32] = to_bytes32(created);
+    expect.gas_used = 93134;
+}
+
+TEST_F(state_transition, code_deployment_out_of_gas_refund_tw)
+{
+    rev = EVMC_TANGERINE_WHISTLE;  // 63/64 gas rule enabled
+    block.base_fee = 0;
+    const auto initcode = sstore(0, 1)     // set storage
+                          + sstore(0, 0)   // gas refund
+                          + ret(0, 5000);  // create contract with a lot of zeros
+
+    tx.to = To;
+    tx.gas_limit = 1000000;
+    pre.insert(To, {.code = mstore(0, push(initcode)) +
+                            sstore(0, create().input(32 - initcode.size(), initcode.size()))});
+
+    expect.post[To].storage[0x00_bytes32] = 0x00_bytes32;
+    expect.gas_used = 990207;
+}
+
+TEST_F(state_transition, code_deployment_out_of_gas_refund_f)
+{
+    rev = EVMC_FRONTIER;
+    block.base_fee = 0;
+    const auto initcode = sstore(0, 1)     // set storage
+                          + sstore(0, 0)   // gas refund
+                          + ret(0, 1000);  // create contract with a lot of zeros
+
+    tx.to = To;
+    tx.gas_limit = 100000;
+    pre.insert(To, {.code = mstore(0, push(initcode)) +
+                            sstore(0, create().input(32 - initcode.size(), initcode.size()))});
+
+    expect.post[To].exists = true;
+    const auto created = compute_create_address(To, pre.get(To).nonce);
+    expect.post[created].code = bytes{};  // code deployment failure creates empty account
+    expect.post[created].nonce = 0;
+    expect.post[created].storage[0x00_bytes32] = 0x00_bytes32;
+    expect.post[To].storage[0x00_bytes32] = to_bytes32(created);
+    expect.gas_used = 83140;
+}


### PR DESCRIPTION
In Frontier when CREATE fails to deploy the code because of the deployment cost the creation behaves as it has been successful although the created account has empty code.

Fix the CREATE instruction by returning the address of the created account instead of the null address.

The gas refund is also applied as in the case of successful code deployment. Geth agrees with this but this situation probably never happened on Mainnet.