### PR TITLE
test: Recognize all official fork/revision names

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -463,6 +463,7 @@ jobs:
           branch: evmc-v11.0.0-alpha.1
           commit: evmc-v11.0.0-alpha.1
       - download_execution_tests:
+          # TODO: Fix failures and upgrade to v13.1
           rev: v13
       - run:
           name: "Silkworm-driven blockchain tests (Advanced)"
@@ -500,7 +501,7 @@ jobs:
             bin/evmone-statetest ~/spec-tests/fixtures/state_tests
 
       - download_execution_tests:
-          rev: v13
+          rev: v13.1
       - run:
           name: "State tests"
           working_directory: ~/build

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -21,7 +21,7 @@ evmc_revision to_rev(std::string_view s)
         return EVMC_BYZANTIUM;
     if (s == "Constantinople")
         return EVMC_CONSTANTINOPLE;
-    if (s == "ConstantinopleFix")
+    if (s == "Petersburg" || s == "ConstantinopleFix")
         return EVMC_PETERSBURG;
     if (s == "Istanbul")
         return EVMC_ISTANBUL;
@@ -29,10 +29,8 @@ evmc_revision to_rev(std::string_view s)
         return EVMC_BERLIN;
     if (s == "London" || s == "ArrowGlacier")
         return EVMC_LONDON;
-    if (s == "Merge")
+    if (s == "Paris" || s == "Merge")
         return EVMC_PARIS;
-    if (s == "Merge+3855")  // PUSH0
-        return EVMC_SHANGHAI;
     if (s == "Shanghai")
         return EVMC_SHANGHAI;
     if (s == "Cancun")


### PR DESCRIPTION
This adds "Paris" and "Petersburg" to the names recognized by the testing utils.