### PR TITLE
t8n: System contracts execution and other improvements

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -37,6 +37,7 @@ DUP1,4
 endif()
 
 add_subdirectory(statetest)
+add_subdirectory(t8n)
 
 get_property(ALL_TESTS DIRECTORY PROPERTY TESTS)
 set_tests_properties(${ALL_TESTS} PROPERTIES ENVIRONMENT LLVM_PROFILE_FILE=${CMAKE_BINARY_DIR}/integration-%p.profraw)

--- a/test/integration/t8n/CMakeLists.txt
+++ b/test/integration/t8n/CMakeLists.txt
@@ -32,6 +32,8 @@ add_test(
 )
 string(
     JOIN ".*" EXPECTED_OUT_ALLOC
+    # Beacon Roots system contract has new entry:
+    [=["0x000f3df6d732807ef1319fb7b8bb8522d0beac02": .*"storage": \{[^}]*"0x00000000000000000000000000000000000000000000000000000000000016ca": "0x0000000000000000000000000000000000000000000000000000000054c99069"]=]
     # new account created with code 0x00:
     [=["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": \{[^}]*"code": "0x00",]=]
 )

--- a/test/integration/t8n/CMakeLists.txt
+++ b/test/integration/t8n/CMakeLists.txt
@@ -1,0 +1,42 @@
+# evmone: Fast Ethereum Virtual Machine implementation
+# Copyright 2024 The evmone Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+# Integration tests for evmone-t8n.
+
+set(PREFIX ${PREFIX}/t8n)
+
+set(TEST_CASE cancun_create_tx)
+
+add_test(
+    NAME ${PREFIX}/${TEST_CASE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_CASE}
+    COMMAND
+    evmone-t8n
+    --state.fork Cancun
+    --state.reward 0
+    --state.chainid 1
+    --input.alloc alloc.json
+    --input.txs txs.json
+    --input.env env.json
+    --output.basedir ${CMAKE_CURRENT_BINARY_DIR}/${TEST_CASE}
+    --output.result out.json
+    --output.alloc outAlloc.json
+    --output.errorlog error.json
+)
+set_tests_properties(${PREFIX}/${TEST_CASE} PROPERTIES FIXTURES_REQUIRED ${TEST_CASE})
+
+add_test(
+    NAME ${PREFIX}/${TEST_CASE}/out_alloc
+    COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_BINARY_DIR}/${TEST_CASE}/outAlloc.json
+)
+string(
+    JOIN ".*" EXPECTED_OUT_ALLOC
+    # new account created with code 0x00:
+    [=["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": \{[^}]*"code": "0x00",]=]
+)
+set_tests_properties(
+    ${PREFIX}/${TEST_CASE}/out_alloc PROPERTIES
+    FIXTURES_CLEANUP ${TEST_CASE}
+    PASS_REGULAR_EXPRESSION ${EXPECTED_OUT_ALLOC}
+)

--- a/test/integration/t8n/cancun_create_tx/alloc.json
+++ b/test/integration/t8n/cancun_create_tx/alloc.json
@@ -1,0 +1,15 @@
+{
+  "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": {
+    "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
+    "nonce": "0x01",
+    "balance": "0x00",
+    "storage": {
+      "0x12e2": "0x54c98c81"
+    }
+  },
+  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "code": "",
+    "nonce": "0x00",
+    "balance": "0x02540be400"
+  }
+}

--- a/test/integration/t8n/cancun_create_tx/env.json
+++ b/test/integration/t8n/cancun_create_tx/env.json
@@ -1,0 +1,6 @@
+{
+    "currentCoinbase": "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "currentNumber": "0x01",
+    "currentTimestamp": "0x54c99069",
+    "currentGasLimit": "0x2fefd8"
+}

--- a/test/integration/t8n/cancun_create_tx/txs.json
+++ b/test/integration/t8n/cancun_create_tx/txs.json
@@ -1,0 +1,14 @@
+[
+  {
+    "input": "0x60015ff3",
+    "gas": "0x186a0",
+    "nonce": "0x0",
+    "value": "0x0",
+    "gasPrice": "0x32",
+    "chainId": "0x1",
+    "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "v": "0x1b",
+    "r": "0x468a915f087692bb9be503831a3dfef2cf9c8dee26deb40ff2ec99e8d22665ae",
+    "s": "0x5cedae0810c3851ecd1004bfdbfe6ddc7753c2d665993bb01ce75af7857b13dc"
+  }
+]

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -134,6 +134,8 @@ int main(int argc, const char* argv[])
                 j_result["receipts"] = json::json::array();
                 j_result["rejected"] = json::json::array();
 
+                state::system_call(state, block, rev, vm);
+
                 for (size_t i = 0; i < j_txs.size(); ++i)
                 {
                     auto tx = test::from_json<state::Transaction>(j_txs[i]);

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -56,7 +56,10 @@ int main(int argc, const char* argv[])
             else if (arg == "--input.txs" && ++i < argc)
                 txs_file = argv[i];
             else if (arg == "--output.basedir" && ++i < argc)
+            {
                 output_dir = argv[i];
+                fs::create_directories(output_dir);
+            }
             else if (arg == "--output.result" && ++i < argc)
                 output_result_file = argv[i];
             else if (arg == "--output.alloc" && ++i < argc)


### PR DESCRIPTION
- Execute system contracts (Beacon roots system contract in Cancun) before executing any transaction. Fixes #822, fixes #832.
- Create output directory `--output.basedir` if it doesn't exist.
- Add a CMake smoke test for `evmone-t8n`. Fixes #813.