### PR TITLE
cmake: Bump minimum required CMake version to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.16...3.27)
+cmake_minimum_required(VERSION 3.18...3.27)
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/evmc/.git)
     message(FATAL_ERROR "Git submodules not initialized, execute:\n  git submodule update --init")

--- a/circle.yml
+++ b/circle.yml
@@ -703,7 +703,7 @@ jobs:
     executor: linux-base
     steps:
       - install_cmake:
-          version: 3.16.9
+          version: 3.18.4
       - build
       - test
 


### PR DESCRIPTION
We want to use `cmake -E cat` added in 3.18.
This is also the version from Debian 11 released in 2021.