### PR TITLE
RLP-encode invalid transactions

### DIFF
--- a/test/integration/t8n/CMakeLists.txt
+++ b/test/integration/t8n/CMakeLists.txt
@@ -27,7 +27,22 @@ add_test(
 set_tests_properties(${PREFIX}/${TEST_CASE} PROPERTIES FIXTURES_REQUIRED ${TEST_CASE})
 
 add_test(
-    NAME ${PREFIX}/${TEST_CASE}/out_alloc
+    NAME ${PREFIX}/${TEST_CASE}/out.json
+    COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_BINARY_DIR}/${TEST_CASE}/out.json
+)
+string(
+    JOIN ".*" EXPECTED_OUT
+    # Create blob transaction should be rejected:
+    [=["error": "blob transaction must not be a create transaction"]=]
+)
+set_tests_properties(
+    ${PREFIX}/${TEST_CASE}/out.json PROPERTIES
+    FIXTURES_CLEANUP ${TEST_CASE}
+    PASS_REGULAR_EXPRESSION ${EXPECTED_OUT}
+)
+
+add_test(
+    NAME ${PREFIX}/${TEST_CASE}/outAlloc.json
     COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_BINARY_DIR}/${TEST_CASE}/outAlloc.json
 )
 string(
@@ -38,7 +53,7 @@ string(
     [=["0x6295ee1b4f6dd65047762f924ecd367c17eabf8f": \{[^}]*"code": "0x00",]=]
 )
 set_tests_properties(
-    ${PREFIX}/${TEST_CASE}/out_alloc PROPERTIES
+    ${PREFIX}/${TEST_CASE}/outAlloc.json PROPERTIES
     FIXTURES_CLEANUP ${TEST_CASE}
     PASS_REGULAR_EXPRESSION ${EXPECTED_OUT_ALLOC}
 )

--- a/test/integration/t8n/cancun_create_tx/txs.json
+++ b/test/integration/t8n/cancun_create_tx/txs.json
@@ -10,5 +10,34 @@
     "v": "0x1b",
     "r": "0x468a915f087692bb9be503831a3dfef2cf9c8dee26deb40ff2ec99e8d22665ae",
     "s": "0x5cedae0810c3851ecd1004bfdbfe6ddc7753c2d665993bb01ce75af7857b13dc"
+  },
+  {
+    "input": "0x00",
+    "gas": "0x3d0900",
+    "nonce": "0x0",
+    "value": "0x186a0",
+    "v": "0x0",
+    "r": "0xfc12b67159a3567f8bdbc49e0be369a2e20e09d57a51c41310543a4128409464",
+    "s": "0x2de0cfe5495c4f58ff60645ceda0afd67a4c90a70bc89fe207269435b35e5b67",
+    "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+    "chainId": "0x1",
+    "type": "0x3",
+    "maxFeePerGas": "0x12a05f200",
+    "maxPriorityFeePerGas": "0x2",
+    "accessList": [
+      {
+        "address": "0x095e7baea6a6c7c4c2dfeb977efac326af552d87",
+        "storageKeys": [
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000000000000000000000000001"
+        ]
+      }
+    ],
+    "maxFeePerBlobGas": "0xa",
+    "blobVersionedHashes": [
+      "0x01a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    ],
+    "hash": "0xf564e770e59f0e74ea8d992ba407cabb2847ac66019911106e2ed97b330e26a8",
+    "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
   }
 ]

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -529,20 +529,16 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
     }
     else if (tx.type == Transaction::Type::access_list)
     {
-        if (tx.v > 1)
-            throw std::invalid_argument("`v` value for eip2930 transaction must be 0 or 1");
         // tx_type +
-        // rlp [nonce, gas_price, gas_limit, to, value, data, access_list, v, r, s];
+        // rlp [chain_id, nonce, gas_price, gas_limit, to, value, data, access_list, v, r, s];
         return bytes{0x01} +  // Transaction type (eip2930 type == 1)
                rlp::encode_tuple(tx.chain_id, tx.nonce, tx.max_gas_price,
                    static_cast<uint64_t>(tx.gas_limit),
                    tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
-                   tx.access_list, static_cast<bool>(tx.v), tx.r, tx.s);
+                   tx.access_list, tx.v, tx.r, tx.s);
     }
     else if (tx.type == Transaction::Type::eip1559)
     {
-        if (tx.v > 1)
-            throw std::invalid_argument("`v` value for eip1559 transaction must be 0 or 1");
         // tx_type +
         // rlp [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value,
         // data, access_list, sig_parity, r, s];
@@ -550,22 +546,18 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
                rlp::encode_tuple(tx.chain_id, tx.nonce, tx.max_priority_gas_price, tx.max_gas_price,
                    static_cast<uint64_t>(tx.gas_limit),
                    tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
-                   tx.access_list, static_cast<bool>(tx.v), tx.r, tx.s);
+                   tx.access_list, tx.v, tx.r, tx.s);
     }
     else  // Transaction::Type::blob
     {
-        if (tx.v > 1)
-            throw std::invalid_argument("`v` value for blob transaction must be 0 or 1");
-        if (!tx.to.has_value())  // Blob tx has to have `to` address
-            throw std::invalid_argument("`to` value for blob transaction must not be null");
         // tx_type +
         // rlp [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value,
         // data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, sig_parity, r, s];
         return bytes{stdx::to_underlying(Transaction::Type::blob)} +
                rlp::encode_tuple(tx.chain_id, tx.nonce, tx.max_priority_gas_price, tx.max_gas_price,
-                   static_cast<uint64_t>(tx.gas_limit), tx.to.value(), tx.value, tx.data,
-                   tx.access_list, tx.max_blob_gas_price, tx.blob_hashes, static_cast<bool>(tx.v),
-                   tx.r, tx.s);
+                   static_cast<uint64_t>(tx.gas_limit),
+                   tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
+                   tx.access_list, tx.max_blob_gas_price, tx.blob_hashes, tx.v, tx.r, tx.s);
     }
 }
 

--- a/test/unittests/state_rlp_test.cpp
+++ b/test/unittests/state_rlp_test.cpp
@@ -368,44 +368,70 @@ TEST(state_rlp, tx_to_rlp_eip1559_invalid_v_value)
 {
     state::Transaction tx{};
     tx.type = evmone::state::Transaction::Type::eip1559;
-    tx.data = ""_hex;
-    tx.gas_limit = 1;
-    tx.max_gas_price = 1;
-    tx.max_priority_gas_price = 1;
-    tx.sender = 0x0000000000000000000000000000000000000000_address;
-    tx.to = 0x0000000000000000000000000000000000000000_address;
-    tx.value = 0;
-    tx.access_list = {};
-    tx.nonce = 47;
-    tx.r = 0x0000000000000000000000000000000000000000000000000000000000000000_u256;
-    tx.s = 0x0000000000000000000000000000000000000000000000000000000000000000_u256;
-    tx.v = 2;
     tx.chain_id = 1;
+    tx.nonce = 2;
+    tx.max_priority_gas_price = 3;
+    tx.max_gas_price = 4;
+    tx.gas_limit = 5;
+    tx.to = {};
+    tx.value = 6;
+    tx.data = "da"_hex;
+    tx.access_list = {};
+    tx.v = 7;
+    tx.r = 8_u256;
+    tx.s = 9_u256;
 
-    EXPECT_THAT([tx]() { rlp::encode(tx); },
-        ThrowsMessage<std::invalid_argument>("`v` value for eip1559 transaction must be 0 or 1"));
+    const auto rlp_rep = rlp::encode(tx);
+    EXPECT_EQ(hex(rlp_rep),
+        "02"    // tx_type
+        "cd"    // rlp list start
+        "01"    // chain_id
+        "02"    // nonce
+        "03"    // max_priority_fee_per_gas
+        "04"    // max_fee_per_gas
+        "05"    // gas_limit
+        "80"    // to
+        "06"    // value
+        "81da"  // data
+        "c0"    // access_list
+        "07"    // sig_parity
+        "08"    // sig_r
+        "09"    // sig_s
+    );
 }
 
 TEST(state_rlp, tx_to_rlp_eip2930_invalid_v_value)
 {
     state::Transaction tx{};
     tx.type = evmone::state::Transaction::Type::access_list;
-    tx.data = ""_hex;
-    tx.gas_limit = 1;
-    tx.max_gas_price = 1;
-    tx.max_priority_gas_price = 1;
-    tx.sender = 0x0000000000000000000000000000000000000000_address;
-    tx.to = 0x0000000000000000000000000000000000000000_address;
-    tx.value = 0;
-    tx.access_list = {};
-    tx.nonce = 47;
-    tx.r = 0x0000000000000000000000000000000000000000000000000000000000000000_u256;
-    tx.s = 0x0000000000000000000000000000000000000000000000000000000000000000_u256;
-    tx.v = 2;
     tx.chain_id = 1;
+    tx.nonce = 2;
+    tx.max_gas_price = 3;
+    tx.gas_limit = 4;
+    tx.to = {};
+    tx.value = 5;
+    tx.data = "da"_hex;
+    tx.access_list = {};
+    tx.v = 6;
+    tx.r = 7_u256;
+    tx.s = 8_u256;
 
-    EXPECT_THAT([tx]() { rlp::encode(tx); },
-        ThrowsMessage<std::invalid_argument>("`v` value for eip2930 transaction must be 0 or 1"));
+    const auto rlp_rep = rlp::encode(tx);
+    EXPECT_EQ(hex(rlp_rep),
+        "01"    // tx_type
+        "cc"    // rlp list start
+        "01"    // chain_id
+        "02"    // nonce
+        "03"    // max_fee_per_gas
+        "04"    // gas_limit
+        "80"    // to
+        "05"    // value
+        "81da"  // data
+        "c0"    // access_list
+        "06"    // sig_parity
+        "07"    // sig_r
+        "08"    // sig_s
+    );
 }
 
 TEST(state_rlp, tx_to_rlp_eip1559_with_non_empty_access_list)
@@ -505,50 +531,79 @@ TEST(state_rlp, tx_to_rlp_blob)
 TEST(state_rlp, tx_to_rlp_blob_invalid_v_value)
 {
     state::Transaction tx{};
-
     tx.type = evmone::state::Transaction::Type::blob;
-    tx.data = ""_b;
-    tx.gas_limit = 30000;
-    tx.max_gas_price = 14237787676;
-    tx.max_priority_gas_price = 0;
-    tx.sender = 0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5_address;
-    tx.to = 0x535b918f3724001fd6fb52fcc6cbc220592990a3_address;
-    tx.value = 73360267083380739_u256;
-    tx.access_list = {};
-    tx.nonce = 132949;
-    tx.r = 0x2fe690e16de3534bee626150596573d57cb56d0c2e48a02f64c0a03c1636ce2a_u256;
-    tx.s = 0x4814f3dc7dac2ee153a2456aa3968717af7400972167dfb00b1cce1c23b6dd9f_u256;
-    tx.v = 2;
     tx.chain_id = 1;
-    tx.max_blob_gas_price = 4;
-    tx.blob_hashes = {0x0111111111111111111111111111111111111111111111111111111111111111_bytes32,
-        0x0122222222222222222222222222222222222222222222222222222222222222_bytes32};
+    tx.nonce = 2;
+    tx.max_priority_gas_price = 3;
+    tx.max_gas_price = 4;
+    tx.gas_limit = 5;
+    tx.to = 0x00_address;
+    tx.value = 6;
+    tx.data = "da"_hex;
+    tx.access_list = {};
+    tx.max_blob_gas_price = 7;
+    tx.blob_hashes = {};
+    tx.v = 8;
+    tx.r = 9_u256;
+    tx.s = 0xa_u256;
 
-    EXPECT_THAT([tx]() { rlp::encode(tx); },
-        ThrowsMessage<std::invalid_argument>("`v` value for blob transaction must be 0 or 1"));
+    const auto rlp_rep = rlp::encode(tx);
+    EXPECT_EQ(hex(rlp_rep),
+        "03"                                          // tx_type
+        "e3"                                          // rlp list start
+        "01"                                          // chain_id
+        "02"                                          // nonce
+        "03"                                          // max_priority_fee_per_gas
+        "04"                                          // max_fee_per_gas
+        "05"                                          // gas_limit
+        "940000000000000000000000000000000000000000"  // to
+        "06"                                          // value
+        "81da"                                        // data
+        "c0"                                          // access_list
+        "07"                                          // max_fee_per_blob_gas
+        "c0"                                          // blob_versioned_hashes
+        "08"                                          // sig_parity
+        "09"                                          // sig_r
+        "0a"                                          // sig_s
+    );
 }
 
 TEST(state_rlp, tx_to_rlp_blob_invalid_to_value)
 {
     state::Transaction tx{};
-
     tx.type = evmone::state::Transaction::Type::blob;
-    tx.data = ""_b;
-    tx.gas_limit = 30000;
-    tx.max_gas_price = 14237787676;
-    tx.max_priority_gas_price = 0;
-    tx.sender = 0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5_address;
-    tx.value = 73360267083380739_u256;
-    tx.access_list = {};
-    tx.nonce = 132949;
-    tx.r = 0x2fe690e16de3534bee626150596573d57cb56d0c2e48a02f64c0a03c1636ce2a_u256;
-    tx.s = 0x4814f3dc7dac2ee153a2456aa3968717af7400972167dfb00b1cce1c23b6dd9f_u256;
-    tx.v = 1;
     tx.chain_id = 1;
-    tx.max_blob_gas_price = 4;
-    tx.blob_hashes = {0x0111111111111111111111111111111111111111111111111111111111111111_bytes32,
-        0x0122222222222222222222222222222222222222222222222222222222222222_bytes32};
+    tx.nonce = 2;
+    tx.max_priority_gas_price = 3;
+    tx.max_gas_price = 4;
+    tx.gas_limit = 5;
+    tx.to = {};
+    tx.value = 6;
+    tx.data = "da"_hex;
+    tx.access_list = {};
+    tx.max_blob_gas_price = 7;
+    tx.blob_hashes = {0x0b_bytes32};
+    tx.v = 1;
+    tx.r = 9_u256;
+    tx.s = 0xa_u256;
 
-    EXPECT_THAT([tx]() { rlp::encode(tx); },
-        ThrowsMessage<std::invalid_argument>("`to` value for blob transaction must not be null"));
+    const auto rlp_rep = rlp::encode(tx);
+    EXPECT_EQ(hex(rlp_rep),
+        "03"    // tx_type
+        "f0"    // rlp list start
+        "01"    // chain_id
+        "02"    // nonce
+        "03"    // max_priority_fee_per_gas
+        "04"    // max_fee_per_gas
+        "05"    // gas_limit
+        "80"    // to
+        "06"    // value
+        "81da"  // data
+        "c0"    // access_list
+        "07"    // max_fee_per_blob_gas
+        "e1a0000000000000000000000000000000000000000000000000000000000000000b"  // blob_versioned_hashes
+        "01"                                                                    // sig_parity
+        "09"                                                                    // sig_r
+        "0a"                                                                    // sig_s
+    );
 }


### PR DESCRIPTION
In case a transaction has a field with invalid value we still should RLP-encode it (instead of throwing an exception). This is legit usage in testing tools like evmone-t8n.

Also add an integration test for `evmone-t8n` based on real input.

Fixes #841.