### PR TITLE
ci: Upgrade spec tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -192,7 +192,7 @@ commands:
           name: "Download execution-spec-tests"
           working_directory: ~/spec-tests
           command: |
-            curl -L https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.0/fixtures_develop.tar.gz | tar -xz
+            curl -L https://github.com/ethereum/execution-spec-tests/releases/download/v2.1.1/fixtures_develop.tar.gz | tar -xz
             ls -l
 
   build:
@@ -463,7 +463,9 @@ jobs:
           branch: master
           commit: 985013585c358bbfda399c668bdf9992815b806f
       - download_execution_tests:
-          rev: v13.1
+          # v13.2 + fix
+          rev: develop
+          commit: 52ddcbcef0d58ec7de6b768b564725391a30b934
       - run:
           name: "Silkworm-driven blockchain tests (Advanced)"
           working_directory: ~/build
@@ -500,7 +502,9 @@ jobs:
             bin/evmone-statetest ~/spec-tests/fixtures/state_tests
 
       - download_execution_tests:
-          rev: v13.1
+          # v13.2 + fix
+          rev: develop
+          commit: 52ddcbcef0d58ec7de6b768b564725391a30b934
       - run:
           name: "State tests"
           working_directory: ~/build


### PR DESCRIPTION
- execution-spec-tests: [v2.1.1](https://github.com/ethereum/execution-spec-tests/releases/tag/v2.1.1)
- ethereum/tests: [v13.2](https://github.com/ethereum/tests/releases/tag/v13.2)+fix