### PR TITLE
Test case: initcode-mode not being EOF-validated

### DIFF
--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -1142,3 +1142,27 @@ TEST_F(eof_validation, EOF1_returncontract_invalid)
                       .container(embedded),
         EOFValidationError::unreachable_instructions);
 }
+
+TEST_F(eof_validation, EOF1_eofcreate_returncontract_return_mix_valid)
+{
+    // This test ensures that we _do not_ have a validation rule preventing EOFCREATE,
+    // RETURNCONTRACT and RETURN mixing.
+    const auto embedded = eof_bytecode(bytecode{OP_INVALID});
+
+    // This contains both RETURNCONTRACT and RETURN, as well as references same
+    // container from both EOFCREATE and RETURNCONTRACT
+    const auto mixing_initcode =
+        eofcreate().container(0) + rjumpi(6, 1) + returncontract(0, 0, 0) + ret_top();
+
+    const auto mixing_initcontainer = eof_bytecode(mixing_initcode, 4).container(embedded);
+
+    // This top level container mixes all combinations of EOFCREATE/RETURNCONTRACT/RETURN.
+    add_test_case(eof_bytecode(mixing_initcode, 4).container(mixing_initcontainer),
+        EOFValidationError::success);
+}
+
+TEST_F(eof_validation, EOF1_unreferenced_subcontainer_valid)
+{
+    const auto embedded = eof_bytecode(bytecode{OP_INVALID});
+    add_test_case(eof_bytecode(OP_STOP).container(embedded), EOFValidationError::success);
+}


### PR DESCRIPTION
Recently on the EOF impl call we discussed a potential rule to validate and prohibit "weird" mixing of initcode-mode being on or off - during EOF validation.

We concluded we do not find such validation rule useful enough. In case this rule withstands the test of time, we should have a test case for this.

I think this is a test case where we acertain, that **none of the following conditions** are validated:

> - Each EOF subcontainer must either be referenced by an `EOFCREATE` or a `RETURNCONTRACT` instruction, but never both
> - Each EOF subcontainer may either contain `RETURNCONTRACT` or `RETURN` / `STOP` instructions, but never a mix of these two kinds
> - A subcontainer referenced by an `EOFCREATE` must never contain a `RETURN` / `STOP` instruction, whereas a subcontainer referenced by a `RETURNCONTRACT` must never contain a `RETURNCONTRACT`

This quote is taken from the potential addition to the rationale section of EIP-7620, as PRed here: https://github.com/ethereum/EIPs/blob/d8149857a036b69f24c9f8d56fa87dbd0bbf2d0c/EIPS/eip-7620.md#eof-validation-checking-initcode-mode
