### PR TITLE
codecov: Drop flags config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,14 +3,3 @@ codecov:
 
 comment:
   layout: "diff, flags, files"
-
-flags:
-  statetests:
-    paths:
-      - lib/evmone
-      - test/state
-      - test/statetest
-  blockchaintests:
-    joined: false
-    paths:
-      - lib/evmone


### PR DESCRIPTION
The `blockchaintests` flag is not used any more.
The `statetests` flag is unnecessarily limited to only some directories.