### PR TITLE
EOF subcontainer validation without recursion

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -623,8 +623,7 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
     return max_stack_height_it->max;
 }
 
-std::variant<EOF1Header, EOFValidationError> validate_eof1(
-    evmc_revision rev, bytes_view main_container) noexcept
+EOFValidationError validate_eof1(evmc_revision rev, bytes_view main_container) noexcept
 {
     const auto error_or_header = validate_header(rev, main_container);
     if (const auto* error = std::get_if<EOFValidationError>(&error_or_header))
@@ -699,7 +698,7 @@ std::variant<EOF1Header, EOFValidationError> validate_eof1(
         container_queue.pop();
     }
 
-    return main_container_header;
+    return EOFValidationError::success;
 }
 }  // namespace
 
@@ -816,11 +815,7 @@ uint8_t get_eof_version(bytes_view container) noexcept
 
 EOFValidationError validate_eof(evmc_revision rev, bytes_view container) noexcept
 {
-    const auto header_or_error = validate_eof1(rev, container);
-    if (const auto* error = std::get_if<EOFValidationError>(&header_or_error))
-        return *error;
-    else
-        return EOFValidationError::success;
+    return validate_eof1(rev, container);
 }
 
 std::string_view get_error_message(EOFValidationError err) noexcept

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -297,8 +297,16 @@ std::variant<EOF1Header, EOFValidationError> validate_header(
     }
     const auto data_offset = static_cast<uint16_t>(offset);
 
-    return EOF1Header{container[2], code_sizes, code_offsets, data_size, data_offset,
-        container_sizes, container_offsets, types};
+    return EOF1Header{
+        .version = container[2],
+        .code_sizes = code_sizes,
+        .code_offsets = code_offsets,
+        .data_size = data_size,
+        .data_offset = data_offset,
+        .container_sizes = container_sizes,
+        .container_offsets = container_offsets,
+        .types = types,
+    };
 }
 
 EOFValidationError validate_instructions(evmc_revision rev, const EOF1Header& header,

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -12,6 +12,12 @@
 using namespace evmone;
 using namespace evmone::test;
 
+TEST_F(eof_validation, before_activation)
+{
+    ASSERT_EQ(evmone::validate_eof(EVMC_CANCUN, bytes(eof_bytecode(OP_STOP))),
+        EOFValidationError::eof_version_unknown);
+}
+
 TEST_F(eof_validation, validate_empty_code)
 {
     add_test_case("", EOFValidationError::invalid_prefix);

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -1196,3 +1196,12 @@ TEST_F(eof_validation, EOF1_subcontainer_containing_unreachable_code_sections)
     add_test_case(eof_bytecode(OP_INVALID).container(embedded_2),
         EOFValidationError::unreachable_code_sections);
 }
+
+TEST_F(eof_validation, max_nested_containers)
+{
+    bytecode code = eof_bytecode(OP_INVALID);
+    while (code.size() <= std::numeric_limits<uint16_t>::max())
+        code = eof_bytecode(OP_INVALID).container(code);
+
+    add_test_case(code, EOFValidationError::success);
+}


### PR DESCRIPTION
Main part of the refactoring, that gets rid of recursion, is basically a transformation from:

- validate header
- for all subcontainers
  - validate subcontainer (recursion)
- validate instructions
- validate jumps, stack etc.

to:

- validate header
- queue = { {container, header} }
- while queue not empty
  - cont, header = queue.pop()
  - for all subcontainers
    - validate subcontainer header
    - queue.push( {subcontainer, subcontainer_header} )
  - validate instructions 
  - validate jumps, stack etc.