### PR TITLE
eofparse: Return number of errors

### DIFF
--- a/test/eofparse/eofparse.cpp
+++ b/test/eofparse/eofparse.cpp
@@ -39,6 +39,7 @@ int main()
 {
     try
     {
+        int num_errors = 0;
         for (std::string line; std::getline(std::cin, line);)
         {
             if (line.empty() || line.starts_with('#'))
@@ -48,6 +49,7 @@ int main()
             if (!o)
             {
                 std::cout << "err: invalid hex\n";
+                ++num_errors;
                 continue;
             }
 
@@ -56,6 +58,7 @@ int main()
             if (err != evmone::EOFValidationError::success)
             {
                 std::cout << "err: " << evmone::get_error_message(err) << "\n";
+                ++num_errors;
                 continue;
             }
 
@@ -69,11 +72,11 @@ int main()
             }
             std::cout << "\n";
         }
-        return 0;
+        return num_errors;
     }
     catch (const std::exception& ex)
     {
         std::cerr << ex.what() << "\n";
-        return 1;
+        return -1;
     }
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -36,6 +36,7 @@ DUP1,4
 
 endif()
 
+add_subdirectory(eofparse)
 add_subdirectory(statetest)
 add_subdirectory(t8n)
 

--- a/test/integration/eofparse/CMakeLists.txt
+++ b/test/integration/eofparse/CMakeLists.txt
@@ -1,0 +1,25 @@
+# evmone: Fast Ethereum Virtual Machine implementation
+# Copyright 2024 The evmone Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+set(PREFIX ${PROJECT_NAME}/integration/eofparse)
+
+string(REPLACE ";" " " CROSSCOMPILING_EMULATOR "${CMAKE_CROSSCOMPILING_EMULATOR}")
+
+add_test(NAME ${PREFIX}/minimal_eof COMMAND sh -c "echo EF0001.010004 0200010001 040000 00,00800000 FE | ${CROSSCOMPILING_EMULATOR} $<TARGET_FILE:evmone-eofparse>")
+set_tests_properties(${PREFIX}/minimal_eof PROPERTIES PASS_REGULAR_EXPRESSION "OK fe")
+
+add_test(NAME ${PREFIX}/two_code_sections COMMAND sh -c "echo EF0001 010008 02000200030001 040000 00 00800000,00800000 E50001,00 | ${CROSSCOMPILING_EMULATOR} $<TARGET_FILE:evmone-eofparse>")
+set_tests_properties(${PREFIX}/two_code_sections PROPERTIES PASS_REGULAR_EXPRESSION "OK e50001,00")
+
+add_test(NAME ${PREFIX}/eof_version_unknown COMMAND sh -c "echo EF00.FF | ${CROSSCOMPILING_EMULATOR} $<TARGET_FILE:evmone-eofparse>")
+set_tests_properties(${PREFIX}/eof_version_unknown PROPERTIES PASS_REGULAR_EXPRESSION "err: eof_version_unknown")
+
+add_test(NAME ${PREFIX}/invalid_hex COMMAND sh -c "echo gaga | ${CROSSCOMPILING_EMULATOR} $<TARGET_FILE:evmone-eofparse>")
+set_tests_properties(${PREFIX}/invalid_hex PROPERTIES PASS_REGULAR_EXPRESSION "err: invalid hex")
+
+add_test(NAME ${PREFIX}/example_input_file COMMAND sh -c "${CROSSCOMPILING_EMULATOR} $<TARGET_FILE:evmone-eofparse> <${CMAKE_CURRENT_SOURCE_DIR}/two_errors.txt")
+set_tests_properties(${PREFIX}/example_input_file PROPERTIES PASS_REGULAR_EXPRESSION "OK 00\nerr: type_section_missing\nerr: no_terminating_instruction")
+
+add_test(NAME ${PREFIX}/exit_code COMMAND sh -c "${CROSSCOMPILING_EMULATOR} $<TARGET_FILE:evmone-eofparse> <${CMAKE_CURRENT_SOURCE_DIR}/two_errors.txt >/dev/null; echo $?")
+set_tests_properties(${PREFIX}/exit_code PROPERTIES PASS_REGULAR_EXPRESSION "2")

--- a/test/integration/eofparse/two_errors.txt
+++ b/test/integration/eofparse/two_errors.txt
@@ -1,0 +1,10 @@
+# Example input file to eofparse tool. Two of the following lines contain EOF validation errors.
+
+# Minimal valid EOF container.
+EF0001 010004 0200010001 040000 00  00800000 00
+
+# Mandatory sections missing
+EF0001 00
+
+# Code section not terminated
+EF0001 010004 0200010001 040000 00  00800000 5b


### PR DESCRIPTION
In the evmone-eofparse tool exit with the number of invalid EOFs encountered.

Also add some basic integration tests.

Fixes #872