### PR TITLE
ci: Migrate to macOS M1 only

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -56,19 +56,13 @@ executors:
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   macos:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: 15.3.0
-    environment:
-      CMAKE_BUILD_PARALLEL_LEVEL: 4
-  macos-m1:
     resource_class: macos.m1.large.gen1
     macos:
-      xcode: 15.3.0
+      xcode: 15.4.0
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
   macos-xcode-min:
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: 15.0.0
     environment:
@@ -367,18 +361,6 @@ jobs:
       - test
       - package
 
-  release-macos-m1:
-    executor: macos-m1
-    environment:
-      BUILD_TYPE: Release
-    steps:
-      - run:
-          name: "Install System Dependencies"
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake
-      - build
-      - test
-      - package
-
   deploy:
     docker:
       - image: circleci/golang
@@ -594,7 +576,7 @@ jobs:
             - ~/corpus
 
   macos-asan:
-    executor: macos-m1
+    executor: macos
     environment:
       BUILD_TYPE: RelWithDebInfo
       CMAKE_OPTIONS: -DSANITIZE=address,undefined
@@ -669,7 +651,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - release-macos-m1
       - deploy:
           requires:
             - release-linux


### PR DESCRIPTION
CircleCI is removing the support for macOS on Intel hardware. Switch to M1 resources.