### PR TITLE
ci: Separate execution-spec-tests job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,12 +20,6 @@ executors:
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
-  blockchain-tests:
-    docker:
-      - image: ethereum/cpp-build-env:21-gcc-13
-    resource_class: xlarge
-    environment:
-      CMAKE_BUILD_PARALLEL_LEVEL: 8
   linux-clang-xlarge:
     docker:
       - image: ethereum/cpp-build-env:21-clang-17
@@ -380,25 +374,34 @@ jobs:
             echo $name
             ghr -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -n "$name" $prerelease_flag $CIRCLE_TAG ~/package
 
-  state-tests:
-    executor: blockchain-tests
+  execution-spec-tests:
+    executor: linux-gcc-latest
     environment:
       BUILD_TYPE: Coverage
-      CMAKE_OPTIONS: -DCMAKE_CXX_FLAGS=-Og
     steps:
       - download_execution_spec_tests
       - build
-      - run:
-          name: "Execution spec tests (blockchain_tests)"
-          working_directory: ~/build
-          command: >
-            bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
       - run:
           name: "Execution spec tests (state_tests)"
           working_directory: ~/build
           command: >
             bin/evmone-statetest ~/spec-tests/fixtures/state_tests
+      - run:
+          name: "Execution spec tests (blockchain_tests)"
+          working_directory: ~/build
+          command: >
+            bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
+      - collect_coverage_gcc
+      - upload_coverage:
+          flags: execution-spec-tests
 
+  ethereum-tests:
+    executor: linux-gcc-latest
+    environment:
+      BUILD_TYPE: Coverage
+      CMAKE_OPTIONS: -DCMAKE_CXX_FLAGS=-Og
+    steps:
+      - build
       - download_execution_tests:
           # v13.2 + fix
           rev: develop
@@ -447,10 +450,10 @@ jobs:
             bin/evmone-eoftest ~/tests/EOFTests
       - collect_coverage_gcc
       - upload_coverage:
-          flags: statetests
+          flags: ethereum-tests
 
   precompiles-silkpre:
-    executor: blockchain-tests
+    executor: linux-gcc-latest
     environment:
       BUILD_TYPE: Coverage
       CMAKE_OPTIONS: -DCMAKE_CXX_FLAGS=-Og -DEVMONE_PRECOMPILES_SILKPRE=1
@@ -468,7 +471,7 @@ jobs:
             bin/evmone-statetest ~/tests/GeneralStateTests ~/tests/LegacyTests/Constantinople/GeneralStateTests
       - collect_coverage_gcc
       - upload_coverage:
-          flags: statetests-silkpre
+          flags: ethereum-tests-silkpre
 
   gcc-min:
     executor: linux-gcc-min
@@ -661,7 +664,8 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9].*/
-      - state-tests
+      - execution-spec-tests
+      - ethereum-tests
       - precompiles-silkpre
       - cmake-min
       - gcc-min


### PR DESCRIPTION
- Create separate job for `execution-spec-tests` (previously part of `state-tests`).
- Rename the `state-tests` to `ethereum-tests` to match the source of the tests (ethereum/tests).
- Publish coverage data with separate flags: `execution-spec-tests` and `ethereum-tests` respectively.