### PR TITLE
ci: Sync EOF tests with ethereum/tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -434,7 +434,7 @@ jobs:
             ~/tests/EIPTests/BlockchainTests/
       - download_execution_tests:
           repo: ipsilon/tests
-          rev: eof-eofcreate-20240416
+          rev: v13.3
           legacy: false
       - run:
           name: "State tests (EOF)"


### PR DESCRIPTION
Use the official release v13.3 of ethereum/tests
(git tag also pushed to ipsilon/tests).