### PR TITLE
Use can_init for EOFCREATE validation

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -641,7 +641,7 @@ EOFValidationError validate_eof1(evmc_revision rev, bytes_view main_container) n
 
     while (!container_queue.empty())
     {
-        // Validate subcontainer headers and get their data sections
+        // Validate subcontainer headers and record whether they can be used as initcontainers
         const auto& [container, header] = container_queue.front();
         std::vector<bool> subcontainer_can_init;
         for (size_t subcont_idx = 0; subcont_idx < header.container_sizes.size(); ++subcont_idx)


### PR DESCRIPTION
This was bugging me for a while. 

We can leverage the same path in all cases where data section trunctaion is checked.

Not ideal, I tried a bunch of options, this seems least obtrusive. WDYT?