### PR TITLE
Fix EOF initcode handling before EOF is enabled

### DIFF
--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -280,9 +280,12 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
         msg.input_data = &state.memory[init_code_offset];
         msg.input_size = init_code_size;
 
-        // EOF initcode is not allowed for legacy creation
-        if (is_eof_container({msg.input_data, msg.input_size}))
-            return {EVMC_SUCCESS, gas_left};  // "Light" failure.
+        if (state.rev >= EVMC_PRAGUE)
+        {
+            // EOF initcode is not allowed for legacy creation
+            if (is_eof_container({msg.input_data, msg.input_size}))
+                return {EVMC_SUCCESS, gas_left};  // "Light" failure.
+        }
     }
     msg.sender = state.msg->recipient;
     msg.depth = state.msg->depth + 1;


### PR DESCRIPTION
The special rule of handling EOF initcode in CREATE/CREATE2 instructions should not be activated before EOF is activated.