### PR TITLE
Track EVM stack "end" instead of "top"

### DIFF
--- a/lib/evmone/advanced_analysis.hpp
+++ b/lib/evmone/advanced_analysis.hpp
@@ -56,11 +56,11 @@ struct AdvancedExecutionState : ExecutionState
     /// Computes the current EVM stack height.
     [[nodiscard]] int stack_size() noexcept
     {
-        return static_cast<int>((&stack.top() - stack_space.bottom()));
+        return static_cast<int>(stack.end() - stack_space.bottom());
     }
 
     /// Adjust the EVM stack height by given change.
-    void adjust_stack_size(int change) noexcept { stack = &stack.top() + change; }
+    void adjust_stack_size(int change) noexcept { stack = stack.end() + change; }
 
     /// Terminates the execution with the given status code.
     const Instruction* exit(evmc_status_code status_code) noexcept

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -67,10 +67,7 @@ public:
     StackSpace() noexcept : m_stack_space{allocate()} {}
 
     /// Returns the pointer to the "bottom", i.e. below the stack space.
-    [[nodiscard, clang::no_sanitize("bounds")]] uint256* bottom() noexcept
-    {
-        return m_stack_space.get() - 1;
-    }
+    [[nodiscard]] uint256* bottom() noexcept { return m_stack_space.get(); }
 };
 
 


### PR DESCRIPTION
This is more correct C++ because it avoids the "bottom" pointer (one below the stack space base pointer). In C++ only pointers to the elements of an array and the "end" pointers are well defined.

This also potentially helps with the "overaligned" stack space optimization. To be continued...