### PR TITLE
CI: Upgrade compilers: GCC 14 and clang 18

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -64,6 +64,8 @@ Checks:
   - "-readability-magic-numbers"
   - "-readability-named-parameter"
   - "-readability-qualified-auto"
+  # TODO: Check if removing inline affects clang optimized builds.
+  - "-readability-redundant-inline-specifier"
   - "-readability-uppercase-literal-suffix"
 
 CheckOptions:

--- a/circle.yml
+++ b/circle.yml
@@ -6,24 +6,24 @@ orbs:
 executors:
   lint:
     docker:
-      - image: ethereum/cpp-build-env:21-lint
+      - image: ethereum/cpp-build-env:22-lint
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   linux-gcc-latest:
     docker:
-      - image: ethereum/cpp-build-env:21-gcc-13
+      - image: ethereum/cpp-build-env:22-gcc-14
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
   linux-gcc-multilib:
     docker:
-      - image: ethereum/cpp-build-env:21-gcc-13-multilib
+      - image: ethereum/cpp-build-env:22-gcc-14-multilib
     resource_class: small
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   linux-clang-xlarge:
     docker:
-      - image: ethereum/cpp-build-env:21-clang-17
+      - image: ethereum/cpp-build-env:22-clang-18
     resource_class: xlarge
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 8
@@ -41,7 +41,7 @@ executors:
       CMAKE_BUILD_PARALLEL_LEVEL: 2
   linux-clang-latest:
     docker:
-      - image: ethereum/cpp-build-env:21-clang-17
+      - image: ethereum/cpp-build-env:22-clang-18
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
   linux-clang-min:
@@ -197,9 +197,6 @@ commands:
   collect_coverage_gcc:
     description: "Collect coverage data (GCC)"
     steps:
-      - run:
-          name: "Install gcovr"
-          command: sudo apt update && sudo apt install -y gcovr
       - run:
           name: "Collect coverage data (GCC)"
           working_directory: ~/build

--- a/test/state/account.hpp
+++ b/test/state/account.hpp
@@ -17,10 +17,10 @@ using evmc::bytes32;
 struct StorageValue
 {
     /// The current value.
-    bytes32 current = {};
+    bytes32 current;
 
     /// The original value.
-    bytes32 original = {};
+    bytes32 original;
 
     evmc_access_status access_status = EVMC_ACCESS_COLD;
 };

--- a/test/utils/utils.hpp
+++ b/test/utils/utils.hpp
@@ -5,6 +5,7 @@
 
 #include <evmc/evmc.hpp>
 #include <evmc/hex.hpp>
+#include <algorithm>
 
 namespace evmone::test
 {


### PR DESCRIPTION
Upgrade compilers: GCC 14 and clang 18.
Alongside, tune clang-tidy config and fix small build warning/errors.