### PR TITLE
Upgrade EVMC and use evmc::{bytes, bytes_view}

### DIFF
--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -7,13 +7,11 @@
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
 #include <memory>
-#include <string_view>
 #include <vector>
 
 namespace evmone
 {
-using bytes_view = std::basic_string_view<uint8_t>;
-
+using evmc::bytes_view;
 class ExecutionState;
 class VM;
 

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <evmc/bytes.hpp>
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
 #include <cassert>
@@ -13,8 +14,8 @@
 
 namespace evmone
 {
-using bytes = std::basic_string<uint8_t>;
-using bytes_view = std::basic_string_view<uint8_t>;
+using evmc::bytes;
+using evmc::bytes_view;
 
 struct EOFCodeType
 {

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -19,9 +19,9 @@ namespace baseline
 class CodeAnalysis;
 }
 
-using uint256 = intx::uint256;
-using bytes = std::basic_string<uint8_t>;
-using bytes_view = std::basic_string_view<uint8_t>;
+using evmc::bytes;
+using evmc::bytes_view;
+using intx::uint256;
 
 
 /// Provides memory for EVM stack.

--- a/lib/evmone/tracing.hpp
+++ b/lib/evmone/tracing.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <evmc/bytes.hpp>
 #include <evmc/evmc.h>
 #include <evmc/utils.h>
 #include <intx/intx.hpp>
@@ -12,8 +13,7 @@
 
 namespace evmone
 {
-using bytes_view = std::basic_string_view<uint8_t>;
-
+using evmc::bytes_view;
 class ExecutionState;
 
 class Tracer

--- a/test/state/rlp.hpp
+++ b/test/state/rlp.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <evmc/bytes.hpp>
 #include <intx/intx.hpp>
 #include <cassert>
 #include <string>
@@ -13,8 +14,8 @@
 
 namespace evmone::rlp
 {
-using bytes = std::basic_string<uint8_t>;
-using bytes_view = std::basic_string_view<uint8_t>;
+using evmc::bytes;
+using evmc::bytes_view;
 
 namespace internal
 {

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -80,6 +80,11 @@ target_sources(
 )
 target_link_libraries(evmone-unittests PRIVATE evmone evmone::evmmax evmone::state evmone::statetestutils testutils evmc::instructions GTest::gtest GTest::gtest_main)
 target_include_directories(evmone-unittests PRIVATE ${evmone_private_include_dir})
+target_compile_options(evmone-unittests PRIVATE
+    # Disable false positive C4789
+    # https://developercommunity.visualstudio.com/t/False-positive-buffer-overrun-warning-C/10666762
+    $<$<CXX_COMPILER_ID:MSVC>:-wd4789>
+)
 
 gtest_discover_tests(evmone-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)
 

--- a/test/unittests/evm_eof_test.cpp
+++ b/test/unittests/evm_eof_test.cpp
@@ -148,29 +148,25 @@ TEST_P(evm, eof1_datasize)
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000000"_hex);
 
-    bytes data = {0x0};
-    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(bytes{0x0});
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000001"_hex);
 
-    data = bytes(32, 0x0);
-    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(bytes(32, 0x0));
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000020"_hex);
 
-    data = bytes(64, 0x0);
-    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(bytes(64, 0x0));
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),
         "0000000000000000000000000000000000000000000000000000000000000040"_hex);
 
-    data = bytes(80, 0x0);
-    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(data);
+    code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2).data(bytes(80, 0x0));
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size),

--- a/test/unittests/precompiles_ripemd160_test.cpp
+++ b/test/unittests/precompiles_ripemd160_test.cpp
@@ -5,10 +5,11 @@
 #include <evmc/hex.hpp>
 #include <evmone_precompiles/ripemd160.hpp>
 #include <gtest/gtest.h>
+#include <span>
 
 using evmone::crypto::ripemd160;
 
-inline std::string hex(std::basic_string_view<std::byte> x)
+inline std::string hex(std::span<const std::byte> x)
 {
     return evmc::hex({reinterpret_cast<const unsigned char*>(x.data()), x.size()});
 }


### PR DESCRIPTION
This fixes builds with libc++ 18 where std::char_traits<unsigned char> is deprecated.

Requires https://github.com/ethereum/evmc/pull/712.