### PR TITLE
clang-tidy: Convert "Checks" to YAML list

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,70 +1,70 @@
 FormatStyle: file
 HeaderFilterRegex: 'lib/evmone/|test/state/'
 WarningsAsErrors: '*'
-Checks: >
-  bugprone-*,
-  -bugprone-assignment-in-if-condition,
-  -bugprone-easily-swappable-parameters,
-  -bugprone-implicit-widening-of-multiplication-result,
-  -bugprone-unchecked-optional-access,
-  cert-dcl21-cpp,
-  cert-dcl50-cpp,
-  cert-dcl58-cpp,
-  cert-env33-c,
-  cert-err33-c,
-  cert-err34-c,
-  cert-err52-cpp,
-  cert-err60-cpp,
-  cert-flp30-c,
-  cert-mem57-cpp,
-  cert-msc50-cpp,
-  cert-msc51-cpp,
-  cert-oop57-cpp,
-  cert-oop58-cpp,
-  clang-analyzer-*,
-  cppcoreguidelines-*,
-  -cppcoreguidelines-avoid-c-arrays,
-  -cppcoreguidelines-avoid-const-or-ref-data-members,
-  -cppcoreguidelines-avoid-goto,
-  -cppcoreguidelines-avoid-magic-numbers,
-  -cppcoreguidelines-avoid-non-const-global-variables,
-  -cppcoreguidelines-macro-usage,
-  -cppcoreguidelines-no-malloc,
-  -cppcoreguidelines-non-private-member-variables-in-classes,
-  -cppcoreguidelines-owning-memory,
-  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
-  -cppcoreguidelines-pro-bounds-constant-array-index,
-  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
-  -cppcoreguidelines-pro-type-reinterpret-cast,
-  -cppcoreguidelines-pro-type-static-cast-downcast,
-  -cppcoreguidelines-pro-type-union-access,
-  -cppcoreguidelines-pro-type-vararg,
-  -cppcoreguidelines-special-member-functions,
-  google-global-names-in-headers,
-  google-runtime-int,
-  hicpp-exception-baseclass,
-  hicpp-multiway-paths-covered,
-  hicpp-no-assembler,
-  misc-*,
-  -misc-include-cleaner,
-  -misc-non-private-member-variables-in-classes,
-  -misc-use-anonymous-namespace,
-  modernize-*,
-  -modernize-avoid-c-arrays,
-  -modernize-use-trailing-return-type,
-  performance-*,
-  -performance-enum-size,
-  portability-*,
-  readability-*,
-  -readability-braces-around-statements,
-  -readability-else-after-return,
-  -readability-function-cognitive-complexity,
-  -readability-function-size,
-  -readability-identifier-length,
-  -readability-magic-numbers,
-  -readability-named-parameter,
-  -readability-qualified-auto,
-  -readability-uppercase-literal-suffix,
+Checks:
+  - "bugprone-*"
+  - "-bugprone-assignment-in-if-condition"
+  - "-bugprone-easily-swappable-parameters"
+  - "-bugprone-implicit-widening-of-multiplication-result"
+  - "-bugprone-unchecked-optional-access"
+  - "cert-dcl21-cpp"
+  - "cert-dcl50-cpp"
+  - "cert-dcl58-cpp"
+  - "cert-env33-c"
+  - "cert-err33-c"
+  - "cert-err34-c"
+  - "cert-err52-cpp"
+  - "cert-err60-cpp"
+  - "cert-flp30-c"
+  - "cert-mem57-cpp"
+  - "cert-msc50-cpp"
+  - "cert-msc51-cpp"
+  - "cert-oop57-cpp"
+  - "cert-oop58-cpp"
+  - "clang-analyzer-*"
+  - "cppcoreguidelines-*"
+  - "-cppcoreguidelines-avoid-c-arrays"
+  - "-cppcoreguidelines-avoid-const-or-ref-data-members"
+  - "-cppcoreguidelines-avoid-goto"
+  - "-cppcoreguidelines-avoid-magic-numbers"
+  - "-cppcoreguidelines-avoid-non-const-global-variables"
+  - "-cppcoreguidelines-macro-usage"
+  - "-cppcoreguidelines-no-malloc"
+  - "-cppcoreguidelines-non-private-member-variables-in-classes"
+  - "-cppcoreguidelines-owning-memory"
+  - "-cppcoreguidelines-pro-bounds-array-to-pointer-decay"
+  - "-cppcoreguidelines-pro-bounds-constant-array-index"
+  - "-cppcoreguidelines-pro-bounds-pointer-arithmetic"
+  - "-cppcoreguidelines-pro-type-reinterpret-cast"
+  - "-cppcoreguidelines-pro-type-static-cast-downcast"
+  - "-cppcoreguidelines-pro-type-union-access"
+  - "-cppcoreguidelines-pro-type-vararg"
+  - "-cppcoreguidelines-special-member-functions"
+  - "google-global-names-in-headers"
+  - "google-runtime-int"
+  - "hicpp-exception-baseclass"
+  - "hicpp-multiway-paths-covered"
+  - "hicpp-no-assembler"
+  - "misc-*"
+  - "-misc-include-cleaner"
+  - "-misc-non-private-member-variables-in-classes"
+  - "-misc-use-anonymous-namespace"
+  - "modernize-*"
+  - "-modernize-avoid-c-arrays"
+  - "-modernize-use-trailing-return-type"
+  - "performance-*"
+  - "-performance-enum-size"
+  - "portability-*"
+  - "readability-*"
+  - "-readability-braces-around-statements"
+  - "-readability-else-after-return"
+  - "-readability-function-cognitive-complexity"
+  - "-readability-function-size"
+  - "-readability-identifier-length"
+  - "-readability-magic-numbers"
+  - "-readability-named-parameter"
+  - "-readability-qualified-auto"
+  - "-readability-uppercase-literal-suffix"
 
 CheckOptions:
   readability-identifier-naming.ClassCase: CamelCase


### PR DESCRIPTION
Since clang-tidy 17 the "Checks" can be specified as list of strings (instead of single string).
This should improve maintenance of the configuration: ability to leave comments about individual checks.