### PR TITLE
EOF RETURNDATA* to pad on OOB read

### DIFF
--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -569,25 +569,22 @@ inline Result extcodecopy(StackTop stack, int64_t gas_left, ExecutionState& stat
     return {EVMC_SUCCESS, gas_left};
 }
 
-inline Result returndataload(StackTop stack, int64_t gas_left, ExecutionState& state) noexcept
+inline void returndataload(StackTop stack, ExecutionState& state) noexcept
 {
     auto& index = stack.top();
 
     if (state.return_data.size() < index)
-        return {EVMC_INVALID_MEMORY_ACCESS, gas_left};
+        index = 0;
     else
     {
         const auto begin = static_cast<size_t>(index);
-        const auto end = begin + 32;
-        if (state.return_data.size() < end)
-            return {EVMC_INVALID_MEMORY_ACCESS, gas_left};
+        const auto end = std::min(begin + 32, state.return_data.size());
 
         uint8_t data[32] = {};
         for (size_t i = 0; i < (end - begin); ++i)
             data[i] = state.return_data[begin + i];
 
         index = intx::be::unsafe::load<uint256>(data);
-        return {EVMC_SUCCESS, gas_left};
     }
 }
 

--- a/test/unittests/evm_eof_calls_test.cpp
+++ b/test/unittests/evm_eof_calls_test.cpp
@@ -340,72 +340,111 @@ TEST_P(evm, returndataload_outofrange)
 
     rev = EVMC_PRAGUE;
     {
-        const uint8_t call_output[31]{};
+        const auto call_output =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex;  // 31 bytes
         host.call_result.output_data = std::data(call_output);
         host.call_result.output_size = std::size(call_output);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(0) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
+        execute(eof_bytecode(extstaticcall(0) + returndataload(0) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00"_hex);
     }
     {
-        const uint8_t call_output[32]{};
+        const auto call_output =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex;  // 32 bytes
         host.call_result.output_data = std::data(call_output);
         host.call_result.output_size = std::size(call_output);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(1) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(31) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(32) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(0) + OP_STOP, 3));
+        execute(eof_bytecode(extstaticcall(0) + returndataload(1) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(31) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaa00000000000000000000000000000000000000000000000000000000000000"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(32) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0x0000000000000000000000000000000000000000000000000000000000000000"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0x0000000000000000000000000000000000000000000000000000000000000000"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(0) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
     }
     {
-        const uint8_t call_output[34]{};
+        // 34 bytes
+        const auto call_output =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex;
         host.call_result.output_data = std::data(call_output);
         host.call_result.output_size = std::size(call_output);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(3) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(1) + OP_STOP, 3));
+        execute(eof_bytecode(extstaticcall(0) + returndataload(3) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00"_hex);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(2) + OP_STOP, 3));
+        execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0x0000000000000000000000000000000000000000000000000000000000000000"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(1) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(2) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
     }
     {
-        const uint8_t call_output[64]{};
+        const auto call_output =
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex;  // 64 bytes
         host.call_result.output_data = std::data(call_output);
         host.call_result.output_size = std::size(call_output);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(33) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + OP_STOP, 3));
-        EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
-
-
-        execute(eof_bytecode(extstaticcall(0) + returndataload(1) + OP_STOP, 3));
+        execute(eof_bytecode(extstaticcall(0) + returndataload(33) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00"_hex);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(31) + OP_STOP, 3));
+        execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0x0000000000000000000000000000000000000000000000000000000000000000"_hex);
 
-        execute(eof_bytecode(extstaticcall(0) + returndataload(32) + OP_STOP, 3));
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(1) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
-        execute(eof_bytecode(extstaticcall(0) + returndataload(0) + OP_STOP, 3));
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(31) + ret_top(), 3));
         EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(32) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
+
+        execute(eof_bytecode(extstaticcall(0) + returndataload(0) + ret_top(), 3));
+        EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+        EXPECT_EQ(bytes_view(result.output_data, result.output_size),
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex);
     }
 }
 
@@ -416,14 +455,17 @@ TEST_P(evm, returndataload_empty)
         return;
 
     rev = EVMC_PRAGUE;
-    execute(eof_bytecode(extstaticcall(0) + returndataload(0) + OP_STOP, 3));
-    EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
+    execute(eof_bytecode(extstaticcall(0) + returndataload(0) + ret_top(), 3));
+    EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(bytes_view(result.output_data, result.output_size), evmc::bytes32(0));
 
-    execute(eof_bytecode(extstaticcall(0) + returndataload(1) + OP_STOP, 3));
-    EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
+    execute(eof_bytecode(extstaticcall(0) + returndataload(1) + ret_top(), 3));
+    EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(bytes_view(result.output_data, result.output_size), evmc::bytes32(0));
 
-    execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + OP_STOP, 3));
-    EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
+    execute(eof_bytecode(extstaticcall(0) + returndataload(max_uint256) + ret_top(), 3));
+    EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(bytes_view(result.output_data, result.output_size), evmc::bytes32(0));
 }
 
 TEST_P(evm, returndataload_outofrange_highbits)
@@ -440,8 +482,9 @@ TEST_P(evm, returndataload_outofrange_highbits)
     // Covers an incorrect cast of RETURNDATALOAD arg to `size_t` ignoring the high bits.
     const auto highbits =
         0x1000000000000000000000000000000000000000000000000000000000000000_bytes32;
-    execute(eof_bytecode(extstaticcall(0) + returndataload(highbits) + OP_STOP, 3));
-    EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
+    execute(eof_bytecode(extstaticcall(0) + returndataload(highbits) + ret_top(), 3));
+    EXPECT_EQ(result.status_code, EVMC_SUCCESS);
+    EXPECT_EQ(bytes_view(result.output_data, result.output_size), evmc::bytes32(0));
 }
 
 TEST_P(evm, extcall_gas_refund_aggregation_different_calls)


### PR DESCRIPTION
Closes https://github.com/ethereum/evmone/issues/896, implements https://github.com/ipsilon/eof/pull/90 / https://github.com/ethereum/EIPs/pull/8617 the simplest way - by checking two first bytes of code on every instructions. 

A better version would be to store the result in ExecutionState, and the best to use an entirely different instruction table in `dispatch` functions.

Should we do the `ExecutionState` version right away now, or keep as is? Anyway, opening as draft until the EOF pr doesn't get merged (should be decided on the next eof impl call)