### PR TITLE
tidy: Avoid returning void

### DIFF
--- a/test/precompiles_bench/precompiles_bench.cpp
+++ b/test/precompiles_bench/precompiles_bench.cpp
@@ -141,7 +141,10 @@ void precompile(benchmark::State& state)
         {
             const auto [status, _] = Fn(input.data(), input.size(), output.get(), max_output_size);
             if (status != EVMC_SUCCESS) [[unlikely]]
-                return state.SkipWithError("invalid result");
+            {
+                state.SkipWithError("invalid result");
+                return;
+            }
         }
         total_gas_used += batch_gas_cost;
     }

--- a/test/state/mpt.cpp
+++ b/test/state/mpt.cpp
@@ -173,7 +173,10 @@ void MPTNode::insert(const Path& path, bytes&& value)  // NOLINT(misc-no-recursi
     {
         assert(!m_path.empty());       // Ext must have non-empty path.
         if (this_idx == m_path.end())  // Paths match: go into the child.
-            return m_children[0]->insert({insert_idx, path.end()}, std::move(value));
+        {
+            m_children[0]->insert({insert_idx, path.end()}, std::move(value));
+            return;
+        }
 
         // The original branch node must be pushed down, possible extended with
         // the adjusted extended node if the path split point is not directly at the branch node.


### PR DESCRIPTION
Fix clang-tidy check "readability-avoid-return-with-void-value". https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-return-with-void-value.html