### PR TITLE
tidy: Avoid nested conditional operator

### DIFF
--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -128,9 +128,12 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
     };
     static constexpr auto mult_complexity_eip198 = [](const uint256& x) noexcept {
         const auto x2 = x * x;
-        return (x <= 64)   ? x2 :
-               (x <= 1024) ? (x2 >> 2) + 96 * x - 3072 :
-                             (x2 >> 4) + 480 * x - 199680;
+        if (x <= 64)
+            return x2;
+        else if (x <= 1024)
+            return (x2 >> 2) + 96 * x - 3072;
+        else
+            return (x2 >> 4) + 480 * x - 199680;
     };
 
     const auto max_len = std::max(mod_len, base_len);

--- a/test/unittests/evm_calls_test.cpp
+++ b/test/unittests/evm_calls_test.cpp
@@ -627,9 +627,14 @@ TEST_P(evm, call_value)
     {
         const auto has_value_arg = (op == OP_CALL || op == OP_CALLCODE);
         const auto value_cost = has_value_arg ? 9000 : 0;
-        const auto expected_value = has_value_arg           ? passed_value :
-                                    (op == OP_DELEGATECALL) ? origin_value :
-                                                              0;
+        const auto expected_value = [=] {
+            if (has_value_arg)
+                return passed_value;
+            else if (op == OP_DELEGATECALL)
+                return origin_value;
+            else
+                return 0;
+        }();
 
         const auto code =
             4 * push(0) + push(has_value_arg ? passed_value : 0) + push(recipient) + push(0) + op;


### PR DESCRIPTION
Fix clang-tidy check "void-nested-conditional-operator". https://clang.llvm.org/extra/clang-tidy/checks/readability/avoid-nested-conditional-operator.html