### PR TITLE
ci: Build clang/sanitizers with debug libc++

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -537,6 +537,7 @@ jobs:
   clang-latest-sanitizers:
     executor: linux-clang-xlarge
     environment:
+      TOOLCHAIN: clang-libcxx-debug
       CMAKE_OPTIONS: -DBUILD_SHARED_LIBS=NO -DSANITIZE=address,undefined,shift-exponent,implicit-conversion,nullability
       UBSAN_OPTIONS: halt_on_error=1
     steps:

--- a/cmake/toolchains/clang-libcxx-debug.cmake
+++ b/cmake/toolchains/clang-libcxx-debug.cmake
@@ -1,0 +1,8 @@
+# evmone: Ethereum Virtual Machine
+# Copyright 2024 The evmone Authors.
+# Licensed under the Apache License, Version 2.0. See the LICENSE file.
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++ -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG")


### PR DESCRIPTION
For the sanitizer build use libc++ with debug hardening enabled.

Closes https://github.com/ethereum/evmone/issues/906.