### PR TITLE
Disallow truncated data in toplevel containers

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -423,7 +423,7 @@ jobs:
             ~/tests/EIPTests/BlockchainTests/
       - download_execution_tests:
           repo: ipsilon/tests
-          rev: eof-notxcreate
+          rev: eof-toplevel
           legacy: false
       - run:
           name: "State tests (EOF)"

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -652,7 +652,7 @@ EOFValidationError validate_eof1(evmc_revision rev, bytes_view main_container) n
             visited_code_sections.end())
             return EOFValidationError::unreachable_code_sections;
 
-        if (referenced_by_eofcreate && !header.can_init(container.size()))
+        if (referenced_by_eofcreate && !header.has_full_data(container.size()))
             return EOFValidationError::eofcreate_with_truncated_container;
 
         // Enqueue subcontainers

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -138,6 +138,7 @@ enum class EOFValidationError
     too_many_container_sections,
     invalid_container_section_index,
     eofcreate_with_truncated_container,
+    toplevel_container_truncated,
 
     impossible,
 };

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -68,8 +68,8 @@ struct EOF1Header
         return container.substr(data_offset);
     }
 
-    /// A helper to check whether the container can be an initcontainer.
-    [[nodiscard]] bool can_init(size_t container_size) const noexcept
+    /// A helper to check whether the container has data section body size equal to declare size.
+    [[nodiscard]] bool has_full_data(size_t container_size) const noexcept
     {
         // Containers with truncated data section cannot be initcontainers.
         const auto truncated_data = static_cast<size_t>(data_offset + data_size) > container_size;

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -402,10 +402,6 @@ Result create_eof_impl(
         const auto error_subcont = validate_eof(state.rev, initcontainer);
         if (error_subcont != EOFValidationError::success)
             return {EVMC_SUCCESS, gas_left};  // "Light" failure.
-
-        const auto initcontainer_header = read_valid_eof1_header(initcontainer);
-        if (!initcontainer_header.has_full_data(initcontainer.size()))
-            return {EVMC_SUCCESS, gas_left};  // "Light" failure.
     }
 
     evmc_message msg{.kind = to_call_kind(Op)};

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -404,7 +404,7 @@ Result create_eof_impl(
             return {EVMC_SUCCESS, gas_left};  // "Light" failure.
 
         const auto initcontainer_header = read_valid_eof1_header(initcontainer);
-        if (!initcontainer_header.can_init(initcontainer.size()))
+        if (!initcontainer_header.has_full_data(initcontainer.size()))
             return {EVMC_SUCCESS, gas_left};  // "Light" failure.
     }
 

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -257,7 +257,7 @@ std::optional<evmc_message> Host::prepare_message(evmc_message msg) noexcept
                     if (header == nullptr)
                         return {};  // Light early exception.
 
-                    if (!header->can_init(msg.input_size))
+                    if (!header->has_full_data(msg.input_size))
                         return {};  // Light early exception.
 
                     const auto container_size =

--- a/test/unittests/eof_validation.cpp
+++ b/test/unittests/eof_validation.cpp
@@ -87,6 +87,8 @@ std::string_view get_tests_error_message(EOFValidationError err) noexcept
         return "EOF_InvalidContainerSectionIndex";
     case EOFValidationError::eofcreate_with_truncated_container:
         return "EOF_EofCreateWithTruncatedContainer";
+    case EOFValidationError::toplevel_container_truncated:
+        return "EOF_ToplevelContainerTruncated";
     case EOFValidationError::impossible:
         return "impossible";
     }

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -184,9 +184,20 @@ TEST_F(eof_validation, EOF1_truncated_section)
         EOFValidationError::invalid_section_bodies_size);
     add_test_case("EF0001 010004 0200010002 040000 00 00800000 FE",
         EOFValidationError::invalid_section_bodies_size);
-    // Data section may be truncated
-    add_test_case("EF0001 010004 0200010001 040002 00 00800000 FE", EOFValidationError::success);
-    add_test_case("EF0001 010004 0200010001 040002 00 00800000 FE AA", EOFValidationError::success);
+
+    // Data section may be truncated in runtime subcontainer
+    add_test_case(
+        eof_bytecode(returncontract(0, 0, 2), 2).container(eof_bytecode(OP_INVALID).data("", 2)),
+        EOFValidationError::success);
+    add_test_case(
+        eof_bytecode(returncontract(0, 0, 1), 2).container(eof_bytecode(OP_INVALID).data("aa", 2)),
+        EOFValidationError::success);
+
+    // Data section may not be truncated in toplevel container
+    add_test_case(
+        eof_bytecode(OP_INVALID).data("", 2), EOFValidationError::toplevel_container_truncated);
+    add_test_case(
+        eof_bytecode(OP_INVALID).data("aa", 2), EOFValidationError::toplevel_container_truncated);
 }
 
 TEST_F(eof_validation, EOF1_code_section_offset)
@@ -1016,9 +1027,9 @@ TEST_F(eof_validation, EOF1_embedded_container)
         EOFValidationError::success);
 
     // no data section in container, but anticipated aux_data
+    // data section is allowed to be truncated in runtime subcontainer
     add_test_case(
-        "EF0001 010004 0200010006 0300010014 040002 00 00800001 6000E0000000 "
-        "EF000101000402000100010400000000800000FE",
+        eof_bytecode(returncontract(0, 0, 2), 2).container(eof_bytecode(OP_INVALID).data("", 2)),
         EOFValidationError::success);
 
     // with data section


### PR DESCRIPTION
This change only affects what is allowed in tests. Truncated data sections are not allowed at top level now, to check truncated data rules, tests should put it into subcontainers.