### PR TITLE
test: Dump LLVM profile data to separate files

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -543,7 +543,7 @@ jobs:
             SHOW_ARGS='-format=html -show-branches=count -show-regions -show-expansions'
             
             mkdir ~/coverage
-            llvm-profdata merge *.profraw -o evmone.profdata
+            llvm-profdata merge -sparse *.profraw -o evmone.profdata
             llvm-cov show $ARGS $SHOW_ARGS > ~/coverage/full.html
             llvm-cov show $ARGS $SHOW_ARGS -region-coverage-lt=100 > ~/coverage/missing.html
 

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -87,7 +87,12 @@ target_compile_options(evmone-unittests PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:-wd4789>
 )
 
-gtest_discover_tests(evmone-unittests TEST_PREFIX ${PROJECT_NAME}/unittests/)
+gtest_discover_tests(
+    evmone-unittests
+    TEST_PREFIX ${PROJECT_NAME}/unittests/
+    PROPERTIES
+    ENVIRONMENT LLVM_PROFILE_FILE=${PROJECT_BINARY_DIR}/unittests-%p.profraw
+)
 
 option(EVMONE_EVM_TEST_TOOL "Enable EVM unit testing tool for EVMC implementations (not maintained)" OFF)
 if(EVMONE_EVM_TEST_TOOL)


### PR DESCRIPTION
When running unit tests via ctest -j the profile data files seems to be overwritten by execution processes and the coverage information is incomplete. Set the LLVM_PROFILE_FILE environment variable for CTest registered unit tests and order the process number be a part of the profile file name.