### PR TITLE
test: Allow `"to": null` in JSON transaction

### DIFF
--- a/test/integration/t8n/cancun_create_tx/txs.json
+++ b/test/integration/t8n/cancun_create_tx/txs.json
@@ -1,5 +1,6 @@
 [
   {
+    "to": null,
     "input": "0x60015ff3",
     "gas": "0x186a0",
     "nonce": "0x0",

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -298,8 +298,11 @@ static void from_json_tx_common(const json::json& j, state::Transaction& o)
     o.sender = from_json<evmc::address>(j.at("sender"));
     o.nonce = from_json<uint64_t>(j.at("nonce"));
 
-    if (const auto to_it = j.find("to"); to_it != j.end() && !to_it->get<std::string>().empty())
-        o.to = from_json<evmc::address>(*to_it);
+    if (const auto to_it = j.find("to"); to_it != j.end())
+    {
+        if (!to_it->is_null() && !to_it->get<std::string>().empty())
+            o.to = from_json<evmc::address>(*to_it);
+    }
 
     if (const auto gas_price_it = j.find("gasPrice"); gas_price_it != j.end())
     {

--- a/test/unittests/statetest_loader_tx_test.cpp
+++ b/test/unittests/statetest_loader_tx_test.cpp
@@ -12,6 +12,36 @@ using namespace testing;
 
 // TODO: Add specific test of loading nonce, chainId, r, s, v
 
+TEST(statetest_loader, tx_to_empty_string)
+{
+    // The "to":"" is correctly parsed as a creation transaction.
+    constexpr std::string_view input = R"({
+        "to": "",
+        "input": "", "gas": "1", "chainId": "1", "value": "0", "sender": "a0a1",
+        "gasPrice": "1", "nonce": "0", "v": "1",
+        "r": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "s": "0x2222222222222222222222222222222222222222222222222222222222222222"
+    })";
+
+    const auto tx = test::from_json<state::Transaction>(json::json::parse(input));
+    EXPECT_FALSE(tx.to.has_value());
+}
+
+TEST(statetest_loader, tx_to_null)
+{
+    // The "to":null is correctly parsed as a creation transaction.
+    constexpr std::string_view input = R"({
+        "to": null,
+        "input": "", "gas": "1", "chainId": "1", "value": "0", "sender": "a0a1",
+        "gasPrice": "1", "nonce": "0", "v": "1",
+        "r": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "s": "0x2222222222222222222222222222222222222222222222222222222222222222"
+    })";
+
+    const auto tx = test::from_json<state::Transaction>(json::json::parse(input));
+    EXPECT_FALSE(tx.to.has_value());
+}
+
 TEST(statetest_loader, tx_create_legacy)
 {
     constexpr std::string_view input = R"({
@@ -20,7 +50,6 @@ TEST(statetest_loader, tx_create_legacy)
         "chainId": "0x5",
         "value": "0xe0e1",
         "sender": "a0a1",
-        "to": "",
         "gasPrice": "0x7071",
         "nonce": "0",
         "r": "0x1111111111111111111111111111111111111111111111111111111111111111",
@@ -86,7 +115,6 @@ TEST(statetest_loader, tx_access_list)
         "gas": "0",
         "value": "0",
         "sender": "",
-        "to": "",
         "maxFeePerGas": "0",
         "maxPriorityFeePerGas": "0",
         "accessList": [
@@ -150,7 +178,6 @@ TEST(statetest_loader, tx_type_1)
         "type": "1",
         "value": "0",
         "sender": "",
-        "to": "",
         "gasPrice": "0",
         "accessList": [
             {"address": "ac01", "storageKeys": []},
@@ -190,7 +217,6 @@ TEST(statetest_loader, tx_type_3)
         "type": "3",
         "value": "0",
         "sender": "",
-        "to": "",
         "maxFeePerGas": "0",
         "maxPriorityFeePerGas": "0",
         "accessList": [
@@ -280,7 +306,6 @@ TEST(statetest_loader, invalid_tx_type)
                 "type": "2",
                 "value": "0",
                 "sender": "",
-                "to": "",
                 "gasPrice": "0",
                 "accessList": [
                     {"address": "ac01", "storageKeys": []},
@@ -302,7 +327,6 @@ TEST(statetest_loader, invalid_tx_type)
             "type": "1",
             "value": "0",
             "sender": "",
-            "to": "",
             "gasPrice": "0",
             "nonce": "0",
             "r": "0x1111111111111111111111111111111111111111111111111111111111111111",
@@ -321,7 +345,6 @@ TEST(statetest_loader, invalid_tx_type)
             "type": "1",
             "value": "0",
             "sender": "",
-            "to": "",
             "maxFeePerGas": "0",
             "maxPriorityFeePerGas": "0",
             "accessList": [


### PR DESCRIPTION
Fixes https://github.com/ethereum/evmone/issues/923.