### PR TITLE
EOF: limit validated container size to MAX_INITCODE_SIZE

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -129,6 +129,9 @@ commands:
 
   download_execution_spec_tests:
     parameters:
+      repo:
+        type: string
+        default: ethereum/execution-spec-tests
       release:
         type: string
       fixtures_suffix:
@@ -139,7 +142,7 @@ commands:
           name: "Download execution-spec-tests: <<parameters.release>>"
           working_directory: ~/spec-tests
           command: |
-            curl -L https://github.com/ethereum/execution-spec-tests/releases/download/<<parameters.release>>/fixtures_<<parameters.fixtures_suffix>>.tar.gz | tar -xz
+            curl -L https://github.com/<<parameters.repo>>/releases/download/<<parameters.release>>/fixtures_<<parameters.fixtures_suffix>>.tar.gz | tar -xz
             ls -l
 
   build:
@@ -398,7 +401,8 @@ jobs:
     steps:
       - build
       - download_execution_spec_tests:
-          release: eip7692@v1.0.3
+          repo: ipsilon/execution-spec-tests
+          release: eip7692@v1.0.4+ipsilon_bf37249b
           fixtures_suffix: eip7692
       - run:
           name: "EOF pre-release execution spec tests (state_tests)"

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -782,9 +782,12 @@ std::variant<EOF1Header, EOFValidationError> validate_header(
     std::vector<uint16_t> container_offsets;
     for (const auto container_size : container_sizes)
     {
+        assert(offset <= std::numeric_limits<uint16_t>::max());
         container_offsets.emplace_back(static_cast<uint16_t>(offset));
         offset += container_size;
     }
+
+    assert(offset <= std::numeric_limits<uint16_t>::max());
     const auto data_offset = static_cast<uint16_t>(offset);
 
     return EOF1Header{

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -37,6 +37,9 @@ constexpr auto REL_OFFSET_SIZE = sizeof(int16_t);
 constexpr auto STACK_SIZE_LIMIT = 1024;
 constexpr uint8_t NON_RETURNING_FUNCTION = 0x80;
 
+constexpr size_t MAX_CODE_SIZE = 0x6000;
+constexpr size_t MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
+
 using EOFSectionHeaders = std::array<std::vector<uint16_t>, MAX_SECTION + 1>;
 
 size_t eof_header_size(const EOFSectionHeaders& headers) noexcept
@@ -592,6 +595,10 @@ EOFValidationError validate_eof1(
         bytes_view bytes;
         ContainerKind kind;
     };
+
+    if (main_container.size() > MAX_INITCODE_SIZE)
+        return EOFValidationError::container_size_above_limit;
+
     // Queue of containers left to process
     std::queue<ContainerValidation> container_queue;
 
@@ -757,6 +764,12 @@ std::variant<EOF1Header, EOFValidationError> validate_header(
     std::vector<uint16_t> code_offsets;
     const auto type_section_size = section_headers[TYPE_SECTION][0];
     auto offset = header_size + type_section_size;
+
+    // `offset` is being checked to not overflow the container size. NOTE: this is done
+    // implicitly in `validate_section_headers` above. Combined with the
+    // requirement for the container size to not exceed MAX_INITCODE_SIZE, this allows
+    // us to cast to a narrower integer.
+
     for (const auto code_size : code_sizes)
     {
         assert(offset <= std::numeric_limits<uint16_t>::max());
@@ -771,8 +784,7 @@ std::variant<EOF1Header, EOFValidationError> validate_header(
         container_offsets.emplace_back(static_cast<uint16_t>(offset));
         offset += container_size;
     }
-    // NOTE: assertion always satisfied only as long as initcode limits apply (48K).
-    assert(offset <= std::numeric_limits<uint16_t>::max());
+
     const auto data_offset = static_cast<uint16_t>(offset);
 
     return EOF1Header{
@@ -971,6 +983,8 @@ std::string_view get_error_message(EOFValidationError err) noexcept
         return "ambiguous_container_kind";
     case EOFValidationError::incompatible_container_kind:
         return "incompatible_container_kind";
+    case EOFValidationError::container_size_above_limit:
+        return "container_size_above_limit";
     case EOFValidationError::impossible:
         return "impossible";
     }

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -141,6 +141,7 @@ enum class EOFValidationError
     toplevel_container_truncated,
     ambiguous_container_kind,
     incompatible_container_kind,
+    container_size_above_limit,
 
     impossible,
 };

--- a/test/unittests/eof_validation.cpp
+++ b/test/unittests/eof_validation.cpp
@@ -93,6 +93,8 @@ std::string_view get_tests_error_message(EOFValidationError err) noexcept
         return "EOF_AmbiguousContainerKind";
     case EOFValidationError::incompatible_container_kind:
         return "EOF_IncompatibleContainerKind";
+    case EOFValidationError::container_size_above_limit:
+        return "EOF_ContainerSizeAboveLimit";
     case EOFValidationError::impossible:
         return "impossible";
     }

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -1211,9 +1211,11 @@ TEST_F(eof_validation, EOF1_subcontainer_containing_unreachable_code_sections)
 
 TEST_F(eof_validation, max_nested_containers)
 {
+    constexpr size_t MAX_CODE_SIZE = 0x6000;
+    constexpr size_t MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
     bytecode code{};
     bytecode nextcode = eof_bytecode(OP_INVALID);
-    while (nextcode.size() <= std::numeric_limits<uint16_t>::max())
+    while (nextcode.size() <= MAX_INITCODE_SIZE)
     {
         code = nextcode;
         nextcode = eof_bytecode(OP_INVALID).container(nextcode);


### PR DESCRIPTION
https://github.com/ipsilon/eof/pull/125 / https://github.com/ethereum/EIPs/pull/8670