### PR TITLE
EOF validation tests runner: support initcode flag

### DIFF
--- a/test/eoftest/eoftest_runner.cpp
+++ b/test/eoftest/eoftest_runner.cpp
@@ -34,16 +34,6 @@ struct EOFValidationTest
     std::unordered_map<std::string, Case> cases;
 };
 
-ContainerKind container_kind_from_string(std::string_view s)
-{
-    if (s == "runtime")
-        return ContainerKind::runtime;
-    else if (s == "initcode")
-        return ContainerKind::initcode;
-    else
-        throw std::invalid_argument{"unknown container kind"};
-}
-
 void from_json(const json::json& j, EOFValidationTest::Case& o)
 {
     const auto op_code = evmc::from_hex(j.at("code").get<std::string>());
@@ -51,8 +41,8 @@ void from_json(const json::json& j, EOFValidationTest::Case& o)
         throw std::invalid_argument{"code is invalid hex string"};
     o.code = *op_code;
 
-    if (const auto it_kind = j.find("kind"); it_kind != j.end())
-        o.kind = container_kind_from_string(it_kind->get<std::string>());
+    if (const auto it_initcode = j.find("initcode"); it_initcode != j.end())
+        o.kind = it_initcode->get<bool>() ? ContainerKind::initcode : ContainerKind::runtime;
 
     for (const auto& [rev, result] : j.at("results").items())
     {

--- a/test/unittests/eof_validation.cpp
+++ b/test/unittests/eof_validation.cpp
@@ -103,18 +103,6 @@ std::string_view get_tests_error_message(EOFValidationError err) noexcept
     return "<unknown>";
 }
 
-std::string_view to_string(ContainerKind container_kind) noexcept
-{
-    switch (container_kind)
-    {
-    case (ContainerKind::runtime):
-        return "runtime";
-    case (ContainerKind::initcode):
-        return "initcode";
-    }
-    return "<unknown>";
-}
-
 }  // namespace
 
 void eof_validation::TearDown()
@@ -146,7 +134,8 @@ void eof_validation::export_eof_validation_test()
 
         auto& jcase = jvectors[case_name];
         jcase["code"] = hex0x(test_case.container);
-        jcase["kind"] = to_string(test_case.kind);
+        if (test_case.kind == ContainerKind::initcode)
+            jcase["initcode"] = true;
 
         auto& jresults = jcase["results"][evmc::to_string(rev)];
         if (test_case.error == EOFValidationError::success)


### PR DESCRIPTION
This is the fixture format agreed on EOF implementers call and produced by EEST in https://github.com/ethereum/execution-spec-tests/pull/651

Based on #916 because it removes the tests for `initcode_runtime` container kind, and those were failing the run of exported validation tests.