### PR TITLE
Extract `MAX_CODE_SIZE` constant

### DIFF
--- a/lib/evmone/CMakeLists.txt
+++ b/lib/evmone/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(evmone
     baseline.hpp
     baseline_instruction_table.cpp
     baseline_instruction_table.hpp
+    constants.hpp
     eof.cpp
     eof.hpp
     instructions.hpp

--- a/lib/evmone/constants.hpp
+++ b/lib/evmone/constants.hpp
@@ -1,0 +1,15 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+namespace evmone
+{
+/// The limit of the size of created contract
+/// defined by [EIP-170](https://eips.ethereum.org/EIPS/eip-170)
+constexpr auto MAX_CODE_SIZE = 0x6000;
+
+/// The limit of the size of init codes for contract creation
+/// defined by [EIP-3860](https://eips.ethereum.org/EIPS/eip-3860)
+constexpr auto MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
+}  // namespace evmone

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -4,6 +4,7 @@
 
 #include "eof.hpp"
 #include "baseline_instruction_table.hpp"
+#include "constants.hpp"
 #include "execution_state.hpp"
 #include "instructions_traits.hpp"
 
@@ -36,9 +37,6 @@ constexpr auto OUTPUTS_INPUTS_NUMBER_LIMIT = 0x7F;
 constexpr auto REL_OFFSET_SIZE = sizeof(int16_t);
 constexpr auto STACK_SIZE_LIMIT = 1024;
 constexpr uint8_t NON_RETURNING_FUNCTION = 0x80;
-
-constexpr size_t MAX_CODE_SIZE = 0x6000;
-constexpr size_t MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
 
 using EOFSectionHeaders = std::array<std::vector<uint16_t>, MAX_SECTION + 1>;
 

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -5,6 +5,7 @@
 #include "host.hpp"
 #include "precompiles.hpp"
 #include "rlp.hpp"
+#include <evmone/constants.hpp>
 #include <evmone/eof.hpp>
 
 namespace evmone::state
@@ -346,7 +347,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     // because container section is not allowed to be empty
     assert(msg.kind != EVMC_EOFCREATE || result.status_code != EVMC_SUCCESS || !code.empty());
 
-    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > max_code_size)
+    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > MAX_CODE_SIZE)
         return evmc::Result{EVMC_FAILURE};
 
     // Code deployment cost.

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -12,10 +12,6 @@ namespace evmone::state
 {
 using evmc::uint256be;
 
-inline constexpr size_t max_code_size = 0x6000;
-inline constexpr size_t max_initcode_size = 2 * max_code_size;
-inline constexpr size_t max_initcode_count = 256;
-
 /// Computes the address of to-be-created contract with the CREATE scheme.
 ///
 /// Computes the new account address for the contract creation context of the CREATE instruction

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "eof_validation.hpp"
+#include <evmone/constants.hpp>
 #include <evmone/eof.hpp>
 #include <evmone/instructions_traits.hpp>
 #include <gtest/gtest.h>
@@ -11,12 +12,6 @@
 
 using namespace evmone;
 using namespace evmone::test;
-
-namespace
-{
-constexpr size_t MAX_CODE_SIZE = 0x6000;
-constexpr size_t MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE;
-}  // namespace
 
 TEST_F(eof_validation, before_activation)
 {

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "evm_fixture.hpp"
+#include <evmone/constants.hpp>
 #include <numeric>
 
 using namespace evmc::literals;
@@ -691,9 +692,8 @@ TEST_P(evm, staticmode)
 
 TEST_P(evm, max_code_size_push1)
 {
-    constexpr auto max_code_size = 0x6000;
-    const auto code = (max_code_size / 2) * push(1);
-    ASSERT_EQ(code.size(), max_code_size);
+    const auto code = (evmone::MAX_CODE_SIZE / 2) * push(1);
+    ASSERT_EQ(code.size(), evmone::MAX_CODE_SIZE);
 
     execute(code);
     EXPECT_STATUS(EVMC_STACK_OVERFLOW);


### PR DESCRIPTION
Extract the `MAX_CODE_SIZE` and `MAX_INITCODE_SIZE` constants into common header.