### PR TITLE
eoftest: Add support for "containerKind"

### DIFF
--- a/test/eoftest/eoftest_runner.cpp
+++ b/test/eoftest/eoftest_runner.cpp
@@ -41,8 +41,11 @@ void from_json(const json::json& j, EOFValidationTest::Case& o)
         throw std::invalid_argument{"code is invalid hex string"};
     o.code = *op_code;
 
-    if (const auto it_initcode = j.find("initcode"); it_initcode != j.end())
-        o.kind = it_initcode->get<bool>() ? ContainerKind::initcode : ContainerKind::runtime;
+    if (const auto it_kind = j.find("containerKind"); it_kind != j.end())
+    {
+        if (it_kind->get<std::string>() == "INITCODE")
+            o.kind = ContainerKind::initcode;
+    }
 
     for (const auto& [rev, result] : j.at("results").items())
     {

--- a/test/unittests/eof_validation.cpp
+++ b/test/unittests/eof_validation.cpp
@@ -135,7 +135,7 @@ void eof_validation::export_eof_validation_test()
         auto& jcase = jvectors[case_name];
         jcase["code"] = hex0x(test_case.container);
         if (test_case.kind == ContainerKind::initcode)
-            jcase["initcode"] = true;
+            jcase["containerKind"] = "INITCODE";
 
         auto& jresults = jcase["results"][evmc::to_string(rev)];
         if (test_case.error == EOFValidationError::success)


### PR DESCRIPTION
Add support for `"containerKind"` in the EOF validation JSON tests.
Specified in https://github.com/ethereum/execution-spec-tests/pull/651.