### PR TITLE
EIP-2935: Serve historical block hashes from state

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -371,9 +371,16 @@ jobs:
           # Tests for in-development EVM revision currently passing.
           working_directory: ~/spec-tests/fixtures/state_tests
           command: >
-            ~/build/bin/evmone-statetest 
+            ~/build/bin/evmone-statetest
             prague/eip2537_bls_12_381_precompiles/bls12_precompiles_before_fork
             prague/eip2537_bls_12_381_precompiles/bls12_g1add
+      - run:
+          name: "Execution spec tests (develop, blockchain_tests)"
+          # Tests for in-development EVM revision currently passing.
+          working_directory: ~/spec-tests/fixtures/blockchain_tests
+          command: >
+            ~/build/bin/evmone-blockchaintest
+            prague/eip2935_historical_block_hashes_from_state
       - collect_coverage_gcc
       - upload_coverage:
           flags: execution_spec_tests

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -24,6 +24,10 @@ struct SystemContract
 constexpr std::array SYSTEM_CONTRACTS{
     SystemContract{EVMC_CANCUN, BEACON_ROOTS_ADDRESS,
         [](const BlockInfo& block) noexcept { return bytes_view{block.parent_beacon_block_root}; }},
+    SystemContract{EVMC_PRAGUE, HISTORY_STORAGE_ADDRESS,
+        [](const BlockInfo& block) noexcept {
+            return bytes_view{block.known_block_hashes.at(block.number - 1)};
+        }},
 };
 
 static_assert(std::ranges::is_sorted(SYSTEM_CONTRACTS,

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -15,6 +15,9 @@ constexpr auto SYSTEM_ADDRESS = 0xfffffffffffffffffffffffffffffffffffffffe_addre
 /// The address of the system contract storing the root hashes of beacon chain blocks (EIP-4788).
 constexpr auto BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address;
 
+/// The address of the system contract storing historical block hashes (EIP-2935).
+constexpr auto HISTORY_STORAGE_ADDRESS = 0x0aae40965e6800cd9b1f4b05ff21581047e3f91e_address;
+
 struct BlockInfo;
 class State;
 

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -46,6 +46,8 @@ RevisionSchedule to_rev_schedule(std::string_view s)
 {
     if (s == "ShanghaiToCancunAtTime15k")
         return {EVMC_SHANGHAI, EVMC_CANCUN, 15'000};
+    if (s == "CancunToPragueAtTime15k")
+        return {EVMC_CANCUN, EVMC_PRAGUE, 15'000};
 
     const auto single_rev = to_rev(s);
     return {single_rev, single_rev, 0};


### PR DESCRIPTION
Implement [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) "Serve historical block hashes from state" required for the [Prague](https://eips.ethereum.org/EIPS/eip-7600) revision.
This mostly adds new system contract.