### PR TITLE
test: Rename `emptyMPTHash` → `EMPTY_MPT_HASH`

### DIFF
--- a/test/state/mpt.cpp
+++ b/test/state/mpt.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "mpt.hpp"
+#include "mpt_hash.hpp"
 #include "rlp.hpp"
 #include <algorithm>
 #include <cassert>
@@ -268,7 +269,7 @@ void MPT::insert(bytes_view key, bytes&& value)
 [[nodiscard]] hash256 MPT::hash() const
 {
     if (m_root == nullptr)
-        return emptyMPTHash;
+        return EMPTY_MPT_HASH;
     return keccak256(m_root->encode());
 }
 

--- a/test/state/mpt.hpp
+++ b/test/state/mpt.hpp
@@ -8,9 +8,6 @@
 
 namespace evmone::state
 {
-constexpr auto emptyMPTHash =
-    0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32;
-
 /// Insert-only Merkle Patricia Trie implementation for getting the root hash
 /// out of (key, value) pairs.
 ///

--- a/test/state/mpt_hash.hpp
+++ b/test/state/mpt_hash.hpp
@@ -5,7 +5,6 @@
 
 #include "hash_utils.hpp"
 #include <span>
-#include <unordered_map>
 
 namespace evmone::test
 {
@@ -14,6 +13,12 @@ class TestState;
 
 namespace evmone::state
 {
+/// The hash of the empty Merkle Patricia Trie.
+///
+/// Specifically, this is the value of keccak256(RLP("")), i.e. keccak256({0x80}).
+constexpr auto EMPTY_MPT_HASH =
+    0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32;
+
 /// Computes Merkle Patricia Trie root hash for the given collection of state accounts.
 hash256 mpt_hash(const test::TestState& state);
 

--- a/test/unittests/state_mpt_hash_test.cpp
+++ b/test/unittests/state_mpt_hash_test.cpp
@@ -20,7 +20,7 @@ using namespace evmone::test;
 
 TEST(state_mpt_hash, empty)
 {
-    EXPECT_EQ(mpt_hash(TestState{}), emptyMPTHash);
+    EXPECT_EQ(mpt_hash(TestState{}), EMPTY_MPT_HASH);
 }
 
 TEST(state_mpt_hash, single_account_v1)

--- a/test/unittests/state_mpt_test.cpp
+++ b/test/unittests/state_mpt_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <test/state/mpt.hpp>
+#include <test/state/mpt_hash.hpp>
 #include <test/state/rlp.hpp>
 #include <test/utils/utils.hpp>
 #include <numeric>
@@ -17,7 +18,7 @@ using namespace evmone::test;
 
 TEST(state_mpt, empty_trie)
 {
-    EXPECT_EQ(MPT{}.hash(), emptyMPTHash);
+    EXPECT_EQ(MPT{}.hash(), EMPTY_MPT_HASH);
 }
 
 TEST(state_mpt, single_account_v1)
@@ -29,7 +30,7 @@ TEST(state_mpt, single_account_v1)
     constexpr auto addr = 0x0000000000000000000000000000000000000002_address;
     constexpr uint64_t nonce = 0;
     constexpr auto balance = 1_u256;
-    constexpr auto storage_hash = emptyMPTHash;
+    constexpr auto storage_hash = EMPTY_MPT_HASH;
     constexpr auto code_hash =
         0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32;
 

--- a/test/unittests/state_rlp_test.cpp
+++ b/test/unittests/state_rlp_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gmock/gmock.h>
 #include <test/state/hash_utils.hpp>
+#include <test/state/mpt_hash.hpp>
 #include <test/state/rlp.hpp>
 #include <test/state/state.hpp>
 #include <test/utils/utils.hpp>
@@ -17,9 +18,6 @@ using namespace testing;
 
 static constexpr auto emptyBytesHash =
     0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32;
-
-static constexpr auto emptyMPTHash =
-    0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32;
 
 TEST(state_rlp, empty_bytes_hash)
 {
@@ -36,7 +34,7 @@ TEST(state_rlp, empty_mpt_hash)
 {
     const auto rlp_null = rlp::encode(0);
     EXPECT_EQ(rlp_null, bytes{0x80});
-    EXPECT_EQ(keccak256(rlp_null), emptyMPTHash);
+    EXPECT_EQ(keccak256(rlp_null), state::EMPTY_MPT_HASH);
 }
 
 TEST(state_rlp, encode_string_short)
@@ -92,7 +90,7 @@ TEST(state_rlp, encode_account_with_balance)
         "a0 56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
         "a0 c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"_hex;
 
-    const auto r = rlp::encode_tuple(uint64_t{0}, 1_u256, emptyMPTHash, emptyBytesHash);
+    const auto r = rlp::encode_tuple(uint64_t{0}, 1_u256, state::EMPTY_MPT_HASH, emptyBytesHash);
     EXPECT_EQ(r, expected);
 }
 


### PR DESCRIPTION
And move it from mpt.hpp to mpt_hash.hpp.