### PR TITLE
Fix parsing EOF version in header

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -892,7 +892,7 @@ bool append_data_section(bytes& container, bytes_view aux_data)
 
 uint8_t get_eof_version(bytes_view container) noexcept
 {
-    return is_eof_container(container) ? container[2] : 0;
+    return (is_eof_container(container) && container.size() >= 3) ? container[2] : 0;
 }
 
 EOFValidationError validate_eof(


### PR DESCRIPTION
Fixes the bug introduced in https://github.com/ethereum/evmone/pull/947 where reading the version byte is missing the bounds check.

This bug is hard to detect when `std::string` is used as the test container. Found by a fuzzer.