### PR TITLE
Fix `validate_eof` flag for EOF creation txs

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -33,7 +33,22 @@ DUP1,4
     set_tests_properties(
         ${PREFIX}/validate_eof PROPERTIES PASS_REGULAR_EXPRESSION
         "contract validation failure")
-
+        
+    add_test(NAME ${PREFIX}/validate_eof_success COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 13 EF00010100040200010001040000000080000000)
+    set_tests_properties(
+        ${PREFIX}/validate_eof_success PROPERTIES PASS_REGULAR_EXPRESSION
+        "Result:   success")
+        
+    add_test(NAME ${PREFIX}/validate_eof_create COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 13 --create EF00010100040200010001040000000080000000)
+    set_tests_properties(
+        ${PREFIX}/validate_eof_create PROPERTIES PASS_REGULAR_EXPRESSION
+        "contract validation failure")
+        
+    add_test(NAME ${PREFIX}/validate_eof_create_success COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 13 --create EF00010100040200010004030001001404000000008000025F5FEE00EF00010100040200010001040000000080000000)
+    set_tests_properties(
+        ${PREFIX}/validate_eof_create_success PROPERTIES PASS_REGULAR_EXPRESSION
+        "Result:   success")
+    
 endif()
 
 add_subdirectory(eofparse)


### PR DESCRIPTION
Depends on https://github.com/ethereum/evmc/pull/713, needs to set the submodule to a `master` revision of evmc before merging

Before, running `evmc run` with validate_eof would not recognize creation txs (which have to be validated as initcode) and regular calls to a deployed contract (which have to be validated as runtime) correctly. This fixes that.

Validation is only done on the top-level frame (`msg->depth == 0`), to avoid re-doing it on every deeper frame (all subcontainers are validated recursively anyway, so all code supplied will be validated).

Initcode/runtime code kind is decided by the `msg->kind`, which handling is in turn fixed in the `evmc run` in https://github.com/ethereum/evmc/pull/713