### PR TITLE
ci: Drop MSVC 32-bit support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -314,37 +314,6 @@ jobs:
       - test
       - package
 
-  release-windows-32bit:
-    executor: win/server-2022
-    environment:
-      CMAKE_BUILD_TYPE: Release
-      CMAKE_BUILD_PARALLEL_LEVEL: 4
-    steps:
-      - checkout
-      - checkout_submodules
-      - run:
-          name: "Setup environment (bash)"
-          shell: bash
-          command: |
-            echo 'export PATH=$PATH:"/c/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/bin"' >> $BASH_ENV
-      - run:
-          name: 'Configure'
-          shell: powershell
-          command: |
-            $ErrorActionPreference = "Stop"
-            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
-            which cmake
-            cmake -S . -B ~/build -G Ninja -DCMAKE_INSTALL_PREFIX=C:\install -DEVMONE_TESTING=ON
-      - run:
-          name: 'Build'
-          shell: powershell
-          command: |
-            $ErrorActionPreference = "Stop"
-            & 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\Tools\Launch-VsDevShell.ps1' -Arch x86
-            cmake --build ~/build
-      - test
-      - package
-
   release-macos:
     executor: macos
     environment:
@@ -704,7 +673,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - release-windows-32bit
       - release-macos:
           filters:
             tags:


### PR DESCRIPTION
Drop build and support for MSVC 32-bit x86 architecture. "This platform is almost extinct".

We continue to have some other 32-bit builds (GCC x86 and riscv32) to check pointer size and `size_t` correctness.