### PR TITLE
eof: fix multi-container-section case

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -72,6 +72,7 @@ EOFValidationError get_section_missing_error(uint8_t section_id) noexcept
         return EOFValidationError::type_section_missing;
     case CODE_SECTION:
         return EOFValidationError::code_section_missing;
+    case CONTAINER_SECTION:
     case DATA_SECTION:
         return EOFValidationError::data_section_missing;
     default:
@@ -106,7 +107,7 @@ std::variant<EOFSectionHeaders, EOFValidationError> validate_section_headers(byt
             // If DATA_SECTION is expected, CONTAINER_SECTION is also allowed, because
             // container section is optional.
             if (section_id != expected_section_id &&
-                (expected_section_id != DATA_SECTION || section_id != CONTAINER_SECTION))
+                (expected_section_id != CONTAINER_SECTION || section_id != DATA_SECTION))
                 return get_section_missing_error(expected_section_id);
 
             switch (section_id)
@@ -128,7 +129,7 @@ std::variant<EOFSectionHeaders, EOFValidationError> validate_section_headers(byt
                     return EOFValidationError::zero_section_size;
                 if (section_num > CODE_SECTION_NUMBER_LIMIT)
                     return EOFValidationError::too_many_code_sections;
-                expected_section_id = DATA_SECTION;
+                expected_section_id = CONTAINER_SECTION;
                 state = State::section_size;
                 break;
             }

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -72,7 +72,6 @@ EOFValidationError get_section_missing_error(uint8_t section_id) noexcept
         return EOFValidationError::type_section_missing;
     case CODE_SECTION:
         return EOFValidationError::code_section_missing;
-    case CONTAINER_SECTION:
     case DATA_SECTION:
         return EOFValidationError::data_section_missing;
     default:
@@ -104,10 +103,11 @@ std::variant<EOFSectionHeaders, EOFValidationError> validate_section_headers(byt
         {
             section_id = *it++;
 
-            // If DATA_SECTION is expected, CONTAINER_SECTION is also allowed, because
-            // container section is optional.
-            if (section_id != expected_section_id &&
-                (expected_section_id != CONTAINER_SECTION || section_id != DATA_SECTION))
+            // Skip optional sections.
+            if (section_id != expected_section_id && expected_section_id == CONTAINER_SECTION)
+                expected_section_id = DATA_SECTION;
+
+            if (section_id != expected_section_id)
                 return get_section_missing_error(expected_section_id);
 
             switch (section_id)

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -80,6 +80,12 @@ TEST_F(eof_validation, minimal_valid_EOF1_multiple_code_sections)
         EOFValidationError::success, "non_void_input_output");
 }
 
+TEST_F(eof_validation, minimal_valid_EOF1_multiple_container_sections)
+{
+    add_test_case("EF0001 010004 0200010001 0300010001 0300010001 040000 00 00800000 00 00 00",
+        EOFValidationError::data_section_missing, "no_data_section");
+}
+
 TEST_F(eof_validation, EOF1_types_section_missing)
 {
     add_test_case("EF0001 0200010001 00 FE", EOFValidationError::type_section_missing);


### PR DESCRIPTION
Credit to @chfast to find the case via fuzzing, as well as suggest this version of the fix (alternative version in comment, not sure which is cleaner anymore)