### PR TITLE
cmake: Upgrade intx to v0.12.0

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -11,7 +11,7 @@ hunter_cmake_args(
 
 hunter_config(
     intx
-    VERSION 0.11.0
-    URL https://github.com/chfast/intx/archive/v0.11.0.tar.gz
-    SHA1 025fe6e95e7066b49e6bb3deff597a24442312ff
+    VERSION 0.12.0
+    URL https://github.com/chfast/intx/archive/v0.12.0.tar.gz
+    SHA1 18a64e8e88c50d53325d906c9211daef905b97f4
 )

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -15,11 +15,7 @@ struct Point
     IntT x = 0;
     IntT y = 0;
 
-    friend constexpr bool operator==(const Point& a, const Point& b) noexcept
-    {
-        // TODO(intx): C++20 operator<=> = default does not work for uint256.
-        return a.x == b.x && a.y == b.y;
-    }
+    friend constexpr bool operator==(const Point& a, const Point& b) noexcept = default;
 
     /// Checks if the point represents the special "infinity" value.
     [[nodiscard]] constexpr bool is_inf() const noexcept { return *this == Point{}; }

--- a/test/unittests/evm_eip7516_blobbasefee_test.cpp
+++ b/test/unittests/evm_eip7516_blobbasefee_test.cpp
@@ -8,7 +8,7 @@
 #include "evm_fixture.hpp"
 
 using namespace evmc::literals;
-using namespace intx;
+using namespace intx::literals;
 using namespace evmone::test;
 
 TEST_P(evm, blobbasefee_pre_cancun)

--- a/test/unittests/evmmax_bn254_add_test.cpp
+++ b/test/unittests/evmmax_bn254_add_test.cpp
@@ -7,7 +7,6 @@
 #include <test/utils/utils.hpp>
 
 using namespace evmmax::bn254;
-using namespace intx;
 using namespace evmone::test;
 
 namespace

--- a/test/unittests/evmmax_bn254_mul_test.cpp
+++ b/test/unittests/evmmax_bn254_mul_test.cpp
@@ -7,7 +7,6 @@
 #include <test/utils/utils.hpp>
 
 using namespace evmmax::bn254;
-using namespace intx;
 using namespace evmone::test;
 
 namespace

--- a/test/unittests/evmmax_test.cpp
+++ b/test/unittests/evmmax_test.cpp
@@ -9,12 +9,6 @@
 using namespace intx;
 using namespace evmmax;
 
-// TODO(intx): Add ""_u384.
-inline constexpr auto operator""_u384(const char* s)
-{
-    return intx::from_string<intx::uint384>(s);
-}
-
 constexpr auto P23 = 23_u256;
 constexpr auto BN254Mod = 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
 constexpr auto Secp256k1Mod =

--- a/test/unittests/state_block_test.cpp
+++ b/test/unittests/state_block_test.cpp
@@ -6,7 +6,7 @@
 #include <test/state/state.hpp>
 
 using namespace evmone::state;
-using namespace intx;
+using namespace intx::literals;
 
 TEST(state_block, blob_gas_price)
 {

--- a/test/unittests/state_mpt_hash_test.cpp
+++ b/test/unittests/state_mpt_hash_test.cpp
@@ -12,7 +12,7 @@
 #include <test/utils/utils.hpp>
 #include <array>
 
-using namespace intx;
+using namespace intx::literals;
 using namespace evmone;
 using namespace evmone::state;
 using namespace evmone::test;

--- a/test/unittests/state_mpt_test.cpp
+++ b/test/unittests/state_mpt_test.cpp
@@ -11,7 +11,7 @@
 #include <random>
 #include <ranges>
 
-using namespace intx;
+using namespace intx::literals;
 using namespace evmone;
 using namespace evmone::state;
 using namespace evmone::test;

--- a/test/unittests/statetest_loader_tx_test.cpp
+++ b/test/unittests/statetest_loader_tx_test.cpp
@@ -7,7 +7,7 @@
 #include <test/statetest/statetest.hpp>
 
 using namespace evmone;
-using namespace intx;
+using namespace intx::literals;
 using namespace testing;
 
 // TODO: Add specific test of loading nonce, chainId, r, s, v

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -298,8 +298,7 @@ TEST_F(tracing, trace_eof)
 
 TEST_F(tracing, trace_create_instruction)
 {
-    using namespace intx;
-    using evmc::operator""_address;
+    using namespace evmc::literals;
 
     vm.add_tracer(evmone::create_instruction_tracer(trace_stream));
 
@@ -307,10 +306,10 @@ TEST_F(tracing, trace_create_instruction)
 
     const auto code = push(10) + push(0) + push(0) + OP_CREATE + ret_top();
 
-    auto result_data = "0x60016000526001601ff3"_hex;
+    const auto result_data = "0x60016000526001601ff3"_hex;
     host.call_result.create_address = 0x1122334455667788991011223344556677889910_address;
-    host.call_result.output_data = result_data.c_str();
-    host.call_result.output_size = 10;
+    host.call_result.output_data = result_data.data();
+    host.call_result.output_size = result_data.size();
 
     EXPECT_EQ(trace(code, 0, 0, EVMC_BERLIN), R"(
 {"pc":0,"op":96,"gas":"0xf4240","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}


### PR DESCRIPTION
This version has `_u384` literal suffix
and `using namespace intx::literals` as an alternative to `using namespace intx`.