### PR TITLE
test: Ensure exported state tests have all fields

### DIFF
--- a/test/statetest/statetest_export.cpp
+++ b/test/statetest/statetest_export.cpp
@@ -8,7 +8,7 @@ namespace evmone::test
 {
 json::json to_json(const TestState& state)
 {
-    json::json j;
+    json::json j = json::json({});
     for (const auto& [addr, acc] : state)
     {
         auto& j_acc = j[hex0x(addr)];

--- a/test/statetest/statetest_export.cpp
+++ b/test/statetest/statetest_export.cpp
@@ -8,7 +8,7 @@ namespace evmone::test
 {
 json::json to_json(const TestState& state)
 {
-    json::json j = json::json({});
+    json::json j = json::json::object();
     for (const auto& [addr, acc] : state)
     {
         auto& j_acc = j[hex0x(addr)];

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -273,6 +273,7 @@ template <>
 TestState from_json<TestState>(const json::json& j)
 {
     TestState o;
+    assert(j.is_object());
     for (const auto& [j_addr, j_acc] : j.items())
     {
         auto& acc =

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -180,6 +180,7 @@ void state_transition::export_state_test(
     jenv["currentGasLimit"] = hex0x(block.gas_limit);
     jenv["currentCoinbase"] = hex0x(block.coinbase);
     jenv["currentBaseFee"] = hex0x(block.base_fee);
+    jenv["currentRandom"] = hex0x(block.prev_randao);
 
     jt["pre"] = to_json(pre);
 
@@ -203,6 +204,9 @@ void state_transition::export_state_test(
     jtx["data"][0] = hex0x(tx.data);
     jtx["gasLimit"][0] = hex0x(tx.gas_limit);
     jtx["value"][0] = hex0x(tx.value);
+
+    if (tx.type >= Transaction::Type::access_list)
+        jtx["accessLists"][0] = json::json::array({});
 
     if (!tx.access_list.empty())
     {

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -205,8 +205,9 @@ void state_transition::export_state_test(
     jtx["gasLimit"][0] = hex0x(tx.gas_limit);
     jtx["value"][0] = hex0x(tx.value);
 
+    // Force `accessLists` output even if empty.
     if (tx.type >= Transaction::Type::access_list)
-        jtx["accessLists"][0] = json::json::array({});
+        jtx["accessLists"][0] = json::json::array();
 
     if (!tx.access_list.empty())
     {


### PR DESCRIPTION
I was wrong when I said that the format inconsistency had a test which we can make pass by amending the exported format - there were no exclusions which my fix would fix. So to have some testing mechanism of correctness, we can maybe add an assertion in `statetest_loader` like this? I don't want to overdo it and this seems safe to do.

I guess we can also leave it without the assertion.

I don't know yet about the other format inconsistencies found, so I might add more commits here