### PR TITLE
ci: Upgrade EEST pectra-devnet-3 to v1.5.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -364,7 +364,7 @@ jobs:
           command: >
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
       - download_execution_spec_tests:
-          release: pectra-devnet-3@v1.4.0
+          release: pectra-devnet-3@v1.5.0
           fixtures_suffix: pectra-devnet-3
       - run:
           name: "Execution spec tests (develop, state_tests)"


### PR DESCRIPTION
Upgrade the EEST tests for Prague packaged by the Pectra devnet-3 spec to version v1.5.0.