### PR TITLE
Fix `ExecutionState::reset()`

### DIFF
--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -220,7 +220,9 @@ public:
         status = EVMC_SUCCESS;
         output_offset = 0;
         output_size = 0;
+        deploy_container = {};
         m_tx = {};
+        call_stack = {};
     }
 
     [[nodiscard]] bool in_static_mode() const { return (msg->flags & EVMC_STATIC) != 0; }


### PR DESCRIPTION
Reset previously omitted fields related to EOF execution: `deploy_container` and `call_stack`.