### PR TITLE
baseline: VM-level execution states

### DIFF
--- a/lib/evmone/baseline.hpp
+++ b/lib/evmone/baseline.hpp
@@ -80,9 +80,9 @@ EVMC_EXPORT CodeAnalysis analyze(bytes_view code, bool eof_enabled);
 evmc_result execute(evmc_vm* vm, const evmc_host_interface* host, evmc_host_context* ctx,
     evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t code_size) noexcept;
 
-/// Executes in Baseline interpreter on the given external and initialized state.
-EVMC_EXPORT evmc_result execute(
-    const VM&, int64_t gas_limit, ExecutionState& state, const CodeAnalysis& analysis) noexcept;
+/// Executes in Baseline interpreter with the pre-processed code.
+EVMC_EXPORT evmc_result execute(VM&, const evmc_host_interface& host, evmc_host_context* ctx,
+    evmc_revision rev, const evmc_message& msg, const CodeAnalysis& analysis) noexcept;
 
 }  // namespace baseline
 }  // namespace evmone

--- a/lib/evmone/vm.cpp
+++ b/lib/evmone/vm.cpp
@@ -72,7 +72,7 @@ evmc_set_option_result set_option(evmc_vm* c_vm, char const* c_name, char const*
 }  // namespace
 
 
-inline constexpr VM::VM() noexcept
+VM::VM() noexcept
   : evmc_vm{
         EVMC_ABI_VERSION,
         "evmone",
@@ -82,7 +82,20 @@ inline constexpr VM::VM() noexcept
         evmone::get_capabilities,
         evmone::set_option,
     }
-{}
+{
+    m_execution_states.reserve(1025);
+}
+
+ExecutionState& VM::get_execution_state(size_t depth) noexcept
+{
+    // Vector already has the capacity for all possible depths,
+    // so reallocation never happens (therefore: noexcept).
+    // The ExecutionStates are lazily created because they pre-allocate EVM memory and stack.
+    assert(depth < m_execution_states.capacity());
+    if (m_execution_states.size() <= depth)
+        m_execution_states.resize(depth + 1);
+    return m_execution_states[depth];
+}
 
 }  // namespace evmone
 

--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "execution_state.hpp"
 #include "tracing.hpp"
 #include <evmc/evmc.h>
+#include <vector>
 
 #if defined(_MSC_VER) && !defined(__clang__)
 #define EVMONE_CGOTO_SUPPORTED 0
@@ -22,10 +24,13 @@ public:
     bool validate_eof = false;
 
 private:
+    std::vector<ExecutionState> m_execution_states;
     std::unique_ptr<Tracer> m_first_tracer;
 
 public:
-    inline constexpr VM() noexcept;
+    VM() noexcept;
+
+    [[nodiscard]] ExecutionState& get_execution_state(size_t depth) noexcept;
 
     void add_tracer(std::unique_ptr<Tracer> tracer) noexcept
     {

--- a/test/bench/helpers.hpp
+++ b/test/bench/helpers.hpp
@@ -59,13 +59,13 @@ inline evmc::Result advanced_execute(evmc::VM& /*vm*/, advanced::AdvancedExecuti
     return evmc::Result{execute(exec_state, analysis)};
 }
 
-inline evmc::Result baseline_execute(evmc::VM& c_vm, ExecutionState& exec_state,
+inline evmc::Result baseline_execute(evmc::VM& c_vm, [[maybe_unused]] ExecutionState& exec_state,
     const baseline::CodeAnalysis& analysis, const evmc_message& msg, evmc_revision rev,
-    evmc::Host& host, bytes_view code)
+    evmc::Host& host, [[maybe_unused]] bytes_view code)
 {
-    const auto& vm = *static_cast<evmone::VM*>(c_vm.get_raw_pointer());
-    exec_state.reset(msg, rev, host.get_interface(), host.to_context(), code);
-    return evmc::Result{baseline::execute(vm, msg.gas, exec_state, analysis)};
+    auto& vm = *static_cast<evmone::VM*>(c_vm.get_raw_pointer());
+    return evmc::Result{
+        baseline::execute(vm, host.get_interface(), host.to_context(), rev, msg, analysis)};
 }
 
 inline evmc::Result evmc_execute(evmc::VM& vm, FakeExecutionState& /*exec_state*/,


### PR DESCRIPTION
This adds an array of `ExecutionState` objects to the `VM` instance. They are used internally in the Baseline interpreter instead of passing one via API. This removes the need of maintaining object pool for execution states. 

However, this also makes the `VM` non-thread safe, but it is fine for current users. We can improve on this in the future by spiting the the VM into two parts: non-thread safe opaque execution context and a thread-safe VM with user configuration.