### PR TITLE
test: Wrap usage of state transition API

### DIFF
--- a/test/state/test_state.hpp
+++ b/test/state/test_state.hpp
@@ -6,13 +6,20 @@
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 #include <map>
+#include <span>
+#include <variant>
 
 namespace evmone
 {
 namespace state
 {
+struct BlockInfo;
+struct Ommer;
+struct Transaction;
+struct TransactionReceipt;
+struct Withdrawal;
 class State;
-}
+}  // namespace state
 
 namespace test
 {
@@ -62,6 +69,19 @@ public:
     /// Converts the TestState to intra state for transaction execution.
     [[nodiscard]] state::State to_intra_state() const;
 };
+
+/// Wrapping of state::transition() which operates on TestState.
+[[nodiscard]] std::variant<state::TransactionReceipt, std::error_code> transition(TestState& state,
+    const state::BlockInfo& block, const state::Transaction& tx, evmc_revision rev, evmc::VM& vm,
+    int64_t block_gas_left, int64_t blob_gas_left);
+
+/// Wrapping of state::finalize() which operates on TestState.
+void finalize(TestState& state, evmc_revision rev, const address& coinbase,
+    std::optional<uint64_t> block_reward, std::span<const state::Ommer> ommers,
+    std::span<const state::Withdrawal> withdrawals);
+
+/// Wrapping of state::system_call() which operates on TestState.
+void system_call(TestState& state, const state::BlockInfo& block, evmc_revision rev, evmc::VM& vm);
 
 }  // namespace test
 }  // namespace evmone

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -25,15 +25,15 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
 
             const auto& expected = cases[case_index];
             const auto tx = test.multi_tx.get(expected.indexes);
-            auto state = test.pre_state.to_intra_state();
+            auto state = test.pre_state;
 
-            const auto res = state::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
+            const auto res = test::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
                 state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
 
             // Finalize block with reward 0.
-            state::finalize(state, rev, test.block.coinbase, 0, {}, {});
+            test::finalize(state, rev, test.block.coinbase, 0, {}, {});
 
-            const auto state_root = state::mpt_hash(TestState{state});
+            const auto state_root = state::mpt_hash(state);
 
             if (trace_summary)
             {

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -6,7 +6,6 @@
 #include "../state/ethash_difficulty.hpp"
 #include "../state/mpt_hash.hpp"
 #include "../state/rlp.hpp"
-#include "../state/system_contracts.hpp"
 #include "../statetest/statetest.hpp"
 #include "../utils/utils.hpp"
 #include <evmone/evmone.h>
@@ -76,14 +75,13 @@ int main(int argc, const char* argv[])
         }
 
         state::BlockInfo block;
-        state::State state;
+        TestState state;
 
         if (!alloc_file.empty())
         {
             const auto j = json::json::parse(std::ifstream{alloc_file}, nullptr, false);
-            const auto test_state = test::from_json<TestState>(j);
-            validate_state(test_state, rev);
-            state = test_state.to_intra_state();
+            state = from_json<TestState>(j);
+            validate_state(state, rev);
         }
         if (!env_file.empty())
         {
@@ -135,7 +133,7 @@ int main(int argc, const char* argv[])
                 j_result["receipts"] = json::json::array();
                 j_result["rejected"] = json::json::array();
 
-                state::system_call(state, block, rev, vm);
+                test::system_call(state, block, rev, vm);
 
                 for (size_t i = 0; i < j_txs.size(); ++i)
                 {
@@ -171,7 +169,7 @@ int main(int argc, const char* argv[])
                     }
 
                     auto res =
-                        state::transition(state, block, tx, rev, vm, block_gas_left, blob_gas_left);
+                        test::transition(state, block, tx, rev, vm, block_gas_left, blob_gas_left);
 
                     if (holds_alternative<std::error_code>(res))
                     {
@@ -196,7 +194,7 @@ int main(int argc, const char* argv[])
                         cumulative_gas_used += receipt.gas_used;
                         receipt.cumulative_gas_used = cumulative_gas_used;
                         if (rev < EVMC_BYZANTIUM)
-                            receipt.post_state = state::mpt_hash(TestState{state});
+                            receipt.post_state = state::mpt_hash(state);
                         j_receipt["cumulativeGasUsed"] = hex0x(cumulative_gas_used);
 
                         j_receipt["blockHash"] = hex0x(bytes32{});
@@ -218,11 +216,11 @@ int main(int argc, const char* argv[])
                 }
             }
 
-            state::finalize(
+            test::finalize(
                 state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
 
             j_result["logsHash"] = hex0x(logs_hash(txs_logs));
-            j_result["stateRoot"] = hex0x(state::mpt_hash(TestState{state}));
+            j_result["stateRoot"] = hex0x(state::mpt_hash(state));
         }
 
         j_result["logsBloom"] = hex0x(compute_bloom_filter(receipts));

--- a/test/unittests/state_system_call_test.cpp
+++ b/test/unittests/state_system_call_test.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <test/state/state.hpp>
 #include <test/state/system_contracts.hpp>
+#include <test/state/test_state.hpp>
 #include <test/utils/bytecode.hpp>
 
 using namespace evmc::literals;
@@ -16,7 +17,7 @@ class state_system_call : public testing::Test
 {
 protected:
     evmc::VM vm{evmc_create_evmone()};
-    State state;
+    TestState state;
 };
 
 TEST_F(state_system_call, non_existient)
@@ -24,7 +25,7 @@ TEST_F(state_system_call, non_existient)
     // Use MAX revision to invoke all activate system contracts.
     system_call(state, {}, EVMC_MAX_REVISION, vm);
 
-    EXPECT_EQ(state.get_accounts().size(), 0) << "State must remain unchanged";
+    EXPECT_EQ(state.size(), 0) << "State must remain unchanged";
 }
 
 TEST_F(state_system_call, beacon_roots)
@@ -35,14 +36,14 @@ TEST_F(state_system_call, beacon_roots)
 
     system_call(state, block, EVMC_CANCUN, vm);
 
-    ASSERT_EQ(state.get_accounts().size(), 1);
-    EXPECT_EQ(state.find(SYSTEM_ADDRESS), nullptr);
-    EXPECT_EQ(state.get(BEACON_ROOTS_ADDRESS).nonce, 0);
-    EXPECT_EQ(state.get(BEACON_ROOTS_ADDRESS).balance, 0);
-    const auto& storage = state.get(BEACON_ROOTS_ADDRESS).storage;
+    ASSERT_EQ(state.size(), 1);
+    EXPECT_FALSE(state.contains(SYSTEM_ADDRESS));
+    EXPECT_EQ(state.at(BEACON_ROOTS_ADDRESS).nonce, 0);
+    EXPECT_EQ(state.at(BEACON_ROOTS_ADDRESS).balance, 0);
+    const auto& storage = state.at(BEACON_ROOTS_ADDRESS).storage;
     ASSERT_EQ(storage.size(), 2);
-    EXPECT_EQ(storage.at(0x01_bytes32).current, block.parent_beacon_block_root);
-    EXPECT_EQ(storage.at(0x00_bytes32).current, to_bytes32(SYSTEM_ADDRESS));
+    EXPECT_EQ(storage.at(0x01_bytes32), block.parent_beacon_block_root);
+    EXPECT_EQ(storage.at(0x00_bytes32), to_bytes32(SYSTEM_ADDRESS));
 }
 
 TEST_F(state_system_call, history_storage)
@@ -55,12 +56,12 @@ TEST_F(state_system_call, history_storage)
 
     system_call(state, block, EVMC_PRAGUE, vm);
 
-    ASSERT_EQ(state.get_accounts().size(), 1);
-    EXPECT_EQ(state.find(SYSTEM_ADDRESS), nullptr);
-    EXPECT_EQ(state.get(HISTORY_STORAGE_ADDRESS).nonce, 0);
-    EXPECT_EQ(state.get(HISTORY_STORAGE_ADDRESS).balance, 0);
-    const auto& storage = state.get(HISTORY_STORAGE_ADDRESS).storage;
+    ASSERT_EQ(state.size(), 1);
+    EXPECT_FALSE(state.contains(SYSTEM_ADDRESS));
+    EXPECT_EQ(state.at(HISTORY_STORAGE_ADDRESS).nonce, 0);
+    EXPECT_EQ(state.at(HISTORY_STORAGE_ADDRESS).balance, 0);
+    const auto& storage = state.at(HISTORY_STORAGE_ADDRESS).storage;
     ASSERT_EQ(storage.size(), 2);
-    EXPECT_EQ(storage.at(bytes32{NUMBER}).current, PREV_BLOCKHASH);
-    EXPECT_EQ(storage.at(0x00_bytes32).current, to_bytes32(SYSTEM_ADDRESS));
+    EXPECT_EQ(storage.at(bytes32{NUMBER}), PREV_BLOCKHASH);
+    EXPECT_EQ(storage.at(0x00_bytes32), to_bytes32(SYSTEM_ADDRESS));
 }

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -48,6 +48,7 @@ void state_transition::TearDown()
 
     // Execution:
 
+    auto state = pre;
     const auto trace = !expect.trace.empty();
     auto& selected_vm = trace ? tracing_vm : vm;
 
@@ -56,12 +57,10 @@ void state_transition::TearDown()
     if (trace)
         trace_capture.emplace();
 
-    auto intra_state = pre.to_intra_state();
-    const auto res = state::transition(intra_state, block, tx, rev, selected_vm, block.gas_limit,
+    const auto res = test::transition(state, block, tx, rev, selected_vm, block.gas_limit,
         state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
-    state::finalize(
-        intra_state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
-    TestState post{intra_state};
+    test::finalize(state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
+    const auto& post = state;
 
     if (const auto expected_error = make_error_code(expect.tx_error))
     {


### PR DESCRIPTION
Wrap the usage of the state transition API from the `evmone::state` for tests so that the new API in `evmone::test` only exposes `TestState` and hides `state::State`.

This isolates usage of the `evmone::state` to lower the disturbance caused by API modifications,
e.g. in https://github.com/ethereum/evmone/pull/802.