### PR TITLE
Remove repeated unit tests

### DIFF
--- a/test/unittests/eof_validation_stack_test.cpp
+++ b/test/unittests/eof_validation_stack_test.cpp
@@ -105,8 +105,6 @@ TEST_F(eof_validation, backwards_rjump)
 
 TEST_F(eof_validation, backwards_rjump_variable_stack)
 {
-    add_test_case(eof_bytecode(varstack + rjump(-3), 3), EOFValidationError::success);
-
     add_test_case(
         eof_bytecode(varstack + OP_PUSH0 + OP_POP + rjump(-5), 4), EOFValidationError::success);
 
@@ -151,8 +149,6 @@ TEST_F(eof_validation, backwards_rjump_variable_stack)
 
 TEST_F(eof_validation, forwards_rjump)
 {
-    add_test_case(eof_bytecode(rjump(0) + OP_STOP), EOFValidationError::success);
-
     // forwards rjump + fallthrough - equal stack
     add_test_case(eof_bytecode(push0() + rjumpi(3, 0) + rjump(1) + OP_NOT + OP_STOP, 2),
         EOFValidationError::success);
@@ -219,8 +215,6 @@ TEST_F(eof_validation, forwards_rjump_variable_stack)
 
 TEST_F(eof_validation, backwards_rjumpi)
 {
-    add_test_case(eof_bytecode(rjumpi(-5, 0) + OP_STOP, 1), EOFValidationError::success);
-
     add_test_case(
         eof_bytecode(push0() + OP_POP + rjumpi(-7, 0) + OP_STOP, 1), EOFValidationError::success);
 
@@ -865,10 +859,6 @@ TEST_F(eof_validation, underflow)
     // JUMPF to non-returning function
     add_test_case(eof_bytecode(jumpf(1), 0).code(revert(0, 0), 1, 0x80, 3),
         EOFValidationError::stack_underflow);
-
-    // RETF underflow
-    add_test_case(eof_bytecode(callf(1) + OP_STOP, 2).code(push0() + OP_RETF, 0, 2, 1),
-        EOFValidationError::stack_underflow);
 }
 
 TEST_F(eof_validation, underflow_variable_stack)
@@ -895,26 +885,12 @@ TEST_F(eof_validation, underflow_variable_stack)
                       .code(bytecode{OP_POP} + OP_POP + OP_RETF, 5, 3, 3),
         EOFValidationError::stack_underflow);
 
-    // JUMPF to returning function - only max enough for 3 inputs
-    add_test_case(eof_bytecode(callf(1) + OP_STOP, 3)
-                      .code(varstack + jumpf(2), 0, 3, 3)
-                      .code(bytecode{OP_RETF}, 3, 3, 3),
-        EOFValidationError::stack_underflow);
-
     // JUMPF to non-returning function - [1, 3] stack - neither min nor max enough for 5 inputs
     add_test_case(eof_bytecode(varstack + jumpf(1), 0).code(revert(0, 0), 5, 0x80, 7),
         EOFValidationError::stack_underflow);
 
     // JUMPF to non-returning function - [1, 3] stack - only max enough for 3 inputs
     add_test_case(eof_bytecode(varstack + jumpf(1), 0).code(revert(0, 0), 3, 0x80, 5),
-        EOFValidationError::stack_underflow);
-
-    // RETF from [1, 3] stack - neither min nor max enough for 5 outputs
-    add_test_case(eof_bytecode(callf(1) + OP_STOP, 5).code(varstack + OP_RETF, 0, 5, 3),
-        EOFValidationError::stack_underflow);
-
-    // RETF from [1, 3] stack - only max enough for 3 outputs
-    add_test_case(eof_bytecode(callf(1) + OP_STOP, 3).code(varstack + OP_RETF, 0, 3, 3),
         EOFValidationError::stack_underflow);
 }
 
@@ -1256,9 +1232,6 @@ TEST_F(eof_validation, jumpf_to_returning_variable_stack)
 TEST_F(eof_validation, jumpf_to_nonreturning)
 {
     // Target has 0 inputs
-
-    // 0 inputs on stack at JUMPF
-    add_test_case(eof_bytecode(jumpf(1)).code(OP_STOP, 0, 0x80, 0), EOFValidationError::success);
 
     // Extra items on stack at JUMPF
     add_test_case(eof_bytecode(push0() + push0() + jumpf(1), 2).code(OP_STOP, 0, 0x80, 0),

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -88,8 +88,11 @@ TEST_F(eof_validation, minimal_valid_EOF1_multiple_container_sections)
 
 TEST_F(eof_validation, EOF1_types_section_missing)
 {
+    add_test_case("EF0001 00", EOFValidationError::type_section_missing);
     add_test_case("EF0001 0200010001 00 FE", EOFValidationError::type_section_missing);
+    add_test_case("EF0001 0200010001 030001 00 FE DA", EOFValidationError::type_section_missing);
     add_test_case("EF0001 0200010001 040001 00 FE DA", EOFValidationError::type_section_missing);
+    add_test_case("EF0001 02000200010001 00 FE FE", EOFValidationError::type_section_missing);
 }
 
 TEST_F(eof_validation, EOF1_types_section_0_size)
@@ -97,13 +100,6 @@ TEST_F(eof_validation, EOF1_types_section_0_size)
     add_test_case("EF0001 010000 0200010001 00 FE", EOFValidationError::zero_section_size);
     add_test_case(
         "EF0001 010000 0200010001 040001 00 FE DA", EOFValidationError::zero_section_size);
-}
-
-TEST_F(eof_validation, EOF1_type_section_missing)
-{
-    add_test_case("EF0001 0200010001 00 FE", EOFValidationError::type_section_missing);
-    add_test_case("EF0001 0200010001 030001 00 FE DA", EOFValidationError::type_section_missing);
-    add_test_case("EF0001 00", EOFValidationError::type_section_missing);
 }
 
 TEST_F(eof_validation, EOF1_code_section_missing)
@@ -116,11 +112,6 @@ TEST_F(eof_validation, EOF1_code_section_0_size)
 {
     add_test_case("EF0001 010004 020000 00", EOFValidationError::zero_section_size);
     add_test_case("EF0001 010004 020000 040001 00 DA", EOFValidationError::zero_section_size);
-}
-
-TEST_F(eof_validation, EOF1_data_section_0_size)
-{
-    add_test_case(eof_bytecode(OP_INVALID), EOFValidationError::success);
 }
 
 TEST_F(eof_validation, EOF1_data_section_before_code_section)
@@ -159,8 +150,6 @@ TEST_F(eof_validation, EOF1_incomplete_section_size)
 {
     // TODO: section_headers_not_terminated should rather be incomplete_section_size
     //  in these examples.
-
-    add_test_case("EF0001 01", EOFValidationError::section_headers_not_terminated);
     add_test_case("EF0001 0100", EOFValidationError::incomplete_section_size);
     add_test_case("EF0001 010004 0200", EOFValidationError::incomplete_section_number);
     add_test_case("EF0001 010004 02000100", EOFValidationError::incomplete_section_size);
@@ -176,7 +165,6 @@ TEST_F(eof_validation, EOF1_header_not_terminated)
     add_test_case("EF0001 010004", EOFValidationError::section_headers_not_terminated);
     add_test_case("EF0001 010004 FE", EOFValidationError::code_section_missing);
     add_test_case("EF0001 010004 02", EOFValidationError::incomplete_section_number);
-    add_test_case("EF0001 010004 0200", EOFValidationError::incomplete_section_number);
     add_test_case("EF0001 010004 020001", EOFValidationError::section_headers_not_terminated);
     add_test_case(
         "EF0001 010004 0200010001 040001", EOFValidationError::section_headers_not_terminated);
@@ -192,14 +180,6 @@ TEST_F(eof_validation, EOF1_truncated_section)
         EOFValidationError::invalid_section_bodies_size);
     add_test_case("EF0001 010004 0200010002 040000 00 00800000 FE",
         EOFValidationError::invalid_section_bodies_size);
-
-    // Data section may be truncated in runtime subcontainer
-    add_test_case(
-        eof_bytecode(returncontract(0, 0, 2), 2).container(eof_bytecode(OP_INVALID).data("", 2)),
-        ContainerKind::initcode, EOFValidationError::success);
-    add_test_case(
-        eof_bytecode(returncontract(0, 0, 1), 2).container(eof_bytecode(OP_INVALID).data("aa", 2)),
-        ContainerKind::initcode, EOFValidationError::success);
 
     // Data section may not be truncated in toplevel container
     add_test_case(
@@ -238,12 +218,6 @@ TEST_F(eof_validation, EOF1_trailing_bytes_top_level)
         EOFValidationError::invalid_section_bodies_size);
     add_test_case("EF0001 010004 0200010001 040002 00 00800000 FE AABB DEADBEEF",
         EOFValidationError::invalid_section_bodies_size);
-}
-
-TEST_F(eof_validation, EOF1_no_type_section)
-{
-    add_test_case("EF0001 0200010001 00 FE", EOFValidationError::type_section_missing);
-    add_test_case("EF0001 02000200010001 00 FE FE", EOFValidationError::type_section_missing);
 }
 
 TEST_F(eof_validation, EOF1_multiple_type_sections)
@@ -301,19 +275,24 @@ TEST_F(eof_validation, EOF1_invalid_section_0_type)
 
 TEST_F(eof_validation, EOF1_too_many_code_sections)
 {
-    auto eof_code_sections_1024 = eof_bytecode(jumpf(1));
-    for (int i = 1; i < 1023; ++i)
-        eof_code_sections_1024 =
-            eof_code_sections_1024.code(jumpf(static_cast<uint16_t>(i + 1)), 0, 0x80, 0);
+    auto eof_code_sections_1023 = eof_bytecode(jumpf(1));
+    for (int i = 1; i < 1022; ++i)
+        eof_code_sections_1023 =
+            eof_code_sections_1023.code(jumpf(static_cast<uint16_t>(i + 1)), 0, 0x80, 0);
+
+    auto eof_code_sections_1024 = eof_code_sections_1023;
+    eof_code_sections_1023 = eof_code_sections_1023.code(OP_STOP, 0, 0x80, 0);
+    eof_code_sections_1024 = eof_code_sections_1024.code(jumpf(1023), 0, 0x80, 0);
 
     auto eof_code_sections_1025 = eof_code_sections_1024;
     eof_code_sections_1024 = eof_code_sections_1024.code(OP_STOP, 0, 0x80, 0);
     eof_code_sections_1025 =
         eof_code_sections_1025.code(jumpf(1024), 0, 0x80, 0).code(OP_STOP, 0, 0x80, 0);
 
-    add_test_case(eof_code_sections_1024, EOFValidationError::success, "valid");
-
-    add_test_case(eof_code_sections_1025, EOFValidationError::too_many_code_sections, "invalid");
+    add_test_case(eof_code_sections_1023, EOFValidationError::success, "valid_1023");
+    add_test_case(eof_code_sections_1024, EOFValidationError::success, "valid_1024");
+    add_test_case(
+        eof_code_sections_1025, EOFValidationError::too_many_code_sections, "invalid_1025");
 }
 
 TEST_F(eof_validation, EOF1_undefined_opcodes)
@@ -754,36 +733,6 @@ TEST_F(eof_validation, multiple_code_sections_headers)
         EOFValidationError::data_section_missing);
 }
 
-TEST_F(eof_validation, many_code_sections_1023)
-{
-    auto code = eof_bytecode(jumpf(1));
-    for (auto i = 1; i < 1022; ++i)
-        code = code.code(jumpf(static_cast<uint16_t>(i + 1)), 0, 0x80, 0);
-    code = code.code(OP_STOP, 0, 0x80, 0);
-
-    add_test_case(code, EOFValidationError::success);
-}
-
-TEST_F(eof_validation, many_code_sections_1024)
-{
-    auto code = eof_bytecode(jumpf(1));
-    for (auto i = 1; i < 1023; ++i)
-        code = code.code(jumpf(static_cast<uint16_t>(i + 1)), 0, 0x80, 0);
-    code = code.code(OP_STOP, 0, 0x80, 0);
-
-    add_test_case(code, EOFValidationError::success);
-}
-
-TEST_F(eof_validation, too_many_code_sections)
-{
-    auto code = eof_bytecode(jumpf(1));
-    for (auto i = 1; i < 1024; ++i)
-        code = code.code(jumpf(static_cast<uint16_t>(i + 1)), 0, 0x80, 0);
-    code = code.code(OP_STOP, 0, 0x80, 0);
-
-    add_test_case(code, EOFValidationError::too_many_code_sections);
-}
-
 TEST_F(eof_validation, EOF1_dataloadn_truncated)
 {
     add_test_case("EF0001 010004 0200010001 040000 00 00800000 D1",
@@ -999,6 +948,11 @@ TEST_F(eof_validation, EOF1_embedded_container)
         eof_bytecode(returncontract(0, 0, 2), 2).container(eof_bytecode(OP_INVALID).data("", 2)),
         ContainerKind::initcode, EOFValidationError::success);
 
+    // data section is allowed to be partially truncated in runtime subcontainer
+    add_test_case(
+        eof_bytecode(returncontract(0, 0, 1), 2).container(eof_bytecode(OP_INVALID).data("aa", 2)),
+        ContainerKind::initcode, EOFValidationError::success);
+
     // with data section
     add_test_case(eof_bytecode(eofcreate() + OP_STOP, 4).container(embedded).data("AABB", 2),
         EOFValidationError::success);
@@ -1122,6 +1076,11 @@ TEST_F(eof_validation, EOF1_returncontract_valid)
     const auto embedded = eof_bytecode(bytecode{OP_INVALID});
     add_test_case(eof_bytecode(returncontract(0, 0, 0), 2).container(embedded),
         ContainerKind::initcode, EOFValidationError::success);
+
+    // deploy_container_index = 0 from eofcreate
+    add_test_case(eof_bytecode(eofcreate() + OP_STOP, 4)
+                      .container(eof_bytecode(returncontract(0, 0, 0), 2).container(embedded)),
+        EOFValidationError::success);
 
     // deploy_container_index = 0, 1
     add_test_case(eof_bytecode(rjumpi(6, 0) + returncontract(0, 0, 0) + returncontract(1, 0, 0), 2)
@@ -1259,19 +1218,6 @@ TEST_F(eof_validation, initcode_container_revert)
 {
     const auto initcode = revert(0, 0);
     const auto initcontainer = eof_bytecode(initcode, 2);
-
-    add_test_case(initcontainer, ContainerKind::initcode, EOFValidationError::success);
-
-    const auto factory_code = eofcreate() + OP_STOP;
-    const auto factory_container = eof_bytecode(factory_code, 4).container(initcontainer);
-
-    add_test_case(factory_container, EOFValidationError::success);
-}
-
-TEST_F(eof_validation, initcode_container_returncontract)
-{
-    const auto initcode = returncontract(0, 0, 0);
-    const auto initcontainer = eof_bytecode(initcode, 2).container(eof_bytecode(OP_INVALID));
 
     add_test_case(initcontainer, ContainerKind::initcode, EOFValidationError::success);
 


### PR DESCRIPTION
## Removed tests

- [backwards_rjump_variable_stack_0](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L108)
    - Repeated in [self_referencing_jumps_variable_stack](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L840)
- [forwards_rjump_0](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L154)
    - Repeated in [EOF1_valid_rjump](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L392)
- [backwards_rjumpi_0](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L222)
    - Repeated in [EOF1_valid_rjumpi](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L415-L417)
- [underflow_4](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L870)
    - Repeated in [retf_stack_validation](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L1083-L1085)
- [underflow_variable_stack_5](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L898-L902)
    - Repeated in [jumpf_to_returning_variable_stack](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L1211-L1215)
- [underflow_variable_stack_8](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L912-L914)
    - Repeated in [retf_variable_stack](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L1105-L1106)
- [underflow_variable_stack_9](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L916-L918)
    - Repeated in [retf_variable_stack](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L1108-L1110)
- [jumpf_to_non_returning_0](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_stack_test.cpp#L1260-L1261)
    - Repeated in [non_returning_status](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L843-L844)
- [EOF1_data_section_0_size](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L123)
    - Already existing when testing all instruction codes (Minimal EOF code containing the `INVALID` opcode)
- [EOF1_incomplete_section_size_0](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L163)
    - Repeated in [EOF1_header_not_terminated](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L175)
- [EOF1_header_not_terminated_4](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L179)
    - Repeated in [EOF1_incomplete_section_size](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L165)
- [EOF1_truncated_section_3](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L197-L199)
    - Repeated in [EOF1_embedded_container](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L998-L1000)
- [EOF1_no_type_section](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L243-L247)
    - Repeated in/Moved to [EOF1_type_section_missing](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L89)
- [initcode_container_returncontract_0](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L1276)
    - Repeated in [EOF1_returncontract_valid](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L1123)
- [EOF1_header_not_terminated](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L179)
    - Repeated in [EOF1_incomplete_section_size](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L165)

## Moved Tests

- [EOF1_type_section_missing](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L102-L107) tests were moved into  [EOF1_types_section_missing](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L89)

- [EOF1_truncated_section_4](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L200-L202) moved into [EOF1_embedded_container](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L989)
- [many_code_sections_1023](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L757) moved into [EOF1_too_many_code_sections](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L302)
- [many_code_sections_1024](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L767) moved into [EOF1_too_many_code_sections](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L302)
- [too_many_code_sections](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L777) moved into [EOF1_too_many_code_sections](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L302)
- [initcode_container_returncontract_1](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L1278-L1281) moved into [EOF1_returncontract_valid](https://github.com/ethereum/evmone/blob/master/test/unittests/eof_validation_test.cpp#L1119)