### PR TITLE
test: Support chain_id in loading multi-transaction state tests

### DIFF
--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -299,6 +299,11 @@ static void from_json_tx_common(const json::json& j, state::Transaction& o)
     o.sender = from_json<evmc::address>(j.at("sender"));
     o.nonce = from_json<uint64_t>(j.at("nonce"));
 
+    if (const auto chain_id_it = j.find("chainId"); chain_id_it != j.end())
+        o.chain_id = from_json<uint8_t>(*chain_id_it);
+    else
+        o.chain_id = 1;
+
     if (const auto to_it = j.find("to"); to_it != j.end())
     {
         if (!to_it->is_null() && !to_it->get<std::string>().empty())
@@ -339,8 +344,6 @@ state::Transaction from_json<state::Transaction>(const json::json& j)
 {
     state::Transaction o;
     from_json_tx_common(j, o);
-    if (const auto chain_id_it = j.find("chainId"); chain_id_it != j.end())
-        o.chain_id = from_json<uint8_t>(*chain_id_it);
 
     if (const auto it = j.find("data"); it != j.end())
         o.data = from_json<bytes>(*it);

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -145,7 +145,7 @@ TEST(statetest_loader, load_minimal_test)
     EXPECT_EQ(st.multi_tx.value, 0);
     EXPECT_EQ(st.multi_tx.nonce, 0);
     EXPECT_EQ(st.multi_tx.access_list.size(), 0);
-    EXPECT_EQ(st.multi_tx.chain_id, 0);
+    EXPECT_EQ(st.multi_tx.chain_id, 1);
     EXPECT_EQ(st.multi_tx.nonce, 0);
     EXPECT_EQ(st.multi_tx.r, 0);
     EXPECT_EQ(st.multi_tx.s, 0);

--- a/test/unittests/statetest_loader_tx_test.cpp
+++ b/test/unittests/statetest_loader_tx_test.cpp
@@ -95,7 +95,7 @@ TEST(statetest_loader, tx_eip1559)
     EXPECT_EQ(tx.type, state::Transaction::Type::eip1559);
     EXPECT_EQ(tx.data, (bytes{0xb0, 0xb1}));
     EXPECT_EQ(tx.gas_limit, 0x9091);
-    EXPECT_EQ(tx.chain_id, 0);
+    EXPECT_EQ(tx.chain_id, 1);
     EXPECT_EQ(tx.value, 0xe0e1);
     EXPECT_EQ(tx.sender, 0xa0a1_address);
     EXPECT_EQ(tx.to, 0xc0c1_address);


### PR DESCRIPTION
Also set default `chain_id` to 1 - see confirmation that this is expected behavior https://discord.com/channels/595666850260713488/753271902520213625/1280839101687533619

Pulled out of #961, required for 7702 tests.