### PR TITLE
test: Move invalid tx messages to state utils

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -568,49 +568,4 @@ std::variant<TransactionReceipt, std::error_code> transition(State& state, const
     return rlp::encode_tuple(withdrawal.index, withdrawal.validator_index, withdrawal.recipient,
         withdrawal.amount_in_gwei);
 }
-
-[[nodiscard]] std::string get_tests_invalid_tx_message(ErrorCode errc) noexcept
-{
-    switch (errc)
-    {
-    case SUCCESS:
-        return "";
-    case INTRINSIC_GAS_TOO_LOW:
-        return "TR_IntrinsicGas";
-    case TX_TYPE_NOT_SUPPORTED:
-        return "TR_TypeNotSupported";
-    case INSUFFICIENT_FUNDS:
-        return "TR_NoFunds";
-    case NONCE_HAS_MAX_VALUE:
-        return "TR_NonceHasMaxValue:";
-    case NONCE_TOO_HIGH:
-        return "TR_NonceTooHigh";
-    case NONCE_TOO_LOW:
-        return "TR_NonceTooLow";
-    case TIP_GT_FEE_CAP:
-        return "TR_TipGtFeeCap";
-    case FEE_CAP_LESS_THEN_BLOCKS:
-        return "TR_FeeCapLessThanBlocks";
-    case GAS_LIMIT_REACHED:
-        return "TR_GasLimitReached";
-    case SENDER_NOT_EOA:
-        return "SenderNotEOA";
-    case INIT_CODE_SIZE_LIMIT_EXCEEDED:
-        return "TR_InitCodeLimitExceeded";
-    case CREATE_BLOB_TX:
-        return "TR_BLOBCREATE";
-    case EMPTY_BLOB_HASHES_LIST:
-        return "TR_EMPTYBLOB";
-    case INVALID_BLOB_HASH_VERSION:
-        return "TR_BLOBVERSION_INVALID";
-    case BLOB_GAS_LIMIT_EXCEEDED:
-        return "TR_BLOBLIST_OVERSIZE";
-    case UNKNOWN_ERROR:
-        return "Unknown error";
-    default:
-        assert(false);
-        return "Wrong error code";
-    }
-}
-
 }  // namespace evmone::state

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -8,7 +8,6 @@
 #include "bloom_filter.hpp"
 #include "errors.hpp"
 #include "hash_utils.hpp"
-#include <cassert>
 #include <optional>
 #include <variant>
 #include <vector>
@@ -286,7 +285,4 @@ std::variant<int64_t, std::error_code> validate_transaction(const Account& sende
 
 /// Defines how to RLP-encode a Withdrawal.
 [[nodiscard]] bytes rlp_encode(const Withdrawal& withdrawal);
-
-[[nodiscard]] std::string get_tests_invalid_tx_message(ErrorCode errc) noexcept;
-
 }  // namespace evmone::state

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -95,6 +95,10 @@ state::Transaction from_json<state::Transaction>(const json::json& j);
 /// Exports the State (accounts) to JSON format (aka pre/post/alloc state).
 json::json to_json(const TestState& state);
 
+/// Returns the standardized error message for the transaction validation error.
+[[nodiscard]] std::string get_invalid_tx_message(state::ErrorCode errc) noexcept;
+
+
 std::vector<StateTransitionTest> load_state_tests(std::istream& input);
 
 /// Validates an Ethereum state:

--- a/test/statetest/statetest_export.cpp
+++ b/test/statetest/statetest_export.cpp
@@ -6,6 +6,52 @@
 
 namespace evmone::test
 {
+[[nodiscard]] std::string get_invalid_tx_message(state::ErrorCode errc) noexcept
+{
+    using namespace state;
+    switch (errc)
+    {
+    case SUCCESS:
+        return "";
+    case INTRINSIC_GAS_TOO_LOW:
+        return "TR_IntrinsicGas";
+    case TX_TYPE_NOT_SUPPORTED:
+        return "TR_TypeNotSupported";
+    case INSUFFICIENT_FUNDS:
+        return "TR_NoFunds";
+    case NONCE_HAS_MAX_VALUE:
+        return "TR_NonceHasMaxValue:";
+    case NONCE_TOO_HIGH:
+        return "TR_NonceTooHigh";
+    case NONCE_TOO_LOW:
+        return "TR_NonceTooLow";
+    case TIP_GT_FEE_CAP:
+        return "TR_TipGtFeeCap";
+    case FEE_CAP_LESS_THEN_BLOCKS:
+        return "TR_FeeCapLessThanBlocks";
+    case GAS_LIMIT_REACHED:
+        return "TR_GasLimitReached";
+    case SENDER_NOT_EOA:
+        return "SenderNotEOA";
+    case INIT_CODE_SIZE_LIMIT_EXCEEDED:
+        return "TR_InitCodeLimitExceeded";
+    case CREATE_BLOB_TX:
+        return "TR_BLOBCREATE";
+    case EMPTY_BLOB_HASHES_LIST:
+        return "TR_EMPTYBLOB";
+    case INVALID_BLOB_HASH_VERSION:
+        return "TR_BLOBVERSION_INVALID";
+    case BLOB_GAS_LIMIT_EXCEEDED:
+        return "TR_BLOBLIST_OVERSIZE";
+    case UNKNOWN_ERROR:
+        return "Unknown error";
+    default:
+        assert(false);
+        return "Wrong error code";
+    }
+}
+
+
 json::json to_json(const TestState& state)
 {
     json::json j = json::json::object();

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -228,8 +228,8 @@ void state_transition::export_state_test(
 
     if (holds_alternative<std::error_code>(res))
     {
-        jpost["expectException"] = get_tests_invalid_tx_message(
-            static_cast<ErrorCode>(std::get<std::error_code>(res).value()));
+        jpost["expectException"] =
+            get_invalid_tx_message(static_cast<ErrorCode>(std::get<std::error_code>(res).value()));
         jpost["logs"] = hex0x(logs_hash(std::vector<Log>()));
     }
     else


### PR DESCRIPTION
Moves the function `get_invalid_tx_message()` function from `evmone::state` (state.cpp) to `evmone::test` (statetest_export.cpp).