### PR TITLE
state: Split transaction and block related types of out state.hpp

### DIFF
--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "../state/block.hpp"
 #include "../state/bloom_filter.hpp"
-#include "../state/state.hpp"
 #include "../state/test_state.hpp"
+#include "../state/transaction.hpp"
 #include "../utils/utils.hpp"
 #include <evmc/evmc.hpp>
 #include <span>

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -36,6 +36,8 @@ target_sources(
     system_contracts.cpp
     test_state.hpp
     test_state.cpp
+    transaction.hpp
+    transaction.cpp
 )
 
 option(EVMONE_PRECOMPILES_SILKPRE "Enable precompiles support via silkpre library" OFF)

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -9,6 +9,8 @@ target_include_directories(evmone-state PRIVATE ${evmone_private_include_dir})
 target_sources(
     evmone-state PRIVATE
     account.hpp
+    block.hpp
+    block.cpp
     bloom_filter.hpp
     bloom_filter.cpp
     errors.hpp

--- a/test/state/block.cpp
+++ b/test/state/block.cpp
@@ -1,0 +1,38 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "block.hpp"
+#include "rlp.hpp"
+
+namespace evmone::state
+{
+intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept
+{
+    /// A helper function approximating `factor * e ** (numerator / denominator)`.
+    /// https://eips.ethereum.org/EIPS/eip-4844#helpers
+    static constexpr auto fake_exponential = [](uint64_t factor, uint64_t numerator,
+                                                 uint64_t denominator) noexcept {
+        intx::uint256 i = 1;
+        intx::uint256 output = 0;
+        intx::uint256 numerator_accum = factor * denominator;
+        while (numerator_accum > 0)
+        {
+            output += numerator_accum;
+            numerator_accum = (numerator_accum * numerator) / (denominator * i);
+            i += 1;
+        }
+        return output / denominator;
+    };
+
+    static constexpr auto MIN_BLOB_GASPRICE = 1;
+    static constexpr auto BLOB_GASPRICE_UPDATE_FRACTION = 3338477;
+    return fake_exponential(MIN_BLOB_GASPRICE, excess_blob_gas, BLOB_GASPRICE_UPDATE_FRACTION);
+}
+
+[[nodiscard]] bytes rlp_encode(const Withdrawal& withdrawal)
+{
+    return rlp::encode_tuple(withdrawal.index, withdrawal.validator_index, withdrawal.recipient,
+        withdrawal.amount_in_gwei);
+}
+}  // namespace evmone::state

--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -1,0 +1,68 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "hash_utils.hpp"
+#include <intx/intx.hpp>
+#include <vector>
+
+namespace evmone::state
+{
+struct Ommer
+{
+    address beneficiary;  ///< Ommer block beneficiary address.
+    uint32_t delta = 0;   ///< Difference between current and ommer block number.
+};
+
+struct Withdrawal
+{
+    uint64_t index = 0;
+    uint64_t validator_index = 0;
+    address recipient;
+    uint64_t amount_in_gwei = 0;  ///< The amount is denominated in gwei.
+
+    /// Returns withdrawal amount in wei.
+    [[nodiscard]] intx::uint256 get_amount() const noexcept
+    {
+        return intx::uint256{amount_in_gwei} * 1'000'000'000;
+    }
+};
+
+struct BlockInfo
+{
+    /// Max amount of blob gas allowed in block. It's constant now but can be dynamic in the future.
+    static constexpr int64_t MAX_BLOB_GAS_PER_BLOCK = 786432;
+
+    int64_t number = 0;
+    int64_t timestamp = 0;
+    int64_t parent_timestamp = 0;
+    int64_t gas_limit = 0;
+    address coinbase;
+    int64_t difficulty = 0;
+    int64_t parent_difficulty = 0;
+    hash256 parent_ommers_hash;
+    bytes32 prev_randao;
+    hash256 parent_beacon_block_root;
+    uint64_t base_fee = 0;
+
+    /// The "excess blob gas" parameter from EIP-4844
+    /// for computing the blob gas price in the current block.
+    uint64_t excess_blob_gas = 0;
+
+    /// The blob gas price parameter from EIP-4844.
+    /// This values is not stored in block headers directly but computed from excess_blob_gas.
+    intx::uint256 blob_base_fee = 0;
+
+    std::vector<Ommer> ommers;
+    std::vector<Withdrawal> withdrawals;
+    std::unordered_map<int64_t, hash256> known_block_hashes;
+};
+
+/// Computes the current blob gas price based on the excess blob gas.
+intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept;
+
+/// Defines how to RLP-encode a Withdrawal.
+[[nodiscard]] bytes rlp_encode(const Withdrawal& withdrawal);
+}  // namespace evmone::state

--- a/test/state/bloom_filter.cpp
+++ b/test/state/bloom_filter.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "bloom_filter.hpp"
-#include "state.hpp"
+#include "transaction.hpp"
 
 namespace evmone::state
 {

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -6,7 +6,6 @@
 
 #include "state.hpp"
 #include <optional>
-#include <unordered_set>
 
 namespace evmone::state
 {

--- a/test/state/mpt_hash.cpp
+++ b/test/state/mpt_hash.cpp
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "mpt_hash.hpp"
+#include "block.hpp"
 #include "mpt.hpp"
 #include "rlp.hpp"
-#include "state.hpp"
 #include "test_state.hpp"
+#include "transaction.hpp"
 
 namespace evmone::state
 {

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -5,12 +5,12 @@
 #pragma once
 
 #include "account.hpp"
+#include "block.hpp"
 #include "bloom_filter.hpp"
 #include "errors.hpp"
 #include "hash_utils.hpp"
-#include <optional>
+#include "transaction.hpp"
 #include <variant>
-#include <vector>
 
 namespace evmone::state
 {
@@ -121,143 +121,6 @@ public:
     /// @}
 };
 
-struct Ommer
-{
-    address beneficiary;  ///< Ommer block beneficiary address.
-    uint32_t delta = 0;   ///< Difference between current and ommer block number.
-};
-
-struct Withdrawal
-{
-    uint64_t index = 0;
-    uint64_t validator_index = 0;
-    address recipient;
-    uint64_t amount_in_gwei = 0;  ///< The amount is denominated in gwei.
-
-    /// Returns withdrawal amount in wei.
-    [[nodiscard]] intx::uint256 get_amount() const noexcept
-    {
-        return intx::uint256{amount_in_gwei} * 1'000'000'000;
-    }
-};
-
-struct BlockInfo
-{
-    /// Max amount of blob gas allowed in block. It's constant now but can be dynamic in the future.
-    static constexpr int64_t MAX_BLOB_GAS_PER_BLOCK = 786432;
-
-    int64_t number = 0;
-    int64_t timestamp = 0;
-    int64_t parent_timestamp = 0;
-    int64_t gas_limit = 0;
-    address coinbase;
-    int64_t difficulty = 0;
-    int64_t parent_difficulty = 0;
-    hash256 parent_ommers_hash;
-    bytes32 prev_randao;
-    hash256 parent_beacon_block_root;
-    uint64_t base_fee = 0;
-
-    /// The "excess blob gas" parameter from EIP-4844
-    /// for computing the blob gas price in the current block.
-    uint64_t excess_blob_gas = 0;
-
-    /// The blob gas price parameter from EIP-4844.
-    /// This values is not stored in block headers directly but computed from excess_blob_gas.
-    intx::uint256 blob_base_fee = 0;
-
-    std::vector<Ommer> ommers;
-    std::vector<Withdrawal> withdrawals;
-    std::unordered_map<int64_t, hash256> known_block_hashes;
-};
-
-using AccessList = std::vector<std::pair<address, std::vector<bytes32>>>;
-
-struct Transaction
-{
-    /// The type of the transaction.
-    ///
-    /// The format is defined by EIP-2718: Typed Transaction Envelope.
-    /// https://eips.ethereum.org/EIPS/eip-2718.
-    enum class Type : uint8_t
-    {
-        /// The legacy RLP-encoded transaction without leading "type" byte.
-        legacy = 0,
-
-        /// The typed transaction with optional account/storage access list.
-        /// Introduced by EIP-2930 https://eips.ethereum.org/EIPS/eip-2930.
-        access_list = 1,
-
-        /// The typed transaction with priority gas price.
-        /// Introduced by EIP-1559 https://eips.ethereum.org/EIPS/eip-1559.
-        eip1559 = 2,
-
-        /// The typed blob transaction (with array of blob hashes).
-        /// Introduced by EIP-4844 https://eips.ethereum.org/EIPS/eip-4844.
-        blob = 3,
-    };
-
-    /// Returns amount of blob gas used by this transaction
-    [[nodiscard]] int64_t blob_gas_used() const
-    {
-        static constexpr auto GAS_PER_BLOB = 0x20000;
-        return GAS_PER_BLOB * static_cast<int64_t>(blob_hashes.size());
-    }
-
-    Type type = Type::legacy;
-    bytes data;
-    int64_t gas_limit;
-    intx::uint256 max_gas_price;
-    intx::uint256 max_priority_gas_price;
-    intx::uint256 max_blob_gas_price;
-    address sender;
-    std::optional<address> to;
-    intx::uint256 value;
-    AccessList access_list;
-    std::vector<bytes32> blob_hashes;
-    uint64_t chain_id = 0;
-    uint64_t nonce = 0;
-    intx::uint256 r;
-    intx::uint256 s;
-    uint8_t v = 0;
-};
-
-struct Log
-{
-    address addr;
-    bytes data;
-    std::vector<hash256> topics;
-};
-
-/// Transaction Receipt
-///
-/// This struct is used in two contexts:
-/// 1. As the formally specified, RLP-encode transaction receipt included in the Ethereum blocks.
-/// 2. As the internal representation of the transaction execution result.
-/// These both roles share most, but not all the information. There are some fields that cannot be
-/// assigned in the single transaction execution context. There are also fields that are not a part
-/// of the RLP-encoded transaction receipts.
-/// TODO: Consider splitting the struct into two based on the duality explained above.
-struct TransactionReceipt
-{
-    Transaction::Type type = Transaction::Type::legacy;
-    evmc_status_code status = EVMC_INTERNAL_ERROR;
-
-    /// Amount of gas used by this transaction.
-    int64_t gas_used = 0;
-
-    /// Amount of gas used by this and previous transactions in the block.
-    int64_t cumulative_gas_used = 0;
-    std::vector<Log> logs;
-    BloomFilter logs_bloom_filter;
-
-    /// Root hash of the state after this transaction. Used only in old pre-Byzantium transactions.
-    std::optional<bytes32> post_state;
-};
-
-/// Computes the current blob gas price based on the excess blob gas.
-intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept;
-
 /// Finalize state after applying a "block" of transactions.
 ///
 /// Applies block reward to coinbase, withdrawals (post Shanghai) and deletes empty touched accounts
@@ -273,16 +136,4 @@ void finalize(State& state, evmc_revision rev, const address& coinbase,
 std::variant<int64_t, std::error_code> validate_transaction(const Account& sender_acc,
     const BlockInfo& block, const Transaction& tx, evmc_revision rev, int64_t block_gas_left,
     int64_t blob_gas_left) noexcept;
-
-/// Defines how to RLP-encode a Transaction.
-[[nodiscard]] bytes rlp_encode(const Transaction& tx);
-
-/// Defines how to RLP-encode a TransactionReceipt.
-[[nodiscard]] bytes rlp_encode(const TransactionReceipt& receipt);
-
-/// Defines how to RLP-encode a Log.
-[[nodiscard]] bytes rlp_encode(const Log& log);
-
-/// Defines how to RLP-encode a Withdrawal.
-[[nodiscard]] bytes rlp_encode(const Withdrawal& withdrawal);
 }  // namespace evmone::state

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -4,7 +4,6 @@
 
 #include "system_contracts.hpp"
 #include "host.hpp"
-#include "state.hpp"
 
 namespace evmone::state
 {

--- a/test/state/transaction.cpp
+++ b/test/state/transaction.cpp
@@ -1,0 +1,83 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "transaction.hpp"
+#include "../utils/stdx/utility.hpp"
+#include "rlp.hpp"
+
+
+namespace evmone::state
+{
+[[nodiscard]] bytes rlp_encode(const Log& log)
+{
+    return rlp::encode_tuple(log.addr, log.topics, log.data);
+}
+
+[[nodiscard]] bytes rlp_encode(const Transaction& tx)
+{
+    assert(tx.type <= Transaction::Type::blob);
+
+    // TODO: Refactor this function. For all type of transactions most of the code is similar.
+    if (tx.type == Transaction::Type::legacy)
+    {
+        // rlp [nonce, gas_price, gas_limit, to, value, data, v, r, s];
+        return rlp::encode_tuple(tx.nonce, tx.max_gas_price, static_cast<uint64_t>(tx.gas_limit),
+            tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data, tx.v, tx.r, tx.s);
+    }
+    else if (tx.type == Transaction::Type::access_list)
+    {
+        // tx_type +
+        // rlp [chain_id, nonce, gas_price, gas_limit, to, value, data, access_list, v, r, s];
+        return bytes{0x01} +  // Transaction type (eip2930 type == 1)
+               rlp::encode_tuple(tx.chain_id, tx.nonce, tx.max_gas_price,
+                   static_cast<uint64_t>(tx.gas_limit),
+                   tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
+                   tx.access_list, tx.v, tx.r, tx.s);
+    }
+    else if (tx.type == Transaction::Type::eip1559)
+    {
+        // tx_type +
+        // rlp [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value,
+        // data, access_list, sig_parity, r, s];
+        return bytes{0x02} +  // Transaction type (eip1559 type == 2)
+               rlp::encode_tuple(tx.chain_id, tx.nonce, tx.max_priority_gas_price, tx.max_gas_price,
+                   static_cast<uint64_t>(tx.gas_limit),
+                   tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
+                   tx.access_list, tx.v, tx.r, tx.s);
+    }
+    else  // Transaction::Type::blob
+    {
+        // tx_type +
+        // rlp [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value,
+        // data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, sig_parity, r, s];
+        return bytes{stdx::to_underlying(Transaction::Type::blob)} +
+               rlp::encode_tuple(tx.chain_id, tx.nonce, tx.max_priority_gas_price, tx.max_gas_price,
+                   static_cast<uint64_t>(tx.gas_limit),
+                   tx.to.has_value() ? tx.to.value() : bytes_view(), tx.value, tx.data,
+                   tx.access_list, tx.max_blob_gas_price, tx.blob_hashes, tx.v, tx.r, tx.s);
+    }
+}
+
+[[nodiscard]] bytes rlp_encode(const TransactionReceipt& receipt)
+{
+    if (receipt.post_state.has_value())
+    {
+        assert(receipt.type == Transaction::Type::legacy);
+
+        return rlp::encode_tuple(receipt.post_state.value(),
+            static_cast<uint64_t>(receipt.cumulative_gas_used),
+            bytes_view(receipt.logs_bloom_filter), receipt.logs);
+    }
+    else
+    {
+        const auto prefix = receipt.type == Transaction::Type::legacy ?
+                                bytes{} :
+                                bytes{stdx::to_underlying(receipt.type)};
+
+        return prefix + rlp::encode_tuple(receipt.status == EVMC_SUCCESS,
+                            static_cast<uint64_t>(receipt.cumulative_gas_used),
+                            bytes_view(receipt.logs_bloom_filter), receipt.logs);
+    }
+}
+}  // namespace evmone::state

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -1,0 +1,106 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "bloom_filter.hpp"
+#include <intx/intx.hpp>
+#include <optional>
+#include <vector>
+
+namespace evmone::state
+{
+using AccessList = std::vector<std::pair<address, std::vector<bytes32>>>;
+
+struct Transaction
+{
+    /// The type of the transaction.
+    ///
+    /// The format is defined by EIP-2718: Typed Transaction Envelope.
+    /// https://eips.ethereum.org/EIPS/eip-2718.
+    enum class Type : uint8_t
+    {
+        /// The legacy RLP-encoded transaction without leading "type" byte.
+        legacy = 0,
+
+        /// The typed transaction with optional account/storage access list.
+        /// Introduced by EIP-2930 https://eips.ethereum.org/EIPS/eip-2930.
+        access_list = 1,
+
+        /// The typed transaction with priority gas price.
+        /// Introduced by EIP-1559 https://eips.ethereum.org/EIPS/eip-1559.
+        eip1559 = 2,
+
+        /// The typed blob transaction (with array of blob hashes).
+        /// Introduced by EIP-4844 https://eips.ethereum.org/EIPS/eip-4844.
+        blob = 3,
+    };
+
+    /// Returns amount of blob gas used by this transaction
+    [[nodiscard]] int64_t blob_gas_used() const
+    {
+        static constexpr auto GAS_PER_BLOB = 0x20000;
+        return GAS_PER_BLOB * static_cast<int64_t>(blob_hashes.size());
+    }
+
+    Type type = Type::legacy;
+    bytes data;
+    int64_t gas_limit;
+    intx::uint256 max_gas_price;
+    intx::uint256 max_priority_gas_price;
+    intx::uint256 max_blob_gas_price;
+    address sender;
+    std::optional<address> to;
+    intx::uint256 value;
+    AccessList access_list;
+    std::vector<bytes32> blob_hashes;
+    uint64_t chain_id = 0;
+    uint64_t nonce = 0;
+    intx::uint256 r;
+    intx::uint256 s;
+    uint8_t v = 0;
+};
+
+struct Log
+{
+    address addr;
+    bytes data;
+    std::vector<hash256> topics;
+};
+
+/// Transaction Receipt
+///
+/// This struct is used in two contexts:
+/// 1. As the formally specified, RLP-encode transaction receipt included in the Ethereum blocks.
+/// 2. As the internal representation of the transaction execution result.
+/// These both roles share most, but not all the information. There are some fields that cannot be
+/// assigned in the single transaction execution context. There are also fields that are not a part
+/// of the RLP-encoded transaction receipts.
+/// TODO: Consider splitting the struct into two based on the duality explained above.
+struct TransactionReceipt
+{
+    Transaction::Type type = Transaction::Type::legacy;
+    evmc_status_code status = EVMC_INTERNAL_ERROR;
+
+    /// Amount of gas used by this transaction.
+    int64_t gas_used = 0;
+
+    /// Amount of gas used by this and previous transactions in the block.
+    int64_t cumulative_gas_used = 0;
+    std::vector<Log> logs;
+    BloomFilter logs_bloom_filter;
+
+    /// Root hash of the state after this transaction. Used only in old pre-Byzantium transactions.
+    std::optional<bytes32> post_state;
+};
+
+/// Defines how to RLP-encode a Transaction.
+[[nodiscard]] bytes rlp_encode(const Transaction& tx);
+
+/// Defines how to RLP-encode a TransactionReceipt.
+[[nodiscard]] bytes rlp_encode(const TransactionReceipt& receipt);
+
+/// Defines how to RLP-encode a Log.
+[[nodiscard]] bytes rlp_encode(const Log& log);
+}  // namespace evmone::state

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "../state/state.hpp"
+#include "../state/block.hpp"
+#include "../state/errors.hpp"
 #include "../state/test_state.hpp"
+#include "../state/transaction.hpp"
 #include <nlohmann/json.hpp>
 
 namespace json = nlohmann;


### PR DESCRIPTION
We are going to hide the `State` in state.hpp from public. This change moves other types out of this file make the future transition easier to control.

The git history is preserved by using file renames and a lot of merge commits (octopus merge didn't work for me).