### PR TITLE
clang-tidy: Disable modernize-use-nodiscard

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -51,6 +51,7 @@ Checks:
   - "-misc-use-anonymous-namespace"
   - "modernize-*"
   - "-modernize-avoid-c-arrays"
+  - "-modernize-use-nodiscard"
   - "-modernize-use-trailing-return-type"
   - "performance-*"
   - "-performance-enum-size"


### PR DESCRIPTION
We discussed that this check is too strict because we want to put `[[nodiscard]]` only in very specific places where ignoring a returned value is close to logic error. The clang-tidy check asking to put it on every class getter is too much.