### PR TITLE
Optimize EOF by reading types on demand

### DIFF
--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -15,6 +15,24 @@
 
 namespace evmone
 {
+/// Loads big endian int16_t from data. Unsafe.
+/// TODO: Move it to intx
+inline int16_t read_int16_be(auto it) noexcept
+{
+    const uint8_t h = *it++;
+    const uint8_t l = *it;
+    return static_cast<int16_t>((h << 8) | l);
+}
+
+/// Loads big endian uint16_t from data. Unsafe.
+/// TODO: Move it to intx
+inline uint16_t read_uint16_be(auto it) noexcept
+{
+    const uint8_t h = *it++;
+    const uint8_t l = *it;
+    return static_cast<uint16_t>((h << 8) | l);
+}
+
 using evmc::bytes;
 using evmc::bytes_view;
 using namespace evmc::literals;
@@ -40,8 +58,14 @@ struct EOFCodeType
 
 struct EOF1Header
 {
+    /// Size of a type entry in bytes.
+    static constexpr size_t TYPE_ENTRY_SIZE = sizeof(EOFCodeType);
+
     /// The EOF version, 0 means legacy code.
     uint8_t version = 0;
+
+    /// Offset of the type section start.
+    size_t type_section_offset = 0;
 
     /// Size of every code section.
     std::vector<uint16_t> code_sizes;
@@ -62,7 +86,20 @@ struct EOF1Header
     /// Offset of every container section start;
     std::vector<uint16_t> container_offsets;
 
-    std::vector<EOFCodeType> types;
+    /// A helper to extract reference to a specific type section.
+    [[nodiscard]] EOFCodeType get_type(bytes_view container, size_t type_idx) const noexcept
+    {
+        const auto offset = type_section_offset + type_idx * TYPE_ENTRY_SIZE;
+        // TODO: Make EOFCodeType aggregate type and use designated initializers.
+        return EOFCodeType{
+            container[offset],                      // inputs
+            container[offset + 1],                  // outputs
+            read_uint16_be(&container[offset + 2])  // max_stack_height
+        };
+    }
+
+    /// Returns the number of types in the type section.
+    [[nodiscard]] size_t get_type_count() const noexcept { return code_sizes.size(); }
 
     /// A helper to extract reference to a specific code section.
     [[nodiscard]] bytes_view get_code(bytes_view container, size_t code_idx) const noexcept
@@ -181,23 +218,5 @@ enum class ContainerKind : uint8_t
 
 /// Output operator for EOFValidationError.
 EVMC_EXPORT std::ostream& operator<<(std::ostream& os, EOFValidationError err) noexcept;
-
-/// Loads big endian int16_t from data. Unsafe.
-/// TODO: Move it to intx
-inline int16_t read_int16_be(auto it) noexcept
-{
-    const uint8_t h = *it++;
-    const uint8_t l = *it;
-    return static_cast<int16_t>((h << 8) | l);
-}
-
-/// Loads big endian uint16_t from data. Unsafe.
-/// TODO: Move it to intx
-inline uint16_t read_uint16_be(auto it) noexcept
-{
-    const uint8_t h = *it++;
-    const uint8_t l = *it;
-    return static_cast<uint16_t>((h << 8) | l);
-}
 
 }  // namespace evmone

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -1101,9 +1101,8 @@ inline code_iterator callf(StackTop stack, ExecutionState& state, code_iterator 
     const auto index = read_uint16_be(&pos[1]);
     const auto& header = state.analysis.baseline->eof_header();
     const auto stack_size = &stack.top() - state.stack_space.bottom();
-
-    const auto callee_required_stack_size =
-        header.types[index].max_stack_height - header.types[index].inputs;
+    const auto callee_type = header.get_type(state.original_code, index);
+    const auto callee_required_stack_size = callee_type.max_stack_height - callee_type.inputs;
     if (stack_size + callee_required_stack_size > StackSpace::limit)
     {
         state.status = EVMC_STACK_OVERFLOW;
@@ -1134,9 +1133,8 @@ inline code_iterator jumpf(StackTop stack, ExecutionState& state, code_iterator 
     const auto index = read_uint16_be(&pos[1]);
     const auto& header = state.analysis.baseline->eof_header();
     const auto stack_size = &stack.top() - state.stack_space.bottom();
-
-    const auto callee_required_stack_size =
-        header.types[index].max_stack_height - header.types[index].inputs;
+    const auto callee_type = header.get_type(state.original_code, index);
+    const auto callee_required_stack_size = callee_type.max_stack_height - callee_type.inputs;
     if (stack_size + callee_required_stack_size > StackSpace::limit)
     {
         state.status = EVMC_STACK_OVERFLOW;

--- a/test/unittests/eof_test.cpp
+++ b/test/unittests/eof_test.cpp
@@ -101,7 +101,8 @@ TEST(eof, read_valid_eof1_header)
         const auto header = read_valid_eof1_header(code);
         EXPECT_EQ(header.code_sizes, test_case.code_sizes) << test_case.code;
         EXPECT_EQ(header.data_size, test_case.data_size) << test_case.code;
-        EXPECT_EQ(header.types.size() * 4, test_case.types_size) << test_case.code;
+        EXPECT_EQ(header.get_type_count(), test_case.types_size / EOF1Header::TYPE_ENTRY_SIZE)
+            << test_case.code;
         EXPECT_EQ(header.container_sizes, test_case.container_sizes) << test_case.code;
     }
 }


### PR DESCRIPTION
Introduces `EOF1Header::get_type` function to read individual EOF
code types. This is fast procedure because we need to read at most 4
bytes and a know offset. By doing so we avoid allocating separated
vector to types.

Closes https://github.com/ethereum/evmone/issues/1003.