### PR TITLE
eof: Return constant hash of EXTCODEHASH of EOF

### DIFF
--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -9,7 +9,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -17,6 +17,9 @@ namespace evmone
 {
 using evmc::bytes;
 using evmc::bytes_view;
+
+constexpr uint8_t EOF_MAGIC_BYTES[] = {0xef, 0x00};
+constexpr bytes_view EOF_MAGIC{EOF_MAGIC_BYTES, std::size(EOF_MAGIC_BYTES)};
 
 struct EOFCodeType
 {

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <evmc/bytes.hpp>
-#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
 #include <evmc/utils.h>
 #include <cassert>
 #include <cstddef>
@@ -17,9 +17,15 @@ namespace evmone
 {
 using evmc::bytes;
 using evmc::bytes_view;
+using namespace evmc::literals;
 
 constexpr uint8_t EOF_MAGIC_BYTES[] = {0xef, 0x00};
 constexpr bytes_view EOF_MAGIC{EOF_MAGIC_BYTES, std::size(EOF_MAGIC_BYTES)};
+
+/// The value returned by EXTCODEHASH of an address with EOF code.
+/// See EIP-3540: https://eips.ethereum.org/EIPS/eip-3540#changes-to-execution-semantics.
+static constexpr auto EOF_CODE_HASH_SENTINEL =
+    0x9dbf3648db8210552e9c4f75c6a1c3057c0ca432043bd648be15fe7be05646f5_bytes32;
 
 struct EOFCodeType
 {

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -113,9 +113,13 @@ size_t Host::get_code_size(const address& addr) const noexcept
 
 bytes32 Host::get_code_hash(const address& addr) const noexcept
 {
-    // TODO: Cache code hash. It will be needed also to compute the MPT hash.
     const auto* const acc = m_state.find(addr);
-    return (acc != nullptr && !acc->is_empty()) ? keccak256(extcode(acc->code)) : bytes32{};
+    if (acc == nullptr || acc->is_empty())
+        return {};
+    if (is_eof_container(acc->code))
+        return EOF_CODE_HASH_SENTINEL;
+    // TODO: Cache code hash. It will be needed also to compute the MPT hash.
+    return keccak256(acc->code);
 }
 
 size_t Host::copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,

--- a/test/unittests/eof_test.cpp
+++ b/test/unittests/eof_test.cpp
@@ -4,6 +4,7 @@
 
 #include <evmone/eof.hpp>
 #include <gtest/gtest.h>
+#include <test/state/hash_utils.hpp>
 #include <test/utils/bytecode.hpp>
 #include <test/utils/utils.hpp>
 
@@ -114,4 +115,9 @@ TEST(eof, get_error_message)
 
     // NOLINTNEXTLINE(*.EnumCastOutOfRange)
     EXPECT_EQ(evmone::get_error_message(static_cast<EOFValidationError>(-1)), "<unknown>");
+}
+
+TEST(eof, extcodehash_sentinel)
+{
+    EXPECT_EQ(keccak256(EOF_MAGIC), EOF_CODE_HASH_SENTINEL);
 }


### PR DESCRIPTION
Replace runtime evaluated `keccak256("EF00")` with a constant returned for an account with EOF code.