### PR TITLE
clang-tidy: Disable readability-container-data-pointer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,6 +58,8 @@ Checks:
   - "portability-*"
   - "readability-*"
   - "-readability-braces-around-statements"
+  # Sometimes we actually want to take the address of the first element.
+  - "-readability-container-data-pointer"
   - "-readability-else-after-return"
   - "-readability-function-cognitive-complexity"
   - "-readability-function-size"


### PR DESCRIPTION
It may be intentional to do `&v[0]` instead of `v.data()` as a way of saying "give me the address of the 0th element" instead of "give me the address of the array of elements".

An example: https://github.com/ethereum/evmone/pull/1046.