### PR TITLE
statetest: Drop support for "fake" `BLOCKHASH`

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -478,11 +478,7 @@ bytes32 Host::get_block_hash(int64_t block_number) const noexcept
     if (const auto& it = m_block.known_block_hashes.find(block_number);
         it != m_block.known_block_hashes.end())
         return it->second;
-
-    // Convention for testing: if the block hash in unknown return the predefined "fake" value.
-    // https://github.com/ethereum/go-ethereum/blob/v1.12.2/tests/state_test_util.go#L432
-    const auto s = std::to_string(block_number);
-    return keccak256({reinterpret_cast<const uint8_t*>(s.data()), s.size()});
+    return {};
 }
 
 void Host::emit_log(const address& addr, const uint8_t* data, size_t data_size,

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -32,17 +32,6 @@ TEST_F(state_transition, known_block_hash)
         0x0000000000000000000000000000000000000000000000000000000000000111_bytes32;
 }
 
-TEST_F(state_transition, known_block_hash_fake)
-{
-    block.number = 2;
-    tx.to = To;
-    pre.insert(*tx.to, {.nonce = 1, .code = sstore(0, blockhash(0)) + sstore(1, blockhash(1))});
-    expect.post[To].storage[0x00_bytes32] =
-        0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d_bytes32;
-    expect.post[To].storage[0x01_bytes32] =
-        0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6_bytes32;
-}
-
 TEST_F(state_transition, block_apply_ommers_reward)
 {
     rev = EVMC_LONDON;


### PR DESCRIPTION
The state tests had a procedure of generating non-empty BLOCKHASH outputs based on the block number. This is deprecated feature not used in any existing tests. Remove support for it in evmone.