### PR TITLE
Introduce `BlockHashes` interface

### DIFF
--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -52,11 +52,14 @@ struct BlockInfo
     uint64_t excess_blob_gas = 0;
 
     /// The blob gas price parameter from EIP-4844.
-    /// This values is not stored in block headers directly but computed from excess_blob_gas.
+    /// This value is not stored in block headers directly but computed from excess_blob_gas.
     intx::uint256 blob_base_fee = 0;
 
     std::vector<Ommer> ommers;
     std::vector<Withdrawal> withdrawals;
+
+    /// Collection of known block hashes by block number. Only use in tests.
+    /// TODO: This should be moved to evmone::test.
     std::unordered_map<int64_t, hash256> known_block_hashes;
 };
 

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -498,14 +498,7 @@ evmc_tx_context Host::get_tx_context() const noexcept
 
 bytes32 Host::get_block_hash(int64_t block_number) const noexcept
 {
-    if (const auto& it = m_block.known_block_hashes.find(block_number);
-        it != m_block.known_block_hashes.end())
-        return it->second;
-
-    // Convention for testing: if the block hash in unknown return the predefined "fake" value.
-    // https://github.com/ethereum/go-ethereum/blob/v1.12.2/tests/state_test_util.go#L432
-    const auto s = std::to_string(block_number);
-    return keccak256({reinterpret_cast<const uint8_t*>(s.data()), s.size()});
+    return m_block_hashes.get_block_hash(block_number);
 }
 
 void Host::emit_log(const address& addr, const uint8_t* data, size_t data_size,

--- a/test/state/host.hpp
+++ b/test/state/host.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "state.hpp"
+#include "state_view.hpp"
 #include <optional>
 
 namespace evmone::state
@@ -39,13 +40,14 @@ class Host : public evmc::Host
     evmc::VM& m_vm;
     State& m_state;
     const BlockInfo& m_block;
+    const BlockHashes& m_block_hashes;
     const Transaction& m_tx;
     std::vector<Log> m_logs;
 
 public:
     Host(evmc_revision rev, evmc::VM& vm, State& state, const BlockInfo& block,
-        const Transaction& tx) noexcept
-      : m_rev{rev}, m_vm{vm}, m_state{state}, m_block{block}, m_tx{tx}
+        const BlockHashes& block_hashes, const Transaction& tx) noexcept
+      : m_rev{rev}, m_vm{vm}, m_state{state}, m_block{block}, m_block_hashes{block_hashes}, m_tx{tx}
     {}
 
     [[nodiscard]] std::vector<Log>&& take_logs() noexcept { return std::move(m_logs); }

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -416,8 +416,8 @@ StateDiff finalize(const StateView& state_view, evmc_revision rev, const address
 }
 
 std::variant<TransactionReceipt, std::error_code> transition(const StateView& state_view,
-    const BlockInfo& block, const Transaction& tx, evmc_revision rev, evmc::VM& vm,
-    int64_t block_gas_left, int64_t blob_gas_left)
+    const BlockInfo& block, const BlockHashes& block_hashes, const Transaction& tx,
+    evmc_revision rev, evmc::VM& vm, int64_t block_gas_left, int64_t blob_gas_left)
 {
     State state{state_view};
     auto* sender_ptr = state.find(tx.sender);
@@ -460,7 +460,7 @@ std::variant<TransactionReceipt, std::error_code> transition(const StateView& st
         sender_acc.balance -= blob_fee;
     }
 
-    Host host{rev, vm, state, block, tx};
+    Host host{rev, vm, state, block, block_hashes, tx};
 
     sender_acc.access_status = EVMC_ACCESS_WARM;  // Tx sender is always warm.
     if (tx.to.has_value())

--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -10,13 +10,12 @@
 #include "errors.hpp"
 #include "hash_utils.hpp"
 #include "state_diff.hpp"
+#include "state_view.hpp"
 #include "transaction.hpp"
 #include <variant>
 
 namespace evmone::state
 {
-class StateView;
-
 /// The Ethereum State: the collection of accounts mapped by their addresses.
 class State
 {
@@ -139,8 +138,8 @@ public:
     std::span<const Withdrawal> withdrawals);
 
 [[nodiscard]] std::variant<TransactionReceipt, std::error_code> transition(const StateView& state,
-    const BlockInfo& block, const Transaction& tx, evmc_revision rev, evmc::VM& vm,
-    int64_t block_gas_left, int64_t blob_gas_left);
+    const BlockInfo& block, const BlockHashes& block_hashes, const Transaction& tx,
+    evmc_revision rev, evmc::VM& vm, int64_t block_gas_left, int64_t blob_gas_left);
 
 std::variant<int64_t, std::error_code> validate_transaction(const Account& sender_acc,
     const BlockInfo& block, const Transaction& tx, evmc_revision rev, int64_t block_gas_left,

--- a/test/state/state_view.hpp
+++ b/test/state/state_view.hpp
@@ -30,4 +30,15 @@ public:
     virtual bytes get_account_code(const address& addr) const noexcept = 0;
     virtual bytes32 get_storage(const address& addr, const bytes32& key) const noexcept = 0;
 };
+
+
+/// Interface to access hashes of known block headers.
+class BlockHashes
+{
+public:
+    virtual ~BlockHashes() = default;
+
+    /// Returns the hash of the block header of the given block number.
+    virtual bytes32 get_block_hash(int64_t block_number) const noexcept = 0;
+};
 }  // namespace evmone::state

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -20,12 +20,13 @@ constexpr auto HISTORY_STORAGE_ADDRESS = 0x0aae40965e6800cd9b1f4b05ff21581047e3f
 
 struct BlockInfo;
 struct StateDiff;
+class BlockHashes;
 class StateView;
 
 /// Performs the system call: invokes system contracts.
 ///
 /// Executes code of pre-defined accounts via pseudo-transaction from the system sender (0xff...fe).
 /// The sender's nonce is not increased.
-[[nodiscard]] StateDiff system_call(
-    const StateView& state_view, const BlockInfo& block, evmc_revision rev, evmc::VM& vm);
+[[nodiscard]] StateDiff system_call(const StateView& state_view, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
 }  // namespace evmone::state

--- a/test/state/test_state.cpp
+++ b/test/state/test_state.cpp
@@ -59,6 +59,17 @@ bytes32 TestState::get_storage(const address& addr, const bytes32& key) const no
     return (it != storage.end()) ? it->second : bytes32{};
 }
 
+bytes32 TestBlockHashes::get_block_hash(int64_t block_number) const noexcept
+{
+    if (const auto& it = known_block_hashes_.find(block_number); it != known_block_hashes_.end())
+        return it->second;
+
+    // Convention for testing: if the block hash in unknown return the predefined "fake" value.
+    // https://github.com/ethereum/go-ethereum/blob/v1.12.2/tests/state_test_util.go#L432
+    const auto s = std::to_string(block_number);
+    return keccak256({reinterpret_cast<const uint8_t*>(s.data()), s.size()});
+}
+
 [[nodiscard]] std::variant<state::TransactionReceipt, std::error_code> transition(TestState& state,
     const state::BlockInfo& block, const state::Transaction& tx, evmc_revision rev, evmc::VM& vm,
     int64_t block_gas_left, int64_t blob_gas_left)

--- a/test/state/test_state.cpp
+++ b/test/state/test_state.cpp
@@ -74,8 +74,9 @@ bytes32 TestBlockHashes::get_block_hash(int64_t block_number) const noexcept
     const state::BlockInfo& block, const state::Transaction& tx, evmc_revision rev, evmc::VM& vm,
     int64_t block_gas_left, int64_t blob_gas_left)
 {
+    const TestBlockHashes block_hashes{block.known_block_hashes};
     const auto result_or_error =
-        state::transition(state, block, tx, rev, vm, block_gas_left, blob_gas_left);
+        state::transition(state, block, block_hashes, tx, rev, vm, block_gas_left, blob_gas_left);
     if (const auto result = get_if<state::TransactionReceipt>(&result_or_error))
         state.apply(result->state_diff);
     return result_or_error;
@@ -91,7 +92,8 @@ void finalize(TestState& state, evmc_revision rev, const address& coinbase,
 
 void system_call(TestState& state, const state::BlockInfo& block, evmc_revision rev, evmc::VM& vm)
 {
-    const auto diff = state::system_call(state, block, rev, vm);
+    const TestBlockHashes block_hashes{block.known_block_hashes};
+    const auto diff = state::system_call(state, block, block_hashes, rev, vm);
     state.apply(diff);
 }
 }  // namespace evmone::test

--- a/test/state/test_state.hpp
+++ b/test/state/test_state.hpp
@@ -72,6 +72,19 @@ public:
     void apply(const state::StateDiff& diff);
 };
 
+class TestBlockHashes : public state::BlockHashes
+{
+    /// The map block_number => block hash of known blocks.
+    const std::unordered_map<int64_t, bytes32>& known_block_hashes_;
+
+public:
+    explicit TestBlockHashes(const std::unordered_map<int64_t, bytes32>& known_block_hashes)
+      : known_block_hashes_{known_block_hashes}
+    {}
+
+    bytes32 get_block_hash(int64_t block_number) const noexcept override;
+};
+
 /// Wrapping of state::transition() which operates on TestState.
 [[nodiscard]] std::variant<state::TransactionReceipt, std::error_code> transition(TestState& state,
     const state::BlockInfo& block, const state::Transaction& tx, evmc_revision rev, evmc::VM& vm,


### PR DESCRIPTION
Define interface `BlockHashes` to access hashes of known block headers. This substitutes the usage of `BlockInfo::known_block_hashes` which can only work in tests, but not in production code.

The method `get_block_hash()` could have been added to `StateView`, but I decided keep it separated for now.