### PR TITLE
test: Split know block hashes into TestBlockHashes

### DIFF
--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -57,10 +57,6 @@ struct BlockInfo
 
     std::vector<Ommer> ommers;
     std::vector<Withdrawal> withdrawals;
-
-    /// Collection of known block hashes by block number. Only use in tests.
-    /// TODO: This should be moved to evmone::test.
-    std::unordered_map<int64_t, hash256> known_block_hashes;
 };
 
 /// Computes the current blob gas price based on the excess blob gas.

--- a/test/state/test_state.hpp
+++ b/test/state/test_state.hpp
@@ -72,23 +72,19 @@ public:
     void apply(const state::StateDiff& diff);
 };
 
-class TestBlockHashes : public state::BlockHashes
+class TestBlockHashes : public state::BlockHashes, public std::unordered_map<int64_t, bytes32>
 {
-    /// The map block_number => block hash of known blocks.
-    const std::unordered_map<int64_t, bytes32>& known_block_hashes_;
-
 public:
-    explicit TestBlockHashes(const std::unordered_map<int64_t, bytes32>& known_block_hashes)
-      : known_block_hashes_{known_block_hashes}
-    {}
+    using std::unordered_map<int64_t, bytes32>::unordered_map;
 
     bytes32 get_block_hash(int64_t block_number) const noexcept override;
 };
 
 /// Wrapping of state::transition() which operates on TestState.
 [[nodiscard]] std::variant<state::TransactionReceipt, std::error_code> transition(TestState& state,
-    const state::BlockInfo& block, const state::Transaction& tx, evmc_revision rev, evmc::VM& vm,
-    int64_t block_gas_left, int64_t blob_gas_left);
+    const state::BlockInfo& block, const state::BlockHashes& block_hashes,
+    const state::Transaction& tx, evmc_revision rev, evmc::VM& vm, int64_t block_gas_left,
+    int64_t blob_gas_left);
 
 /// Wrapping of state::finalize() which operates on TestState.
 void finalize(TestState& state, evmc_revision rev, const address& coinbase,
@@ -96,7 +92,8 @@ void finalize(TestState& state, evmc_revision rev, const address& coinbase,
     std::span<const state::Withdrawal> withdrawals);
 
 /// Wrapping of state::system_call() which operates on TestState.
-void system_call(TestState& state, const state::BlockInfo& block, evmc_revision rev, evmc::VM& vm);
+void system_call(TestState& state, const state::BlockInfo& block,
+    const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
 
 }  // namespace test
 }  // namespace evmone

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -59,6 +59,7 @@ struct StateTransitionTest
     std::string name;
     TestState pre_state;
     state::BlockInfo block;
+    TestBlockHashes block_hashes;
     TestMultiTransaction multi_tx;
     std::vector<Case> cases;
     std::unordered_map<uint64_t, std::string> input_labels;
@@ -84,6 +85,9 @@ bytes from_json<bytes>(const json::json& j);
 
 template <>
 state::BlockInfo from_json<state::BlockInfo>(const json::json& j);
+
+template <>
+TestBlockHashes from_json<TestBlockHashes>(const json::json& j);
 
 template <>
 state::Withdrawal from_json<state::Withdrawal>(const json::json& j);

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -27,8 +27,8 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             const auto tx = test.multi_tx.get(expected.indexes);
             auto state = test.pre_state;
 
-            const auto res = test::transition(state, test.block, tx, rev, vm, test.block.gas_limit,
-                state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
+            const auto res = test::transition(state, test.block, test.block_hashes, tx, rev, vm,
+                test.block.gas_limit, state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
 
             // Finalize block with reward 0.
             test::finalize(state, rev, test.block.coinbase, 0, {}, {});

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -75,6 +75,7 @@ int main(int argc, const char* argv[])
         }
 
         state::BlockInfo block;
+        TestBlockHashes block_hashes;
         TestState state;
 
         if (!alloc_file.empty())
@@ -86,7 +87,8 @@ int main(int argc, const char* argv[])
         if (!env_file.empty())
         {
             const auto j = json::json::parse(std::ifstream{env_file});
-            block = test::from_json<state::BlockInfo>(j);
+            block = from_json<state::BlockInfo>(j);
+            block_hashes = from_json<TestBlockHashes>(j);
         }
 
         json::json j_result;
@@ -133,7 +135,7 @@ int main(int argc, const char* argv[])
                 j_result["receipts"] = json::json::array();
                 j_result["rejected"] = json::json::array();
 
-                test::system_call(state, block, rev, vm);
+                test::system_call(state, block, block_hashes, rev, vm);
 
                 for (size_t i = 0; i < j_txs.size(); ++i)
                 {
@@ -168,8 +170,8 @@ int main(int argc, const char* argv[])
                         std::clog.rdbuf(trace_file_output.rdbuf());
                     }
 
-                    auto res =
-                        test::transition(state, block, tx, rev, vm, block_gas_left, blob_gas_left);
+                    auto res = test::transition(
+                        state, block, block_hashes, tx, rev, vm, block_gas_left, blob_gas_left);
 
                     if (holds_alternative<std::error_code>(res))
                     {

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -57,8 +57,8 @@ void state_transition::TearDown()
     if (trace)
         trace_capture.emplace();
 
-    const auto res = test::transition(state, block, tx, rev, selected_vm, block.gas_limit,
-        state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
+    const auto res = test::transition(state, block, block_hashes, tx, rev, selected_vm,
+        block.gas_limit, state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
     test::finalize(state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
     const auto& post = state;
 

--- a/test/unittests/state_transition.hpp
+++ b/test/unittests/state_transition.hpp
@@ -77,6 +77,7 @@ protected:
         .coinbase = Coinbase,
         .base_fee = 999,
     };
+    TestBlockHashes block_hashes;
     Transaction tx{
         // The default type corresponds to the default `rev` and majority of tests.
         .type = Transaction::Type::eip1559,

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -19,9 +19,10 @@ TEST_F(state_transition, block_apply_withdrawal)
 
 TEST_F(state_transition, known_block_hash)
 {
-    block.known_block_hashes = {
+    block_hashes = {
         {1, 0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421_bytes32},
-        {2, 0x0000000000000000000000000000000000000000000000000000000000000111_bytes32}};
+        {2, 0x0000000000000000000000000000000000000000000000000000000000000111_bytes32},
+    };
     block.number = 5;
 
     tx.to = To;

--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -17,11 +17,7 @@ TEST(statetest_loader, block_info)
             "currentTimestamp": "0",
             "currentBaseFee": "7",
             "currentRandom": "0x00",
-            "withdrawals": [],
-            "blockHashes": {
-                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
-                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
-            }
+            "withdrawals": []
         })";
 
     const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
@@ -31,10 +27,6 @@ TEST(statetest_loader, block_info)
     EXPECT_EQ(bi.base_fee, 7);
     EXPECT_EQ(bi.timestamp, 0);
     EXPECT_EQ(bi.number, 0);
-    EXPECT_EQ(bi.known_block_hashes.at(0),
-        0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
-    EXPECT_EQ(bi.known_block_hashes.at(1),
-        0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
 }
 
 TEST(statetest_loader, block_info_hex)
@@ -51,9 +43,6 @@ TEST(statetest_loader, block_info_hex)
         "parentGasUsed": "0",
         "parentGasLimit": "0x16345785D8A0000",
         "parentTimstamp": "0",
-        "blockHashes": {
-            "0": "0xc305d826e3784046a7e9d31128ef98d3e96133fe454c16ef630574d967dfdb1a"
-        },
         "ommers": [],
         "withdrawals": [],
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
@@ -82,9 +71,6 @@ TEST(statetest_loader, block_info_dec)
         "parentGasUsed": "0",
         "parentGasLimit": "100000000000000000",
         "parentTimstamp": "0",
-        "blockHashes": {
-            "0": "0xc305d826e3784046a7e9d31128ef98d3e96133fe454c16ef630574d967dfdb1a"
-        },
         "ommers": [],
         "withdrawals": [],
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
@@ -111,9 +97,6 @@ TEST(statetest_loader, block_info_0_current_difficulty)
         "parentGasUsed": "0",
         "parentGasLimit": "100000000000000000",
         "parentTimstamp": "0",
-        "blockHashes": {
-            "0": "0xc305d826e3784046a7e9d31128ef98d3e96133fe454c16ef630574d967dfdb1a"
-        },
         "ommers": [],
         "withdrawals": [],
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
@@ -140,9 +123,6 @@ TEST(statetest_loader, block_info_0_parent_difficulty)
         "parentGasUsed": "0",
         "parentGasLimit": "100000000000000000",
         "parentTimestamp": "253",
-        "blockHashes": {
-            "0": "0xc305d826e3784046a7e9d31128ef98d3e96133fe454c16ef630574d967dfdb1a"
-        },
         "ommers": [],
         "withdrawals": [],
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
@@ -269,10 +249,6 @@ TEST(statetest_loader, block_info_parent_blob_gas)
             "currentBaseFee": "7",
             "currentRandom": "0x00",
             "withdrawals": [],
-            "blockHashes": {
-                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
-                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
-            },
             "parentExcessBlobGas": "1",
             "parentBlobGasUsed": "0x60000"
         })";
@@ -284,10 +260,6 @@ TEST(statetest_loader, block_info_parent_blob_gas)
     EXPECT_EQ(bi.base_fee, 7);
     EXPECT_EQ(bi.timestamp, 0);
     EXPECT_EQ(bi.number, 0);
-    EXPECT_EQ(bi.known_block_hashes.at(0),
-        0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
-    EXPECT_EQ(bi.known_block_hashes.at(1),
-        0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
     EXPECT_EQ(bi.excess_blob_gas, 1);
 }
 
@@ -302,10 +274,6 @@ TEST(statetest_loader, block_info_current_blob_gas)
             "currentBaseFee": "7",
             "currentRandom": "0x00",
             "withdrawals": [],
-            "blockHashes": {
-                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
-                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
-            },
             "currentExcessBlobGas": "2"
         })";
 
@@ -316,10 +284,6 @@ TEST(statetest_loader, block_info_current_blob_gas)
     EXPECT_EQ(bi.base_fee, 7);
     EXPECT_EQ(bi.timestamp, 0);
     EXPECT_EQ(bi.number, 0);
-    EXPECT_EQ(bi.known_block_hashes.at(0),
-        0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
-    EXPECT_EQ(bi.known_block_hashes.at(1),
-        0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
     EXPECT_EQ(bi.excess_blob_gas, 2);
 }
 
@@ -335,4 +299,17 @@ TEST(statetest_loader, block_info_parent_beacon_block_root)
 
     const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
     EXPECT_EQ(bi.parent_beacon_block_root, 0xbeac045007_bytes32);
+}
+
+TEST(statetest_loader, block_hashes)
+{
+    constexpr std::string_view input = R"({
+            "blockHashes": {
+                "0" : "0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e",
+                "1" : "0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b"
+            }})";
+
+    const auto bh = test::from_json<test::TestBlockHashes>(json::json::parse(input));
+    EXPECT_EQ(bh.at(0), 0xe729de3fec21e30bea3d56adb01ed14bc107273c2775f9355afb10f594a10d9e_bytes32);
+    EXPECT_EQ(bh.at(1), 0xb5eee60b45801179cbde3781b9a5dee9b3111554618c9cda3d6f7e351fd41e0b_bytes32);
 }


### PR DESCRIPTION
This removes `.known_block_hashes` from `state::BlockInfo`. Block hashes in tests are now provided by `TestBlockHashes`.

The main goal here is to remove test-only fields from `state::BlockInfo`.