### PR TITLE
vm: Allow for tracers removal

### DIFF
--- a/lib/evmone/vm.hpp
+++ b/lib/evmone/vm.hpp
@@ -41,6 +41,8 @@ public:
         *end = std::move(tracer);
     }
 
+    void remove_tracers() noexcept { m_first_tracer.reset(); }
+
     [[nodiscard]] Tracer* get_tracer() const noexcept { return m_first_tracer.get(); }
 };
 }  // namespace evmone

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -125,6 +125,23 @@ TEST_F(tracing, three_tracers)
     EXPECT_EQ(trace(dup1(0)), "A0:PUSH1 B0:PUSH1 C0:PUSH1 A2:DUP1 B2:DUP1 C2:DUP1 ");
 }
 
+TEST_F(tracing, tracer_removed)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, ""));
+    vm.remove_tracers();
+
+    EXPECT_EQ(vm.get_tracer(), nullptr);
+}
+
+TEST_F(tracing, tracers_removed)
+{
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "A"));
+    vm.add_tracer(std::make_unique<OpcodeTracer>(*this, "B"));
+    vm.remove_tracers();
+
+    EXPECT_EQ(vm.get_tracer(), nullptr);
+}
+
 TEST_F(tracing, histogram)
 {
     vm.add_tracer(evmone::create_histogram_tracer(trace_stream));


### PR DESCRIPTION
Add `VM::remove_tracers()` method to remove all registered tracers.
