### PR TITLE
t8n: Include empty requests[Hash] in JSON output - hardcoded

### DIFF
--- a/test/integration/t8n/CMakeLists.txt
+++ b/test/integration/t8n/CMakeLists.txt
@@ -57,3 +57,38 @@ set_tests_properties(
     FIXTURES_CLEANUP ${TEST_CASE}
     PASS_REGULAR_EXPRESSION ${EXPECTED_OUT_ALLOC}
 )
+
+set(TEST_CASE osaka_empty_requests)
+
+add_test(
+    NAME ${PREFIX}/${TEST_CASE}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_CASE}
+    COMMAND
+    evmone-t8n
+    --state.fork Osaka
+    --state.reward 0
+    --state.chainid 1
+    --input.alloc alloc.json
+    --input.txs txs.json
+    --input.env env.json
+    --output.basedir ${CMAKE_CURRENT_BINARY_DIR}/${TEST_CASE}
+    --output.result out.json
+)
+set_tests_properties(${PREFIX}/${TEST_CASE} PROPERTIES FIXTURES_REQUIRED ${TEST_CASE})
+
+add_test(
+    NAME ${PREFIX}/${TEST_CASE}/out.json
+    COMMAND ${CMAKE_COMMAND} -E cat ${CMAKE_CURRENT_BINARY_DIR}/${TEST_CASE}/out.json
+)
+string(
+    JOIN ".*" EXPECTED_OUT
+    # empty requests list of exactly 3 elements (withdrawals, deposits, consolidations)
+    [=["requests": \[[^],]*"0x",[^],]*"0x",[^],]*"0x"[^,]*\]]=]
+    # requests hash should be present
+    [=["requestsHash": "0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f"]=]
+)
+set_tests_properties(
+    ${PREFIX}/${TEST_CASE}/out.json PROPERTIES
+    FIXTURES_CLEANUP ${TEST_CASE}
+    PASS_REGULAR_EXPRESSION ${EXPECTED_OUT}
+)

--- a/test/integration/t8n/osaka_empty_requests/alloc.json
+++ b/test/integration/t8n/osaka_empty_requests/alloc.json
@@ -1,0 +1,7 @@
+{
+  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+    "code": "",
+    "nonce": "0x00",
+    "balance": "0x02540be400"
+  }
+}

--- a/test/integration/t8n/osaka_empty_requests/env.json
+++ b/test/integration/t8n/osaka_empty_requests/env.json
@@ -1,0 +1,6 @@
+{
+    "currentCoinbase": "0x8888f1f195afa192cfee860698584c030f4c9db1",
+    "currentNumber": "0x01",
+    "currentTimestamp": "0x54c99069",
+    "currentGasLimit": "0x2fefd8"
+}

--- a/test/integration/t8n/osaka_empty_requests/txs.json
+++ b/test/integration/t8n/osaka_empty_requests/txs.json
@@ -1,0 +1,15 @@
+[
+  {
+    "to": null,
+    "input": "0x",
+    "gas": "0x186a0",
+    "nonce": "0x0",
+    "value": "0x0",
+    "gasPrice": "0x32",
+    "chainId": "0x1",
+    "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+    "v": "0x1b",
+    "r": "0x468a915f087692bb9be503831a3dfef2cf9c8dee26deb40ff2ec99e8d22665ae",
+    "s": "0x5cedae0810c3851ecd1004bfdbfe6ddc7753c2d665993bb01ce75af7857b13dc"
+  }
+]

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -241,7 +241,13 @@ int main(int argc, const char* argv[])
         if (rev >= EVMC_PRAGUE)
         {
             // EIP-7685: General purpose execution layer requests
-            j_result["requestsRoot"] = hex0x(state::EMPTY_MPT_HASH);
+            j_result["requests"] = json::json::array();
+            // TODO: actual requests should be used in the following lines, for now all empty.
+            j_result["requests"][0] = "0x";
+            j_result["requests"][1] = "0x";
+            j_result["requests"][2] = "0x";
+            j_result["requestsHash"] =
+                "0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f";
         }
 
         std::ofstream{output_dir / output_result_file} << std::setw(2) << j_result;


### PR DESCRIPTION
Hardcoded version of #1064 

Fixes #1062 

If the sha256 refactor from #1064 is not useful, we can just roll with this