### PR TITLE
test: Use newer --benchmark_min_time=1x

### DIFF
--- a/test/bench/CMakeLists.txt
+++ b/test/bench/CMakeLists.txt
@@ -30,9 +30,9 @@ add_test(NAME ${PREFIX}/dirname_empty COMMAND evmone-bench "" --benchmark_list_t
 set_tests_properties(${PREFIX}/dirname_empty PROPERTIES PASS_REGULAR_EXPRESSION "total/synth")
 
 # Run all benchmark cases split into groups to check if none of them crashes.
-add_test(NAME ${PREFIX}/synth COMMAND evmone-bench --benchmark_min_time=0 --benchmark_filter=synth)
-add_test(NAME ${PREFIX}/micro COMMAND evmone-bench --benchmark_min_time=0 --benchmark_filter=micro ${BENCHMARK_SUITE_DIR})
-add_test(NAME ${PREFIX}/main/b COMMAND evmone-bench --benchmark_min_time=0 --benchmark_filter=main/[b] ${BENCHMARK_SUITE_DIR})
-add_test(NAME ${PREFIX}/main/s COMMAND evmone-bench --benchmark_min_time=0 --benchmark_filter=main/[s] ${BENCHMARK_SUITE_DIR})
-add_test(NAME ${PREFIX}/main/w COMMAND evmone-bench --benchmark_min_time=0 --benchmark_filter=main/[w] ${BENCHMARK_SUITE_DIR})
-add_test(NAME ${PREFIX}/main/_ COMMAND evmone-bench --benchmark_min_time=0 --benchmark_filter=main/[^bsw] ${BENCHMARK_SUITE_DIR})
+add_test(NAME ${PREFIX}/synth COMMAND evmone-bench --benchmark_min_time=1x --benchmark_filter=synth)
+add_test(NAME ${PREFIX}/micro COMMAND evmone-bench --benchmark_min_time=1x --benchmark_filter=micro ${BENCHMARK_SUITE_DIR})
+add_test(NAME ${PREFIX}/main/b COMMAND evmone-bench --benchmark_min_time=1x --benchmark_filter=main/[b] ${BENCHMARK_SUITE_DIR})
+add_test(NAME ${PREFIX}/main/s COMMAND evmone-bench --benchmark_min_time=1x --benchmark_filter=main/[s] ${BENCHMARK_SUITE_DIR})
+add_test(NAME ${PREFIX}/main/w COMMAND evmone-bench --benchmark_min_time=1x --benchmark_filter=main/[w] ${BENCHMARK_SUITE_DIR})
+add_test(NAME ${PREFIX}/main/_ COMMAND evmone-bench --benchmark_min_time=1x --benchmark_filter=main/[^bsw] ${BENCHMARK_SUITE_DIR})


### PR DESCRIPTION
We are executing all available benchmarks to detect problems in tools and benchmark inputs. Use newer options --benchmark_min_time=1x to execute each benchmark exactly once.