### PR TITLE
state: Separate transaction validation from transition

### DIFF
--- a/test/state/state.hpp
+++ b/test/state/state.hpp
@@ -137,11 +137,17 @@ public:
     const address& coinbase, std::optional<uint64_t> block_reward, std::span<const Ommer> ommers,
     std::span<const Withdrawal> withdrawals);
 
-[[nodiscard]] std::variant<TransactionReceipt, std::error_code> transition(const StateView& state,
-    const BlockInfo& block, const BlockHashes& block_hashes, const Transaction& tx,
-    evmc_revision rev, evmc::VM& vm, int64_t block_gas_left, int64_t blob_gas_left);
+/// Executes a valid transaction.
+///
+/// @return Transaction receipt with state diff.
+TransactionReceipt transition(const StateView& state, const BlockInfo& block,
+    const BlockHashes& block_hashes, const Transaction& tx, evmc_revision rev, evmc::VM& vm,
+    int64_t execution_gas_limit);
 
-std::variant<int64_t, std::error_code> validate_transaction(const Account& sender_acc,
-    const BlockInfo& block, const Transaction& tx, evmc_revision rev, int64_t block_gas_left,
-    int64_t blob_gas_left) noexcept;
+/// Validate a transaction.
+///
+/// @return Computed execution gas limit or validation error.
+[[nodiscard]] std::variant<int64_t, std::error_code> validate_transaction(
+    const StateView& state_view, const BlockInfo& block, const Transaction& tx, evmc_revision rev,
+    int64_t block_gas_left, int64_t blob_gas_left) noexcept;
 }  // namespace evmone::state

--- a/test/unittests/state_tx_test.cpp
+++ b/test/unittests/state_tx_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <test/state/errors.hpp>
 #include <test/state/state.hpp>
+#include <test/state/test_state.hpp>
 #include <test/utils/utils.hpp>
 
 using namespace evmc::literals;
@@ -18,7 +19,6 @@ TEST(state_tx, validate_nonce)
         .prev_randao = {},
         .base_fee = 0x0a,
         .withdrawals = {}};
-    const Account acc{.nonce = 1, .balance = 0xe8d4a51000};
     Transaction tx{
         .data = {},
         .gas_limit = 60000,
@@ -32,17 +32,18 @@ TEST(state_tx, validate_nonce)
         .r = 0,
         .s = 0,
     };
+    const TestState state{{tx.sender, {.nonce = 1, .balance = 0xe8d4a51000}}};
 
     ASSERT_FALSE(holds_alternative<std::error_code>(
-        validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0)));
+        validate_transaction(state, bi, tx, EVMC_BERLIN, 60000, 0)));
 
     tx.nonce = 0;
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0))
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_BERLIN, 60000, 0))
                   .message(),
         "nonce too low");
 
     tx.nonce = 2;
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0))
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_BERLIN, 60000, 0))
                   .message(),
         "nonce too high");
 }
@@ -54,7 +55,6 @@ TEST(state_tx, validate_sender)
         .prev_randao = {},
         .base_fee = 0,
         .withdrawals = {}};
-    const Account acc{.nonce = 0, .balance = 0};
     Transaction tx{
         .data = {},
         .gas_limit = 60000,
@@ -68,19 +68,20 @@ TEST(state_tx, validate_sender)
         .r = 0,
         .s = 0,
     };
+    const TestState state{{tx.sender, {.nonce = 0, .balance = 0}}};
 
     ASSERT_FALSE(holds_alternative<std::error_code>(
-        validate_transaction(acc, bi, tx, EVMC_BERLIN, 60000, 0)));
+        validate_transaction(state, bi, tx, EVMC_BERLIN, 60000, 0)));
 
     bi.base_fee = 1;
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000, 0))
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_LONDON, 60000, 0))
                   .message(),
         "max fee per gas less than block base fee");
 
     tx.max_gas_price = bi.base_fee;
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_LONDON, 60000, 0))
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_LONDON, 60000, 0))
                   .message(),
         "insufficient funds for gas * price + value");
 }
@@ -88,7 +89,6 @@ TEST(state_tx, validate_sender)
 TEST(state_tx, validate_blob_tx)
 {
     const BlockInfo bi{.gas_limit = 0x989680, .base_fee = 1, .blob_base_fee = 1};
-    const Account acc{.nonce = 0, .balance = 1000000};
     Transaction tx{
         .type = Transaction::Type::blob,
         .gas_limit = 60000,
@@ -96,19 +96,20 @@ TEST(state_tx, validate_blob_tx)
         .sender = 0x02_address,
         .to = {},
     };
+    const TestState state{{tx.sender, {.nonce = 0, .balance = 1000000}}};
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_SHANGHAI, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_SHANGHAI, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
                   .message(),
         make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED).message());
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
                   .message(),
         make_error_code(ErrorCode::CREATE_BLOB_TX).message());
 
     tx.to = 0x01_address;
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
                   .message(),
         make_error_code(ErrorCode::EMPTY_BLOB_HASHES_LIST).message());
@@ -126,7 +127,7 @@ TEST(state_tx, validate_blob_tx)
     tx.blob_hashes.push_back(
         0x0100000000000000000000000000000000000000000000000000000000000006_bytes32);
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
                   .message(),
         make_error_code(ErrorCode::FEE_CAP_LESS_THEN_BLOCKS).message());
@@ -134,23 +135,23 @@ TEST(state_tx, validate_blob_tx)
     tx.max_blob_gas_price = 1;
     tx.blob_hashes.push_back(
         0x0100000000000000000000000000000000000000000000000000000000000007_bytes32);
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
                   .message(),
         make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED).message());
 
     tx.blob_hashes.pop_back();
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK - 1))
                   .message(),
         make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED).message());
 
     EXPECT_EQ(std::get<int64_t>(validate_transaction(
-                  acc, bi, tx, EVMC_CANCUN, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)),
+                  state, bi, tx, EVMC_CANCUN, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)),
         39000);
 
     tx.blob_hashes[0] = 0x0200000000000000000000000000000000000000000000000000000000000001_bytes32;
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000,
+    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
                                             BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
                   .message(),
         make_error_code(ErrorCode::INVALID_BLOB_HASH_VERSION).message());
@@ -163,7 +164,6 @@ TEST(state_tx, validate_data)
         .prev_randao = {},
         .base_fee = 0x0a,
         .withdrawals = {}};
-    const Account acc{.nonce = 1, .balance = 0xe8d4a51000};
     const Transaction tx{
         .data = "EF00 01 010004 0200010001 030004 00 00000000 00 AABBCCDD"_hex,
         .gas_limit = 60000,
@@ -177,9 +177,10 @@ TEST(state_tx, validate_data)
         .r = 0,
         .s = 0,
     };
+    const TestState state{{tx.sender, {.nonce = 1, .balance = 0xe8d4a51000}}};
 
-    ASSERT_FALSE(holds_alternative<std::error_code>(
-        validate_transaction(acc, bi, tx, EVMC_CANCUN, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)));
-    ASSERT_FALSE(holds_alternative<std::error_code>(
-        validate_transaction(acc, bi, tx, EVMC_PRAGUE, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)));
+    ASSERT_FALSE(holds_alternative<std::error_code>(validate_transaction(
+        state, bi, tx, EVMC_CANCUN, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)));
+    ASSERT_FALSE(holds_alternative<std::error_code>(validate_transaction(
+        state, bi, tx, EVMC_PRAGUE, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)));
 }


### PR DESCRIPTION
This change separates transaction validation in
`state::validate_transaction()` from `state::transition()` which previously was also validating the transaction.

Readability goes up in cost of slightly lower efficiency. The change is also good for API because transaction validation usually happens in different place than execution.