### PR TITLE
host: Skip execution of empty code

### DIFF
--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -440,6 +440,9 @@ evmc::Result Host::execute_message(const evmc_message& msg) noexcept
 
     // TODO: get_code() performs the account lookup. Add a way to get an account with code?
     const auto code = m_state.get_code(msg.code_address);
+    if (code.empty())
+        return evmc::Result{EVMC_SUCCESS, msg.gas};  // Skip trivial execution.
+
     return m_vm.execute(*this, m_rev, msg, code.data(), code.size());
 }
 


### PR DESCRIPTION
In the Host inspect the code address and skip execution if the code is empty.

This help with Silkworm performance because there are a lot of ETH transfers between EOAs.