### PR TITLE
state: Fix usage of hash256 alias

### DIFF
--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -67,7 +67,7 @@ struct Log
 {
     address addr;
     bytes data;
-    std::vector<hash256> topics;
+    std::vector<bytes32> topics;
 };
 
 /// Transaction Receipt


### PR DESCRIPTION
Although the `hash256` is alias for `bytes32`, it is not defined in transaction.hpp so use `bytes32` instead.