### PR TITLE
build: Bump hunter to v0.25.8

### DIFF
--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -8,7 +8,7 @@ set(HUNTER_USE_CACHE_SERVERS NO CACHE STRING "Download binaries from Hunter cach
 include(HunterGate)
 
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.25.3.tar.gz"
-    SHA1 "0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.25.8.tar.gz"
+    SHA1 "26c79d587883ec910bce168e25f6ac4595f97033"
     LOCAL
 )


### PR DESCRIPTION
as title, I was getting this:

https://app.circleci.com/pipelines/github/ethereum/evmone/7895/workflows/db9b6ae2-d982-4eb4-8e27-59aa86705862/jobs/121408

without.

```
**********************************************************************
** Visual Studio 2022 Developer PowerShell v17.12.3
** Copyright (c) 2022 Microsoft Corporation
**********************************************************************
/c/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/bin/cmake
-- [cable ] Cable 0.5.0 initialized
-- Build type: Release
-- [hunter] Initializing Hunter workspace (0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb)
-- [hunter]   https://github.com/cpp-pm/hunter/archive/v0.25.3.tar.gz
-- [hunter]   -> C:/Users/circleci/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c
-- The CXX compiler identification is MSVC 19.42.34435.0
-- The C compiler identification is MSVC 19.42.34435.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- [hunter] Calculating Toolchain-SHA1
-- [hunter] Calculating Config-SHA1
-- [hunter] HUNTER_ROOT: C:/Users/circleci/.hunter
-- [hunter] [ Hunter-ID: 0dfbc2c | Toolchain-ID: 03fe3b1 | Config-ID: bc4e752 ]

[hunter ** INTERNAL **] Unexpected MSVC_VERSION: '1942'
```

Notably VS versions got bumpted