### PR TITLE
tests: Enable invalid block blockchain tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -361,8 +361,11 @@ jobs:
       - run:
           name: "Execution spec tests (blockchain_tests)"
           working_directory: ~/build
+          # 4844 and 4788 temporarily turned off b/c they rely on blob features.
           command: >
-            bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
+            bin/evmone-blockchaintest
+            --gtest_filter='*:-*eip4844*:*eip4788*'
+            ~/spec-tests/fixtures/blockchain_tests
       - download_execution_spec_tests:
           release: pectra-devnet-4@v1.0.1
           fixtures_suffix: pectra-devnet-4
@@ -402,8 +405,10 @@ jobs:
       - run:
           name: "EOF pre-release execution spec tests (blockchain_tests)"
           working_directory: ~/build
+          # 4844 and 4788 temporarily turned off b/c they rely on blob features.
           command: >
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests/osaka
+            --gtest_filter='*:-*stEIP4844*'
       - run:
           name: "EOF pre-release execution spec tests (eof_tests)"
           working_directory: ~/build
@@ -438,16 +443,18 @@ jobs:
       - run:
           name: "Blockchain tests (GeneralStateTests)"
           working_directory: ~/build
+          # 4844 and 4788 temporarily turned off b/c they rely on blob features.
           command: >
             bin/evmone-blockchaintest
-            --gtest_filter='*:-VMTests/vmPerformance.*:*.*Call50000_sha256:*.CALLBlake2f_MaxRounds'
+            --gtest_filter='*:-VMTests/vmPerformance.*:*.*Call50000_sha256:*.CALLBlake2f_MaxRounds:*eip4844*:*stEIP4844*:*eip4788*'
             ~/tests/BlockchainTests/GeneralStateTests
       - run:
           name: "Blockchain tests (ValidBlocks)"
           working_directory: ~/build
+          # 4844 and 4788 temporarily turned off b/c they rely on blob features.
           command: >
             bin/evmone-blockchaintest
-            --gtest_filter='*:-bcMultiChainTest.*:bcTotalDifficultyTest.*:bcForkStressTest.ForkStressTest:bcGasPricerTest.RPC_API_Test:bcValidBlockTest.SimpleTx3LowS'
+            --gtest_filter='*:-bcMultiChainTest.*:bcTotalDifficultyTest.*:bcForkStressTest.ForkStressTest:bcGasPricerTest.RPC_API_Test:bcValidBlockTest.SimpleTx3LowS:*bcEIP4844*'
             ~/tests/BlockchainTests/ValidBlocks
             ~/tests/LegacyTests/Cancun/BlockchainTests/ValidBlocks
       - collect_coverage_gcc

--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -47,6 +47,7 @@ struct TestBlock
 {
     state::BlockInfo block_info;
     std::vector<state::Transaction> transactions;
+    bool valid = true;
 
     BlockHeader expected_block_header;
 };

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -73,18 +73,6 @@ static TestBlock load_test_block(const json::json& j, evmc_revision rev)
         }
     }
 
-    if (const auto it = j.find("expectException"); it != j.end())
-    {
-        // TODO: Add support for invalid blocks.
-        throw UnsupportedTestFeature("tests with invalid blocks are not supported");
-    }
-
-    if (const auto it = j.find("transactionSequence"); it != j.end())
-    {
-        // TODO: Add support for invalid blocks.
-        throw UnsupportedTestFeature("tests with invalid transactions are not supported");
-    }
-
     if (const auto it = j.find("uncleHeaders"); it != j.end())
     {
         const auto current_block_number = tb.block_info.number;
@@ -124,7 +112,25 @@ BlockchainTest load_blockchain_test_case(const std::string& name, const json::js
     bt.rev = to_rev_schedule(j.at("network").get<std::string>());
 
     for (const auto& el : j.at("blocks"))
-        bt.test_blocks.emplace_back(load_test_block(el, bt.rev.get_revision(0)));
+    {
+        if (const auto it = el.find("expectException"); it != el.end())
+        {
+            // `rlp_decoded` holds the `FixtureBlock` element with the relevant block data for
+            // invalid blocks within a test. It should be a sibling element to `expectException`.
+
+            // TODO: Add support for invalidly rlp-encoded blocks, which do
+            // not have `rlp_decoded`.
+            if (!el.contains("rlp_decoded"))
+                throw UnsupportedTestFeature(
+                    "tests with invalidly rlp-encoded blocks are not supported");
+
+            auto test_block = load_test_block(el.at("rlp_decoded"), bt.rev.get_revision(0));
+            test_block.valid = false;
+            bt.test_blocks.emplace_back(test_block);
+        }
+        else
+            bt.test_blocks.emplace_back(load_test_block(el, bt.rev.get_revision(0)));
+    }
 
     bt.expectation.last_block_hash = from_json<hash256>(j.at("lastblockhash"));
 

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -300,7 +300,8 @@ TestState from_json<TestState>(const json::json& j)
 /// Load common parts of Transaction or TestMultiTransaction.
 static void from_json_tx_common(const json::json& j, state::Transaction& o)
 {
-    o.sender = from_json<evmc::address>(j.at("sender"));
+    // `sender` is not provided for transactions in invalid blocks.
+    o.sender = load_if_exists<evmc::address>(j, "sender");
     o.nonce = from_json<uint64_t>(j.at("nonce"));
 
     if (const auto chain_id_it = j.find("chainId"); chain_id_it != j.end())


### PR DESCRIPTION
I took the liberty to coarsely disable 4844 (and 4788) blockchain tests across the board, as they will be re-enabled in #1077, which needs to be rebased on top of these changes (invalid block blockchain tests handling in that branch is currently not complete!).

Before merging I'll squash the 1st and last commits together, they aim at the same thing.

Note, that a next step would be to respect the `expectException` field from the test and only accept specific reasons for block invalidity. For now I only handle valid-invalid.