### PR TITLE
Get rid of extra requests data copying when calculating requests hash

### DIFF
--- a/test/state/requests.cpp
+++ b/test/state/requests.cpp
@@ -24,10 +24,9 @@ hash256 calculate_requests_hash(std::span<const Requests> block_requests_list)
         //        if (requests.data.empty())
         //            continue;
 
-        const bytes requests_bytes = static_cast<uint8_t>(requests.type) + requests.data;
         hash256 requests_hash;
         crypto::sha256(reinterpret_cast<std::byte*>(requests_hash.bytes),
-            reinterpret_cast<const std::byte*>(requests_bytes.data()), requests_bytes.size());
+            reinterpret_cast<const std::byte*>(requests.raw_data.data()), requests.raw_data.size());
         requests_hash_list += requests_hash;
     }
 
@@ -78,11 +77,11 @@ Requests collect_deposit_requests(std::span<const TransactionReceipt> receipts)
                 // Index is padded to word boundary, so takes 32 bytes.
                 assert(log.data.size() == INDEX_OFFSET + 32);
 
-                requests.data.append(&log.data[PUBKEY_OFFSET], PUBKEY_SIZE);
-                requests.data.append(&log.data[WITHDRAWAL_CREDS_OFFSET], WITHDRAWAL_CREDS_SIZE);
-                requests.data.append(&log.data[AMOUNT_OFFSET], AMOUNT_SIZE);
-                requests.data.append(&log.data[SIGNATURE_OFFSET], SIGNATURE_SIZE);
-                requests.data.append(&log.data[INDEX_OFFSET], INDEX_SIZE);
+                requests.append({&log.data[PUBKEY_OFFSET], PUBKEY_SIZE});
+                requests.append({&log.data[WITHDRAWAL_CREDS_OFFSET], WITHDRAWAL_CREDS_SIZE});
+                requests.append({&log.data[AMOUNT_OFFSET], AMOUNT_SIZE});
+                requests.append({&log.data[SIGNATURE_OFFSET], SIGNATURE_SIZE});
+                requests.append({&log.data[INDEX_OFFSET], INDEX_SIZE});
             }
         }
     }

--- a/test/state/requests.hpp
+++ b/test/state/requests.hpp
@@ -34,14 +34,24 @@ struct Requests
         consolidation = 2,
     };
 
-    /// Requests type.
-    Type type = Type::deposit;
-    /// Requests data - an opaque byte array, contains zero or more encoded request objects.
-    evmc::bytes data;
+    /// Raw encoded data of requests object: first byte is type, the rest is request objects.
+    evmc::bytes raw_data;
 
-    explicit Requests(Type _type, evmc::bytes _data = {}) noexcept
-      : type(_type), data(std::move(_data))
-    {}
+    explicit Requests(Type _type, evmc::bytes_view data = {})
+    {
+        raw_data.reserve(1 + data.size());
+        raw_data += static_cast<uint8_t>(_type);
+        raw_data += data;
+    }
+
+    /// Requests type.
+    Type type() const noexcept { return static_cast<Type>(raw_data[0]); }
+
+    /// Requests data - an opaque byte array, contains zero or more encoded request objects.
+    evmc::bytes_view data() const noexcept { return {raw_data.data() + 1, raw_data.size() - 1}; }
+
+    /// Append data to requests object byte array.
+    void append(bytes_view data) { raw_data.append(data); }
 };
 
 /// Calculate commitment value of block requests list

--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -99,7 +99,7 @@ std::pair<StateDiff, std::vector<Requests>> system_call(
         Host host{rev, vm, state, block, block_hashes, empty_tx};
         const auto res = vm.execute(host, rev, msg, code.data(), code.size());
         assert(res.status_code == EVMC_SUCCESS);
-        requests.emplace_back(request_type, bytes(res.output_data, res.output_size));
+        requests.emplace_back(request_type, bytes_view{res.output_data, res.output_size});
     }
 
     // TODO: Should we return empty diff if no system contracts?

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -255,7 +255,7 @@ int main(int argc, const char* argv[])
             // EIP-7685: General purpose execution layer requests
             j_result["requests"] = json::json::array();
             for (size_t i = 0; i < requests.size(); ++i)
-                j_result["requests"][i] = hex0x(requests[i].data);
+                j_result["requests"][i] = hex0x(requests[i].data());
 
             auto requests_hash = calculate_requests_hash(requests);
 

--- a/test/unittests/state_system_call_test.cpp
+++ b/test/unittests/state_system_call_test.cpp
@@ -88,10 +88,10 @@ TEST_F(state_system_call, withdrawal)
     EXPECT_EQ(storage.at(0x01_bytes32), 0x01_bytes32);
 
     ASSERT_EQ(requests.size(), 2);
-    EXPECT_EQ(requests[0].type, Requests::Type::withdrawal);
-    EXPECT_EQ(requests[0].data, bytes(WITHDRAWAL_REQUEST));
-    EXPECT_EQ(requests[1].type, Requests::Type::consolidation);
-    EXPECT_TRUE(requests[1].data.empty());
+    EXPECT_EQ(requests[0].type(), Requests::Type::withdrawal);
+    EXPECT_EQ(requests[0].data(), bytes(WITHDRAWAL_REQUEST));
+    EXPECT_EQ(requests[1].type(), Requests::Type::consolidation);
+    EXPECT_TRUE(requests[1].data().empty());
 }
 
 TEST_F(state_system_call, consolidation)
@@ -112,8 +112,8 @@ TEST_F(state_system_call, consolidation)
     EXPECT_EQ(storage.at(0x01_bytes32), 0x01_bytes32);
 
     ASSERT_EQ(requests.size(), 2);
-    EXPECT_EQ(requests[0].type, Requests::Type::withdrawal);
-    EXPECT_TRUE(requests[0].data.empty());
-    EXPECT_EQ(requests[1].type, Requests::Type::consolidation);
-    EXPECT_EQ(requests[1].data, bytes(CONSOLIDATION_REQUEST));
+    EXPECT_EQ(requests[0].type(), Requests::Type::withdrawal);
+    EXPECT_TRUE(requests[0].data().empty());
+    EXPECT_EQ(requests[1].type(), Requests::Type::consolidation);
+    EXPECT_EQ(requests[1].data(), bytes(CONSOLIDATION_REQUEST));
 }


### PR DESCRIPTION
Change Requests representation to byte array of type + requests data.

Closes #1086 