### PR TITLE
Update Blockhash History system contract address (EIP-2935)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -365,17 +365,6 @@ jobs:
           command: >
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
       - download_execution_spec_tests:
-          release: pectra-devnet-4@v1.0.1
-          fixtures_suffix: pectra-devnet-4
-      - run:
-          name: "Execution spec tests (develop, blockchain_tests) - pectra-devnet-4"
-          # Tests for in-development EVM revision currently passing.
-          working_directory: ~/spec-tests/fixtures/blockchain_tests
-          command: >
-            ~/build/bin/evmone-blockchaintest
-            prague/eip2935_historical_block_hashes_from_state
-            prague/eip7685_general_purpose_el_requests
-      - download_execution_spec_tests:
           release: pectra-devnet-5@v1.2.0
           fixtures_suffix: pectra-devnet-5
       - run:
@@ -412,13 +401,14 @@ jobs:
           working_directory: ~/build
           command: >
             bin/evmone-statetest ~/spec-tests/fixtures/state_tests/osaka
-      - run:
-          name: "EOF pre-release execution spec tests (blockchain_tests)"
-          working_directory: ~/build
-          command: >
-            bin/evmone-blockchaintest
-            --gtest_filter='-eofwrap/*'
-            ~/spec-tests/fixtures/blockchain_tests/osaka
+      # TODO: EOF blockchain tests are not yet compatible with pectra-devnet-5.
+      # - run:
+      #     name: "EOF pre-release execution spec tests (blockchain_tests)"
+      #     working_directory: ~/build
+      #     command: >
+      #       bin/evmone-blockchaintest
+      #       --gtest_filter='-eofwrap/*'
+      #       ~/spec-tests/fixtures/blockchain_tests/osaka
       - run:
           name: "EOF pre-release execution spec tests (eof_tests)"
           working_directory: ~/build

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -17,7 +17,7 @@ constexpr auto SYSTEM_ADDRESS = 0xfffffffffffffffffffffffffffffffffffffffe_addre
 constexpr auto BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address;
 
 /// The address of the system contract storing historical block hashes (EIP-2935).
-constexpr auto HISTORY_STORAGE_ADDRESS = 0x0aae40965e6800cd9b1f4b05ff21581047e3f91e_address;
+constexpr auto HISTORY_STORAGE_ADDRESS = 0x0F792be4B0c0cb4DAE440Ef133E90C0eCD48CCCC_address;
 
 /// The address of the system contract processing EL-triggerable withdrawals (EIP-7002).
 constexpr auto WITHDRAWAL_REQUEST_ADDRESS = 0x09Fc772D0857550724b07B850a4323f39112aAaA_address;


### PR DESCRIPTION
The [pectra-devnet-5 specs] includes an [update to EIP-2935]'s system contract and its address.

To pass blockchain tests the https://github.com/ethereum/evmone/pull/1094 is required, but we are going to merge this change first.

[pectra-devnet-5 specs]: https://notes.ethereum.org/@ethpandaops/pectra-devnet-5
[update to EIP-2935]: https://github.com/ethereum/EIPs/pull/9144