### PR TITLE
Exclude empty requests data in commitment (EIP-7685)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -378,11 +378,13 @@ jobs:
       - run:
           name: "Execution spec tests (develop, blockchain_tests)"
           # Tests for in-development EVM revision currently passing.
-          # TODO: Just a single example that happens to work.
           working_directory: ~/spec-tests/fixtures/blockchain_tests
           command: >
             ~/build/bin/evmone-blockchaintest
-            prague/eip2537_bls_12_381_precompiles/bls12_precompiles_before_fork
+            --gtest_filter='-*block_hashes.block_hashes_history'
+            prague/eip2537_bls_12_381_precompiles
+            prague/eip2935_historical_block_hashes_from_state
+            prague/eip6110_deposits
       - collect_coverage_gcc
       - upload_coverage:
           flags: execution_spec_tests

--- a/test/integration/t8n/CMakeLists.txt
+++ b/test/integration/t8n/CMakeLists.txt
@@ -146,10 +146,10 @@ add_test(
 )
 string(
     JOIN ".*" EXPECTED_OUT
-    # empty requests list of exactly 3 elements (withdrawals, deposits, consolidations)
-    [=["requests": \[[^],]*"0x",[^],]*"0x",[^],]*"0x"[^,]*\]]=]
+    # empty requests list
+    [=["requests": \[\]]=]
     # requests hash should be present
-    [=["requestsHash": "0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f"]=]
+    [=["requestsHash": "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"]=]
 )
 set_tests_properties(
     ${PREFIX}/${TEST_CASE}/out.json PROPERTIES

--- a/test/state/requests.cpp
+++ b/test/state/requests.cpp
@@ -20,9 +20,8 @@ hash256 calculate_requests_hash(std::span<const Requests> block_requests_list)
 
     for (const auto& requests : block_requests_list)
     {
-        // TODO recent change in the spec, uncomment for devnet-5
-        //        if (requests.data.empty())
-        //            continue;
+        if (requests.data().empty())
+            continue;  // Skip empty requests.
 
         hash256 requests_hash;
         crypto::sha256(reinterpret_cast<std::byte*>(requests_hash.bytes),

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -255,8 +255,12 @@ int main(int argc, const char* argv[])
         {
             // EIP-7685: General purpose execution layer requests
             j_result["requests"] = json::json::array();
-            for (size_t i = 0; i < requests.size(); ++i)
-                j_result["requests"][i] = hex0x(requests[i].data());
+            for (const auto& r : requests)
+            {
+                if (!r.data().empty())
+                    // Only report non-empty requests. Include the leading type byte.
+                    j_result["requests"].emplace_back(hex0x(r.raw_data));
+            }
 
             auto requests_hash = calculate_requests_hash(requests);
 


### PR DESCRIPTION
Apply the [EIP-7685 update] included in [pectra-devnet-5].

[EIP-7685 update]: https://github.com/ethereum/EIPs/pull/8989
[pectra-devnet-5]: https://notes.ethereum.org/@ethpandaops/pectra-devnet-5

This requires a fix in tests for calldata repricing logic according to https://github.com/ethereum/EIPs/pull/9227