### PR TITLE
Introduce "set code" (4) transaction type for EIP-7702

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -325,6 +325,11 @@ std::variant<TransactionProperties, std::error_code> validate_transaction(
 
     switch (tx.type)
     {
+    case Transaction::Type::set_code:
+        if (rev < EVMC_PRAGUE)
+            return make_error_code(TX_TYPE_NOT_SUPPORTED);
+        [[fallthrough]];
+
     case Transaction::Type::blob:
     case Transaction::Type::eip1559:
         if (rev < EVMC_LONDON)

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -36,6 +36,10 @@ struct Transaction
         /// The typed blob transaction (with array of blob hashes).
         /// Introduced by EIP-4844 https://eips.ethereum.org/EIPS/eip-4844.
         blob = 3,
+
+        /// The typed set code transaction (with authorization list).
+        /// Introduced by EIP-7702 https://eips.ethereum.org/EIPS/eip-7702.
+        set_code = 4,
     };
 
     /// Returns amount of blob gas used by this transaction

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -342,6 +342,10 @@ static void from_json_tx_common(const json::json& j, state::Transaction& o)
         for (const auto& hash : *it)
             o.blob_hashes.push_back(from_json<bytes32>(hash));
     }
+    else if (const auto au_it = j.find("authorizationList"); au_it != j.end())
+    {
+        o.type = state::Transaction::Type::set_code;
+    }
 }
 
 template <>


### PR DESCRIPTION
Intruduce new transaction type 4 "set code" from EIP-7702. This allows
us to recognize such transaction in tests prior full implementation.