### PR TITLE
test: Generate default comparison operator for CodeParams

### DIFF
--- a/test/bench/synthetic_benchmarks.cpp
+++ b/test/bench/synthetic_benchmarks.cpp
@@ -60,13 +60,9 @@ struct CodeParams
 {
     Opcode opcode;
     Mode mode;
-};
 
-/// The less-than comparison operator. Needed for std::map.
-[[maybe_unused]] inline constexpr bool operator<(const CodeParams& a, const CodeParams& b) noexcept
-{
-    return std::tuple(a.opcode, a.mode) < std::tuple(b.opcode, b.mode);
-}
+    friend auto operator<=>(const CodeParams&, const CodeParams&) = default;
+};
 
 std::string to_string(const CodeParams& params)
 {


### PR DESCRIPTION
Use C++20 ability to generate all comparison operators for the `CodeParams` benchmarking utility class.