### PR TITLE
tidy: Use ranges version of C++ algorithms

### DIFF
--- a/lib/evmone/baseline_analysis.cpp
+++ b/lib/evmone/baseline_analysis.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<uint8_t[]> pad_code(bytes_view code)
     constexpr auto padding = 32 + 1;
 
     auto padded_code = std::make_unique_for_overwrite<uint8_t[]>(code.size() + padding);
-    std::copy(std::begin(code), std::end(code), padded_code.get());
+    std::ranges::copy(code, padded_code.get());
     std::fill_n(&padded_code[code.size()], padding, uint8_t{OP_STOP});
     return padded_code;
 }

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -574,7 +574,7 @@ std::variant<EOFValidationError, int32_t> validate_max_stack_height(
         i = next;
     }
 
-    const auto max_stack_height_it = std::max_element(stack_heights.begin(), stack_heights.end(),
+    const auto max_stack_height_it = std::ranges::max_element(stack_heights,
         [](StackHeightRange lhs, StackHeightRange rhs) noexcept { return lhs.max < rhs.max; });
     return max_stack_height_it->max;
 }
@@ -670,8 +670,7 @@ EOFValidationError validate_eof1(
                 return EOFValidationError::invalid_max_stack_height;
         }
 
-        if (std::find(visited_code_sections.begin(), visited_code_sections.end(), false) !=
-            visited_code_sections.end())
+        if (std::ranges::find(visited_code_sections, false) != visited_code_sections.end())
             return EOFValidationError::unreachable_code_sections;
 
         // Check if truncated data section is allowed.

--- a/test/bench/bench.cpp
+++ b/test/bench/bench.cpp
@@ -58,7 +58,7 @@ std::vector<BenchmarkCase::Input> load_inputs(const StateTransitionTest& state_t
 BenchmarkCase load_benchmark(const fs::path& path, const std::string& name_prefix)
 {
     std::ifstream f{path};
-    auto state_test = std::move(evmone::test::load_state_tests(f).at(0));
+    auto state_test = std::move(load_state_tests(f).at(0));
 
     const auto name = name_prefix + path.stem().string();
     const auto code = state_test.pre_state.get(state_test.multi_tx.to.value()).code;
@@ -82,8 +82,8 @@ std::vector<BenchmarkCase> load_benchmarks_from_dir(  // NOLINT(misc-no-recursio
             code_files.emplace_back(e);
     }
 
-    std::sort(std::begin(subdirs), std::end(subdirs));
-    std::sort(std::begin(code_files), std::end(code_files));
+    std::ranges::sort(subdirs);
+    std::ranges::sort(code_files);
 
     std::vector<BenchmarkCase> benchmark_cases;
 

--- a/test/blockchaintest/blockchaintest.cpp
+++ b/test/blockchaintest/blockchaintest.cpp
@@ -54,7 +54,7 @@ void register_test_files(const fs::path& root, evmc::VM& vm)
             std::back_inserter(test_files), [](const fs::directory_entry& entry) {
                 return entry.is_regular_file() && entry.path().extension() == ".json";
             });
-        std::sort(test_files.begin(), test_files.end());
+        std::ranges::sort(test_files);
 
         for (const auto& p : test_files)
             register_test(fs::relative(p, root).parent_path().string(), p, vm);

--- a/test/eoftest/eoftest.cpp
+++ b/test/eoftest/eoftest.cpp
@@ -43,7 +43,7 @@ void register_test_files(const fs::path& root)
             std::back_inserter(test_files), [](const fs::directory_entry& entry) {
                 return entry.is_regular_file() && entry.path().extension() == ".json";
             });
-        std::sort(test_files.begin(), test_files.end());
+        std::ranges::sort(test_files);
 
         for (const auto& p : test_files)
             register_test(fs::relative(p, root).parent_path().string(), p);

--- a/test/state/bloom_filter.cpp
+++ b/test/state/bloom_filter.cpp
@@ -58,7 +58,7 @@ BloomFilter bloom_filter_from_bytes(const bytes_view& data) noexcept
 {
     assert(data.size() == 256);
     BloomFilter res;
-    std::copy(std::begin(data), std::end(data), std::begin(res.bytes));
+    std::ranges::copy(data, res.bytes);
     return res;
 }
 

--- a/test/statetest/statetest.cpp
+++ b/test/statetest/statetest.cpp
@@ -49,7 +49,7 @@ void register_test_files(const fs::path& root, evmc::VM& vm, bool trace)
             std::back_inserter(test_files), [](const fs::directory_entry& entry) {
                 return entry.is_regular_file() && entry.path().extension() == ".json";
             });
-        std::sort(test_files.begin(), test_files.end());
+        std::ranges::sort(test_files);
 
         for (const auto& p : test_files)
             register_test(fs::relative(p, root).parent_path().string(), p, vm, trace);

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -85,7 +85,7 @@ void state_transition::TearDown()
         }
         // Update default expectations - valid transaction means coinbase exists unless explicitly
         // requested otherwise
-        if (expect.post.find(Coinbase) == expect.post.end())
+        if (!expect.post.contains(Coinbase))
             expect.post[Coinbase].exists = true;
     }
 


### PR DESCRIPTION
Apply suggestions by the clang-tidy's modernize-use-ranges check.