### PR TITLE
tidy: Properly set internal linkage to internal functions

### DIFF
--- a/lib/evmone/advanced_analysis.cpp
+++ b/lib/evmone/advanced_analysis.cpp
@@ -9,7 +9,7 @@ namespace evmone::advanced
 {
 /// Clamps x to the max value of To type.
 template <typename To, typename T>
-inline constexpr To clamp(T x) noexcept
+static constexpr To clamp(T x) noexcept
 {
     constexpr auto max = std::numeric_limits<To>::max();
     return x <= max ? static_cast<To>(x) : max;
@@ -219,7 +219,7 @@ AdvancedCodeAnalysis analyze(evmc_revision rev, bytes_view code) noexcept
 
     assert(analysis.instrs.size() <= max_instrs_size);
 
-    // Make sure the push_values has not been reallocated. Otherwise iterators are invalid.
+    // Make sure the push_values has not been reallocated. Otherwise, iterators are invalid.
     assert(analysis.push_values.size() <= max_args_storage_size);
 
     return analysis;

--- a/lib/evmone_precompiles/sha256.cpp
+++ b/lib/evmone_precompiles/sha256.cpp
@@ -135,7 +135,7 @@ static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct BufferState* state)
     return true;
 }
 
-[[gnu::always_inline, msvc::forceinline]] inline void sha_256_implementation(
+[[gnu::always_inline, msvc::forceinline]] static void sha_256_implementation(
     uint32_t h[8], const std::byte* input, size_t len)
 {
     /*

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -122,7 +122,7 @@ state::AccessList from_json<state::AccessList>(const json::json& j)
 }
 
 // Based on calculateEIP1559BaseFee from ethereum/retesteth
-inline uint64_t calculate_current_base_fee_eip1559(
+static uint64_t calculate_current_base_fee_eip1559(
     uint64_t parent_gas_used, uint64_t parent_gas_limit, uint64_t parent_base_fee)
 {
     // TODO: Make sure that 64-bit precision is good enough.

--- a/test/unittests/precompiles_ripemd160_test.cpp
+++ b/test/unittests/precompiles_ripemd160_test.cpp
@@ -9,7 +9,7 @@
 
 using evmone::crypto::ripemd160;
 
-inline std::string hex(std::span<const std::byte> x)
+static std::string hex(std::span<const std::byte> x)
 {
     return evmc::hex({reinterpret_cast<const unsigned char*>(x.data()), x.size()});
 }

--- a/test/unittests/state_rlp_test.cpp
+++ b/test/unittests/state_rlp_test.cpp
@@ -115,7 +115,7 @@ struct CustomStruct
     bytes b;
 };
 
-inline bytes rlp_encode(const CustomStruct& t)
+static bytes rlp_encode(const CustomStruct& t)
 {
     return rlp::encode_tuple(t.a, t.b);
 }
@@ -156,7 +156,7 @@ TEST(state_rlp, encode_uint64)
     EXPECT_EQ(rlp::encode(uint64_t{0xffffffffffffffff}), "88ffffffffffffffff"_hex);
 }
 
-inline bytes to_significant_be_bytes(uint64_t x)
+static bytes to_significant_be_bytes(uint64_t x)
 {
     const auto byte_width = (std::bit_width(x) + 7) / 8;
     const auto leading_zero_bits = std::countl_zero(x) & ~7;  // Leading bits rounded down to 8x.
@@ -169,7 +169,7 @@ inline bytes to_significant_be_bytes(uint64_t x)
 
 /// The "custom" implementation of RLP encoding of uint64. It trims leading zero bytes and
 /// manually constructs bytes with variadic-length encoding.
-inline bytes rlp_encode_uint64(uint64_t x)
+static bytes rlp_encode_uint64(uint64_t x)
 {
     static constexpr uint8_t ShortBase = 0x80;
     if (x < ShortBase)  // Single-byte encoding.


### PR DESCRIPTION
This sets the internal linkage of functions which should have it. `inline` nor `constexpr` functions don't have internal linkage so use `static` or put them in the anonymous namespace. 

These issues are found with clang-tidy's misc-use-internal-linkage.