### PR TITLE
ci: Add pectra-devnet-5 EEST

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -370,14 +370,14 @@ jobs:
           release: pectra-devnet-4@v1.0.1
           fixtures_suffix: pectra-devnet-4
       - run:
-          name: "Execution spec tests (develop, state_tests)"
+          name: "Execution spec tests (develop, state_tests) - pectra-devnet-4"
           # Tests for in-development EVM revision currently passing.
           working_directory: ~/spec-tests/fixtures/state_tests
           command: >
             ~/build/bin/evmone-statetest
             prague/eip2537_bls_12_381_precompiles
       - run:
-          name: "Execution spec tests (develop, blockchain_tests)"
+          name: "Execution spec tests (develop, blockchain_tests) - pectra-devnet-4"
           # Tests for in-development EVM revision currently passing.
           working_directory: ~/spec-tests/fixtures/blockchain_tests
           command: >
@@ -387,6 +387,25 @@ jobs:
             prague/eip7002_el_triggerable_withdrawals
             prague/eip7251_consolidations
             prague/eip7685_general_purpose_el_requests
+      - download_execution_spec_tests:
+          release: pectra-devnet-5@v1.2.0
+          fixtures_suffix: pectra-devnet-5
+      - run:
+          name: "Execution spec tests (develop, state_tests)"
+          # Tests for in-development EVM revision currently passing.
+          # TODO: Just a single example for now (BLS G1MUL is unchanged in pectra-devnet-5).
+          working_directory: ~/spec-tests/fixtures/state_tests
+          command: >
+            ~/build/bin/evmone-statetest
+            prague/eip2537_bls_12_381_precompiles/bls12_g1mul
+      - run:
+          name: "Execution spec tests (develop, blockchain_tests)"
+          # Tests for in-development EVM revision currently passing.
+          # TODO: Just a single example that happens to work.
+          working_directory: ~/spec-tests/fixtures/blockchain_tests
+          command: >
+            ~/build/bin/evmone-blockchaintest
+            prague/eip2537_bls_12_381_precompiles/bls12_precompiles_before_fork
       - collect_coverage_gcc
       - upload_coverage:
           flags: execution_spec_tests


### PR DESCRIPTION
Run EEST tests pectra-devnet-5@v1.2.0 alongside the devnet-4 tests. This allows migrating to the devnet-5 specs EIP-by-EIP. In this PR we just enable example devnet-5 tests which happen to pass in the devnet-4 implementation.