### PR TITLE
ci: Clean directory before downloading execution spec tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -142,6 +142,7 @@ commands:
           name: "Download execution-spec-tests: <<parameters.release>>"
           working_directory: ~/spec-tests
           command: |
+            find . -delete
             curl -L https://github.com/<<parameters.repo>>/releases/download/<<parameters.release>>/fixtures_<<parameters.fixtures_suffix>>.tar.gz | tar -xz
             ls -l
 


### PR DESCRIPTION
Otherwise some tests deleted from devnet-4 remain when testing devnet-5.