### PR TITLE
tests: Add option to filter state tests by name

### DIFF
--- a/test/integration/statetest/CMakeLists.txt
+++ b/test/integration/statetest/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TESTS1 ${CMAKE_CURRENT_SOURCE_DIR}/tests1)
 set(TESTS2 ${CMAKE_CURRENT_SOURCE_DIR}/tests2)
 set(TESTS_EOF ${CMAKE_CURRENT_SOURCE_DIR}/eof)
 set(TESTS_TX ${CMAKE_CURRENT_SOURCE_DIR}/tx)
+set(TESTS_FILTER ${CMAKE_CURRENT_SOURCE_DIR}/filter)
 
 add_test(
     NAME ${PREFIX}/no_arguments
@@ -125,4 +126,13 @@ add_test(
 set_tests_properties(
     ${PREFIX}/tx_invalid_nonce PROPERTIES
     PASS_REGULAR_EXPRESSION "unexpected invalid transaction: nonce too high"
+)
+
+add_test(
+    NAME ${PREFIX}/filter
+    COMMAND evmone-statetest ${TESTS_FILTER}/one_failing_of_two.json -k passing_test_case
+)
+set_tests_properties(
+    ${PREFIX}/filter PROPERTIES
+    FAIL_REGULAR_EXPRESSION "failing_test_case"
 )

--- a/test/integration/statetest/filter/one_failing_of_two.json
+++ b/test/integration/statetest/filter/one_failing_of_two.json
@@ -1,0 +1,96 @@
+{
+  "passing_test_case": {
+    "env": {
+      "currentBaseFee": "0x0a",
+      "currentCoinbase": "0x0000000000000000000000000000000000000000",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xff112233445566",
+      "currentNumber": "0x01",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+      "currentTimestamp": "0x03e8"
+    },
+    "post": {
+      "London": [
+        {
+          "hash": "0x71322a2754548ef6d3b540e9b6b858379787c2d1f31bc68205b70902c1d6155f",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        }
+      ]
+    },
+    "pre": {
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "balance": "0x0de0b6b3a7640000",
+        "code": "0x",
+        "nonce": "0x00",
+        "storage": {}
+      }
+    },
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x061a80"
+      ],
+      "gasPrice": "0x0a",
+      "nonce": "0x00",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "0x0000000000000000000000000000000000000000",
+      "value": [
+        "0x1"
+      ]
+    }
+  },
+  "failing_test_case": {
+    "env": {
+      "currentBaseFee": "0x0a",
+      "currentCoinbase": "0x0000000000000000000000000000000000000000",
+      "currentDifficulty": "0x020000",
+      "currentGasLimit": "0xff112233445566",
+      "currentNumber": "0x01",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000020000",
+      "currentTimestamp": "0x03e8"
+    },
+    "post": {
+      "London": [
+        {
+          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+        }
+      ]
+    },
+    "pre": {
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "balance": "0x0de0b6b3a7640000",
+        "code": "0x",
+        "nonce": "0x00",
+        "storage": {}
+      }
+    },
+    "transaction": {
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x061a80"
+      ],
+      "gasPrice": "0x0a",
+      "nonce": "0x00",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "0x0000000000000000000000000000000000000000",
+      "value": [
+        "0x2"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR improves state test functionality by allowing filtering by test case name defined inside json test file.