### PR TITLE
EOF - EIP-7834 - support metadata section (draft)

### DIFF
--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -81,6 +81,8 @@ struct EOF1Header
     uint16_t data_size = 0;
     /// Offset of data container section start.
     uint16_t data_offset = 0;
+    /// Size of the (optional) metadata section
+    uint16_t metadata_size = 0;
     /// Size of every container section.
     std::vector<uint16_t> container_sizes;
     /// Offset of every container section start;


### PR DESCRIPTION
Just a draft of the spike work on https://eips.ethereum.org/EIPS/eip-7834, not intended to be merge.

Tested using https://github.com/ethereum/execution-spec-tests/pull/1116

Bearing in mind that this is just to dip the toe in the water, any feedback/thoughts welcome, we can use this as notes to make the future proper implementation more informed.