### PR TITLE
state: Simplify code modification indicator in StateDiff

### DIFF
--- a/test/state/account.hpp
+++ b/test/state/account.hpp
@@ -73,6 +73,9 @@ struct Account
     /// The account has been created in the current transaction.
     bool just_created = false;
 
+    // This account's code has been modified.
+    bool code_changed = false;
+
     evmc_access_status access_status = EVMC_ACCESS_COLD;
 
     [[nodiscard]] bool is_empty() const noexcept

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -130,7 +130,7 @@ StateDiff State::build_diff(evmc_revision rev) const
 
         // Output only the new code.
         // TODO: Output also the code hash. It will be needed for DB update and MPT hash.
-        if (m.just_created && !m.code.empty())
+        if (m.code_changed)
             a.code = m.code;
 
         for (const auto& [k, v] : m.storage)

--- a/test/state/state_diff.hpp
+++ b/test/state/state_diff.hpp
@@ -30,8 +30,8 @@ struct StateDiff
         /// TODO: Currently it is not guaranteed the value is different from the initial one.
         uint256 balance;
 
-        /// New account code. If empty, it means the code has not changed.
-        bytes code;
+        /// New or modified account code. If bytes are empty, it means the code has been cleared.
+        std::optional<bytes> code;
 
         /// The list of the account's storage modifications: key => new value.
         /// The value 0 means the storage entry is deleted.

--- a/test/state/test_state.cpp
+++ b/test/state/test_state.cpp
@@ -34,8 +34,8 @@ void TestState::apply(const state::StateDiff& diff)
         auto& a = (*this)[m.addr];
         a.nonce = m.nonce;
         a.balance = m.balance;
-        if (!m.code.empty())
-            a.code = m.code;  // TODO: Consider taking rvalue ref to avoid code copy.
+        if (m.code.has_value())
+            a.code = *m.code;  // TODO: Consider taking rvalue ref to avoid code copy.
         for (const auto& [k, v] : m.modified_storage)
         {
             if (v)


### PR DESCRIPTION
Use `std::optional` to indicate that an account's code has changed in the state diff.