### PR TITLE
 Support EIP-7691: Blob throughput increase

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -372,22 +372,15 @@ jobs:
           # Tests for in-development EVM revision currently passing.
           working_directory: ~/spec-tests/fixtures/state_tests
           command: >
-            ~/build/bin/evmone-statetest
-            prague/eip2537_bls_12_381_precompiles
-            prague/eip7623_increase_calldata_cost
+            ~/build/bin/evmone-statetest ~/spec-tests/fixtures/state_tests
+            --gtest_filter='-*eip7702*'
       - run:
           name: "Execution spec tests (develop, blockchain_tests)"
           # Tests for in-development EVM revision currently passing.
           working_directory: ~/spec-tests/fixtures/blockchain_tests
           command: >
-            ~/build/bin/evmone-blockchaintest
-            --gtest_filter='-*block_hashes.block_hashes_history'
-            prague/eip2537_bls_12_381_precompiles
-            prague/eip2935_historical_block_hashes_from_state
-            prague/eip6110_deposits
-            prague/eip7002_el_triggerable_withdrawals
-            prague/eip7251_consolidations
-            prague/eip7685_general_purpose_el_requests
+            ~/build/bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
+            --gtest_filter='-*block_hashes.block_hashes_history:*eip7702*:*eip7623*'
       - collect_coverage_gcc
       - upload_coverage:
           flags: execution_spec_tests

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -109,12 +109,12 @@ bool validate_block(
 
         // Check that the excess blob gas was updated correctly.
         if (*test_block.block_info.excess_blob_gas !=
-            state::calc_excess_blob_gas(
-                parent_header.blob_gas_used.value_or(0), parent_header.excess_blob_gas.value_or(0)))
+            state::calc_excess_blob_gas(rev, parent_header.blob_gas_used.value_or(0),
+                parent_header.excess_blob_gas.value_or(0)))
             return false;
 
         // Ensure the total blob gas spent is at most equal to the limit
-        if (*test_block.block_info.blob_gas_used > state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK)
+        if (*test_block.block_info.blob_gas_used > state::max_blob_gas_per_block(rev))
             return false;
     }
     else

--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -32,9 +32,6 @@ struct Withdrawal
 
 struct BlockInfo
 {
-    /// Max amount of blob gas allowed in block. It's constant now but can be dynamic in the future.
-    static constexpr uint64_t MAX_BLOB_GAS_PER_BLOCK = 786432;
-
     int64_t number = 0;
     int64_t timestamp = 0;
     int64_t parent_timestamp = 0;
@@ -63,12 +60,15 @@ struct BlockInfo
     std::vector<Withdrawal> withdrawals;
 };
 
+/// Max amount of blob gas allowed in block.
+uint64_t max_blob_gas_per_block(evmc_revision rev) noexcept;
+
 /// Computes the current blob gas price based on the excess blob gas.
-intx::uint256 compute_blob_gas_price(uint64_t excess_blob_gas) noexcept;
+intx::uint256 compute_blob_gas_price(evmc_revision rev, uint64_t excess_blob_gas) noexcept;
 
 /// Computes the current excess blob gas based on parameters of the parent block.
 uint64_t calc_excess_blob_gas(
-    uint64_t parent_blob_gas_used, uint64_t parent_excess_blob_gas) noexcept;
+    evmc_revision rev, uint64_t parent_blob_gas_used, uint64_t parent_excess_blob_gas) noexcept;
 
 /// Defines how to RLP-encode a Withdrawal.
 [[nodiscard]] bytes rlp_encode(const Withdrawal& withdrawal);

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -54,11 +54,11 @@ struct StateTransitionTest
 
         evmc_revision rev;
         std::vector<Expectation> expectations;
+        state::BlockInfo block;
     };
 
     std::string name;
     TestState pre_state;
-    state::BlockInfo block;
     TestBlockHashes block_hashes;
     TestMultiTransaction multi_tx;
     std::vector<Case> cases;
@@ -83,8 +83,7 @@ hash256 from_json<hash256>(const json::json& j);
 template <>
 bytes from_json<bytes>(const json::json& j);
 
-template <>
-state::BlockInfo from_json<state::BlockInfo>(const json::json& j);
+state::BlockInfo from_json_with_rev(const json::json& j, evmc_revision rev);
 
 template <>
 TestBlockHashes from_json<TestBlockHashes>(const json::json& j);

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -167,8 +167,7 @@ state::Withdrawal from_json<state::Withdrawal>(const json::json& j)
         from_json<evmc::address>(j.at("address")), from_json<uint64_t>(j.at("amount"))};
 }
 
-template <>
-state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
+state::BlockInfo from_json_with_rev(const json::json& j, evmc_revision rev)
 {
     evmc::bytes32 prev_randao;
     int64_t current_difficulty = 0;
@@ -232,9 +231,8 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
     {
         const auto parent_excess_blob_gas = from_json<uint64_t>(*it);
         const auto parent_blob_gas_used = from_json<uint64_t>(j.at("parentBlobGasUsed"));
-        // FIXME: not right, but our BlockInfo counts for all post, so may be different forks
         excess_blob_gas =
-            state::calc_excess_blob_gas(EVMC_CANCUN, parent_blob_gas_used, parent_excess_blob_gas);
+            state::calc_excess_blob_gas(rev, parent_blob_gas_used, parent_excess_blob_gas);
     }
     else if (const auto it2 = j.find("currentExcessBlobGas"); it2 != j.end())
     {
@@ -255,8 +253,7 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
         .base_fee = base_fee,
         .blob_gas_used = load_if_exists<uint64_t>(j, "blobGasUsed"),
         .excess_blob_gas = excess_blob_gas,
-        // FIXME: not right, but our BlockInfo counts for all post, so may be different forks
-        .blob_base_fee = state::compute_blob_gas_price(EVMC_CANCUN, excess_blob_gas),
+        .blob_base_fee = state::compute_blob_gas_price(rev, excess_blob_gas),
         .ommers = std::move(ommers),
         .withdrawals = std::move(withdrawals),
     };
@@ -434,7 +431,6 @@ static void from_json(const json::json& j_t, StateTransitionTest& o)
 
     o.multi_tx = j_t.at("transaction").get<TestMultiTransaction>();
 
-    o.block = from_json<state::BlockInfo>(j_t.at("env"));
     o.block_hashes = from_json<TestBlockHashes>(j_t.at("env"));
 
     if (const auto info_it = j_t.find("_info"); info_it != j_t.end())
@@ -455,7 +451,8 @@ static void from_json(const json::json& j_t, StateTransitionTest& o)
     {
         // TODO(c++20): Use emplace_back with aggregate initialization.
         o.cases.push_back({to_rev(rev_name),
-            expectations.get<std::vector<StateTransitionTest::Case::Expectation>>()});
+            expectations.get<std::vector<StateTransitionTest::Case::Expectation>>(),
+            from_json_with_rev(j_t.at("env"), to_rev(rev_name))});
     }
 }
 

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -232,7 +232,9 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
     {
         const auto parent_excess_blob_gas = from_json<uint64_t>(*it);
         const auto parent_blob_gas_used = from_json<uint64_t>(j.at("parentBlobGasUsed"));
-        excess_blob_gas = state::calc_excess_blob_gas(parent_blob_gas_used, parent_excess_blob_gas);
+        // FIXME: not right, but our BlockInfo counts for all post, so may be different forks
+        excess_blob_gas =
+            state::calc_excess_blob_gas(EVMC_CANCUN, parent_blob_gas_used, parent_excess_blob_gas);
     }
     else if (const auto it2 = j.find("currentExcessBlobGas"); it2 != j.end())
     {
@@ -253,7 +255,8 @@ state::BlockInfo from_json<state::BlockInfo>(const json::json& j)
         .base_fee = base_fee,
         .blob_gas_used = load_if_exists<uint64_t>(j, "blobGasUsed"),
         .excess_blob_gas = excess_blob_gas,
-        .blob_base_fee = state::compute_blob_gas_price(excess_blob_gas),
+        // FIXME: not right, but our BlockInfo counts for all post, so may be different forks
+        .blob_base_fee = state::compute_blob_gas_price(EVMC_CANCUN, excess_blob_gas),
         .ommers = std::move(ommers),
         .withdrawals = std::move(withdrawals),
     };

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -12,7 +12,7 @@ namespace evmone::test
 void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_summary)
 {
     SCOPED_TRACE(test.name);
-    for (const auto& [rev, cases] : test.cases)
+    for (const auto& [rev, cases, block] : test.cases)
     {
         validate_state(test.pre_state, rev);
         for (size_t case_index = 0; case_index != cases.size(); ++case_index)
@@ -34,11 +34,11 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             const auto tx = test.multi_tx.get(expected.indexes);
             auto state = test.pre_state;
 
-            const auto res = test::transition(state, test.block, test.block_hashes, tx, rev, vm,
-                test.block.gas_limit, static_cast<int64_t>(state::max_blob_gas_per_block(rev)));
+            const auto res = test::transition(state, block, test.block_hashes, tx, rev, vm,
+                block.gas_limit, static_cast<int64_t>(state::max_blob_gas_per_block(rev)));
 
             // Finalize block with reward 0.
-            test::finalize(state, rev, test.block.coinbase, 0, {}, {});
+            test::finalize(state, rev, block.coinbase, 0, {}, {});
 
             const auto state_root = state::mpt_hash(state);
 

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -35,7 +35,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             auto state = test.pre_state;
 
             const auto res = test::transition(state, test.block, test.block_hashes, tx, rev, vm,
-                test.block.gas_limit, state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
+                test.block.gas_limit, static_cast<int64_t>(state::max_blob_gas_per_block(rev)));
 
             // Finalize block with reward 0.
             test::finalize(state, rev, test.block.coinbase, 0, {}, {});

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -115,7 +115,7 @@ int main(int argc, const char* argv[])
             j_result["currentBaseFee"] = hex0x(block.base_fee);
 
         int64_t cumulative_gas_used = 0;
-        auto blob_gas_left = static_cast<int64_t>(state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
+        auto blob_gas_left = static_cast<int64_t>(state::max_blob_gas_per_block(rev));
         std::vector<state::Transaction> transactions;
         std::vector<state::TransactionReceipt> receipts;
         int64_t block_gas_left = block.gas_limit;
@@ -246,8 +246,8 @@ int main(int argc, const char* argv[])
         j_result["gasUsed"] = hex0x(cumulative_gas_used);
         if (rev >= EVMC_CANCUN)
         {
-            j_result["blobGasUsed"] = hex0x(
-                static_cast<int64_t>(state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK) - blob_gas_left);
+            j_result["blobGasUsed"] =
+                hex0x(static_cast<int64_t>(state::max_blob_gas_per_block(rev)) - blob_gas_left);
             if (block.excess_blob_gas.has_value())
                 j_result["currentExcessBlobGas"] = hex0x(*block.excess_blob_gas);
         }

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -88,7 +88,7 @@ int main(int argc, const char* argv[])
         if (!env_file.empty())
         {
             const auto j = json::json::parse(std::ifstream{env_file});
-            block = from_json<state::BlockInfo>(j);
+            block = from_json_with_rev(j, rev);
             block_hashes = from_json<TestBlockHashes>(j);
         }
 

--- a/test/unittests/state_block_test.cpp
+++ b/test/unittests/state_block_test.cpp
@@ -10,18 +10,36 @@ using namespace intx::literals;
 
 TEST(state_block, blob_gas_price)
 {
-    static constexpr uint64_t TARGET_BLOB_GAS_PER_BLOCK = 0x60000;
+    static constexpr uint64_t TARGET_BLOB_GAS_PER_BLOCK_CANCUN = 0x60000;
 
-    EXPECT_EQ(compute_blob_gas_price(0), 1);
-    EXPECT_EQ(compute_blob_gas_price(1), 1);
-    EXPECT_EQ(compute_blob_gas_price(TARGET_BLOB_GAS_PER_BLOCK), 1);
-    EXPECT_EQ(compute_blob_gas_price(TARGET_BLOB_GAS_PER_BLOCK * 2), 1);
-    EXPECT_EQ(compute_blob_gas_price(TARGET_BLOB_GAS_PER_BLOCK * 7), 2);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, 0), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, 1), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, TARGET_BLOB_GAS_PER_BLOCK_CANCUN), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, TARGET_BLOB_GAS_PER_BLOCK_CANCUN * 2), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, TARGET_BLOB_GAS_PER_BLOCK_CANCUN * 7), 2);
 
-    EXPECT_EQ(compute_blob_gas_price(10'000'000), 19);
-    EXPECT_EQ(compute_blob_gas_price(100'000'000), 10203769476395);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, 10'000'000), 19);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, 100'000'000), 10203769476395);
 
     // Close to the computation overflowing:
-    EXPECT_EQ(compute_blob_gas_price(400'000'000),
+    EXPECT_EQ(compute_blob_gas_price(EVMC_CANCUN, 400'000'000),
         10840331274704280429132033759016842817414750029778539_u256);
+}
+
+TEST(state_block, blob_gas_price_prague)
+{
+    static constexpr uint64_t TARGET_BLOB_GAS_PER_BLOCK_PRAGUE = 0xc0000;
+
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, 0), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, 1), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, TARGET_BLOB_GAS_PER_BLOCK_PRAGUE), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, TARGET_BLOB_GAS_PER_BLOCK_PRAGUE * 2), 1);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, TARGET_BLOB_GAS_PER_BLOCK_PRAGUE * 7), 3);
+
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, 10'000'000), 7);
+    EXPECT_EQ(compute_blob_gas_price(EVMC_PRAGUE, 100'000'000), 470442149);
+
+    // Close to the computation overflowing:
+    EXPECT_EQ(
+        compute_blob_gas_price(EVMC_PRAGUE, 400'000'000), 48980690787953896757236758600209812_u256);
 }

--- a/test/unittests/state_transition.cpp
+++ b/test/unittests/state_transition.cpp
@@ -58,7 +58,7 @@ void state_transition::TearDown()
         trace_capture.emplace();
 
     const auto res = test::transition(state, block, block_hashes, tx, rev, selected_vm,
-        block.gas_limit, state::BlockInfo::MAX_BLOB_GAS_PER_BLOCK);
+        block.gas_limit, static_cast<int64_t>(state::max_blob_gas_per_block(rev)));
     test::finalize(state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
     const auto& post = state;
 

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -70,7 +70,8 @@ TEST_F(state_transition, eip7516_blob_base_fee)
     // 0x1d is the result of ref implementation in EIP-4844
     static constexpr auto price = 0x1d;
     block.blob_base_fee = price;
-    assert(state::compute_blob_gas_price(*block.excess_blob_gas) == *block.blob_base_fee);
+    assert(
+        state::compute_blob_gas_price(EVMC_CANCUN, *block.excess_blob_gas) == *block.blob_base_fee);
 
     tx.to = To;
     pre.insert(*tx.to, {.code = sstore(0x4a, OP_BLOBBASEFEE)});

--- a/test/unittests/state_tx_test.cpp
+++ b/test/unittests/state_tx_test.cpp
@@ -102,20 +102,23 @@ TEST(state_tx, validate_blob_tx)
     };
     const TestState state{{tx.sender, {.nonce = 0, .balance = 1000000}}};
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_SHANGHAI, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
-                  .message(),
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_SHANGHAI, 60000,
+                                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
+            .message(),
         make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED).message());
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
-                  .message(),
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
+            .message(),
         make_error_code(ErrorCode::CREATE_BLOB_TX).message());
 
     tx.to = 0x01_address;
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
-                  .message(),
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
+            .message(),
         make_error_code(ErrorCode::EMPTY_BLOB_HASHES_LIST).message());
 
     tx.blob_hashes.push_back(
@@ -131,34 +134,39 @@ TEST(state_tx, validate_blob_tx)
     tx.blob_hashes.push_back(
         0x0100000000000000000000000000000000000000000000000000000000000006_bytes32);
 
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
-                  .message(),
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
+            .message(),
         make_error_code(ErrorCode::FEE_CAP_LESS_THEN_BLOCKS).message());
 
     tx.max_blob_gas_price = 1;
     tx.blob_hashes.push_back(
         0x0100000000000000000000000000000000000000000000000000000000000007_bytes32);
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
-                  .message(),
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
+            .message(),
         make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED).message());
 
     tx.blob_hashes.pop_back();
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK - 1))
+    EXPECT_EQ(std::get<std::error_code>(
+                  validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN)) - 1))
                   .message(),
         make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED).message());
 
-    EXPECT_EQ(std::get<TransactionProperties>(validate_transaction(state, bi, tx, EVMC_CANCUN,
-                                                  60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
+    EXPECT_EQ(std::get<TransactionProperties>(
+                  validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
                   .execution_gas_limit,
         39000);
 
     tx.blob_hashes[0] = 0x0200000000000000000000000000000000000000000000000000000000000001_bytes32;
-    EXPECT_EQ(std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
-                                            BlockInfo::MAX_BLOB_GAS_PER_BLOCK))
-                  .message(),
+    EXPECT_EQ(
+        std::get<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN, 60000,
+                                      static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN))))
+            .message(),
         make_error_code(ErrorCode::INVALID_BLOB_HASH_VERSION).message());
 }
 
@@ -184,10 +192,10 @@ TEST(state_tx, validate_eof_create_transaction)
     };
     const TestState state{{tx.sender, {.nonce = 1, .balance = 0xe8d4a51000}}};
 
-    ASSERT_FALSE(holds_alternative<std::error_code>(validate_transaction(
-        state, bi, tx, EVMC_CANCUN, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)));
-    ASSERT_FALSE(holds_alternative<std::error_code>(validate_transaction(
-        state, bi, tx, EVMC_PRAGUE, 60000, BlockInfo::MAX_BLOB_GAS_PER_BLOCK)));
+    ASSERT_FALSE(holds_alternative<std::error_code>(validate_transaction(state, bi, tx, EVMC_CANCUN,
+        60000, static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN)))));
+    ASSERT_FALSE(holds_alternative<std::error_code>(validate_transaction(state, bi, tx, EVMC_PRAGUE,
+        60000, static_cast<int64_t>(max_blob_gas_per_block(EVMC_CANCUN)))));
 }
 
 TEST(state_tx, validate_tx_data_cost)

--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -20,7 +20,7 @@ TEST(statetest_loader, block_info)
             "withdrawals": []
         })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 0x0);
@@ -48,7 +48,7 @@ TEST(statetest_loader, block_info_hex)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 100000000000000000);
@@ -76,7 +76,7 @@ TEST(statetest_loader, block_info_dec)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 100000000000000000);
@@ -102,7 +102,7 @@ TEST(statetest_loader, block_info_0_current_difficulty)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 100000000000000000);
@@ -128,7 +128,7 @@ TEST(statetest_loader, block_info_0_parent_difficulty)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 100000000000000000);
@@ -151,7 +151,7 @@ TEST(statetest_loader, block_info_0_random)
             "withdrawals": []
         })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 0x0);
@@ -186,7 +186,7 @@ TEST(statetest_loader, block_info_withdrawals)
             ]
         })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 0x0);
@@ -223,7 +223,7 @@ TEST(statetest_loader, block_info_ommers)
             "withdrawals": []
         })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 0x0);
@@ -253,7 +253,7 @@ TEST(statetest_loader, block_info_parent_blob_gas)
             "parentBlobGasUsed": "0x60000"
         })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 0x0);
@@ -277,7 +277,7 @@ TEST(statetest_loader, block_info_current_blob_gas)
             "currentExcessBlobGas": "2"
         })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
     EXPECT_EQ(bi.gas_limit, 0x0);
@@ -297,7 +297,7 @@ TEST(statetest_loader, block_info_parent_beacon_block_root)
         "parentBeaconBlockRoot": "0xbeac045007"
     })";
 
-    const auto bi = test::from_json<state::BlockInfo>(json::json::parse(input));
+    const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN);
     EXPECT_EQ(bi.parent_beacon_block_root, 0xbeac045007_bytes32);
 }
 

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -117,7 +117,9 @@ TEST(statetest_loader, load_minimal_test)
                 "value": null,
                 "nonce" : "0"
             },
-            "post": {},
+            "post": {
+                "Cancun": []
+            },
             "env": {
                 "currentNumber": "0",
                 "currentTimestamp": "0",
@@ -129,12 +131,12 @@ TEST(statetest_loader, load_minimal_test)
     const auto st = std::move(load_state_tests(s).at(0));
     // TODO: should add some comparison operator to State, BlockInfo, AccessList
     EXPECT_EQ(st.pre_state.size(), 0);
-    EXPECT_EQ(st.block.number, 0);
-    EXPECT_EQ(st.block.timestamp, 0);
-    EXPECT_EQ(st.block.gas_limit, 0);
-    EXPECT_EQ(st.block.coinbase, address{});
-    EXPECT_EQ(st.block.prev_randao, bytes32{});
-    EXPECT_EQ(st.block.base_fee, 0);
+    EXPECT_EQ(st.cases[0].block.number, 0);
+    EXPECT_EQ(st.cases[0].block.timestamp, 0);
+    EXPECT_EQ(st.cases[0].block.gas_limit, 0);
+    EXPECT_EQ(st.cases[0].block.coinbase, address{});
+    EXPECT_EQ(st.cases[0].block.prev_randao, bytes32{});
+    EXPECT_EQ(st.cases[0].block.base_fee, 0);
     EXPECT_EQ(st.multi_tx.type, test::TestMultiTransaction::Type::legacy);
     EXPECT_EQ(st.multi_tx.data, bytes{});
     EXPECT_EQ(st.multi_tx.gas_limit, 0);
@@ -155,7 +157,8 @@ TEST(statetest_loader, load_minimal_test)
     EXPECT_EQ(st.multi_tx.gas_limits.size(), 1);
     EXPECT_EQ(st.multi_tx.gas_limits[0], 0);
     EXPECT_EQ(st.multi_tx.values.size(), 0);
-    EXPECT_EQ(st.cases.size(), 0);
+    EXPECT_EQ(st.cases.size(), 1);
+    EXPECT_EQ(st.cases[0].expectations.size(), 0);
     EXPECT_EQ(st.input_labels.size(), 0);
 }
 


### PR DESCRIPTION
Implements [EIP-7691](https://eips.ethereum.org/EIPS/eip-7691). It seems only 7702 is missing (once spec stabilizes) from passing EEST devnet-5/6 tests

The parametrization of blob gas schedule with `rev` led to quite a bit of fallout...