### PR TITLE
baseline: Get code begin once

### DIFF
--- a/lib/evmone/baseline_execution.cpp
+++ b/lib/evmone/baseline_execution.cpp
@@ -291,6 +291,7 @@ evmc_result execute(VM& vm, const evmc_host_interface& host, evmc_host_context* 
     evmc_revision rev, const evmc_message& msg, const CodeAnalysis& analysis) noexcept
 {
     const auto code = analysis.executable_code();
+    const auto code_begin = code.data();
     auto gas = msg.gas;
 
     auto& state = vm.get_execution_state(static_cast<size_t>(msg.depth));
@@ -304,16 +305,16 @@ evmc_result execute(VM& vm, const evmc_host_interface& host, evmc_host_context* 
     if (INTX_UNLIKELY(tracer != nullptr))
     {
         tracer->notify_execution_start(state.rev, *state.msg, code);
-        gas = dispatch<true>(cost_table, state, gas, code.data(), tracer);
+        gas = dispatch<true>(cost_table, state, gas, code_begin, tracer);
     }
     else
     {
 #if EVMONE_CGOTO_SUPPORTED
         if (vm.cgoto)
-            gas = dispatch_cgoto(cost_table, state, gas, code.data());
+            gas = dispatch_cgoto(cost_table, state, gas, code_begin);
         else
 #endif
-            gas = dispatch<false>(cost_table, state, gas, code.data());
+            gas = dispatch<false>(cost_table, state, gas, code_begin);
     }
 
     const auto gas_left = (state.status == EVMC_SUCCESS || state.status == EVMC_REVERT) ? gas : 0;


### PR DESCRIPTION
Refactor the baseline interpreter by taking the beggining of the code once. This also workarounds a clang-tidy warning about .data() usage.