### PR TITLE
Update clang-tidy config and suppress some warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,6 +52,8 @@ Checks:
   - "modernize-*"
   - "-modernize-avoid-c-arrays"
   - "-modernize-use-nodiscard"
+  # Designated initializers are nice, but should not be used all the time.
+  - "-modernize-use-designated-initializers"
   - "-modernize-use-trailing-return-type"
   - "performance-*"
   - "-performance-enum-size"
@@ -68,6 +70,8 @@ Checks:
   - "-readability-named-parameter"
   - "-readability-qualified-auto"
   - "-readability-uppercase-literal-suffix"
+  # This is too noisy about multiplication and addition precedence.
+  - "-readability-math-missing-parentheses"
 
 CheckOptions:
   readability-identifier-naming.ClassCase: CamelCase

--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -6,6 +6,9 @@
 #include "instructions.hpp"
 #include "instructions_traits.hpp"
 
+// TODO: This warning suppression may be lifted, but the situation in this file is complicated.
+// NOLINTBEGIN(misc-use-internal-linkage)
+
 namespace evmone::advanced
 {
 namespace instr
@@ -347,3 +350,5 @@ EVMC_EXPORT const OpTable& get_op_table(evmc_revision rev) noexcept
     return op_tables[rev];
 }
 }  // namespace evmone::advanced
+
+// NOLINTEND(misc-use-internal-linkage)

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -665,6 +665,9 @@ EOFValidationError validate_eof1(
                 header.get_code(container, code_idx), code_idx, header, container);
             if (const auto* error = std::get_if<EOFValidationError>(&msh_or_error))
                 return *error;
+            // TODO(clang-tidy): Too restrictive, see
+            //   https://github.com/llvm/llvm-project/issues/120867.
+            // NOLINTNEXTLINE(modernize-use-integer-sign-comparison)
             if (std::get<int32_t>(msh_or_error) !=
                 header.get_type(container, code_idx).max_stack_height)
                 return EOFValidationError::invalid_max_stack_height;

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -17,6 +17,7 @@ constexpr auto EXTCALL_ABORT = 2;
 namespace evmone::instr::core
 {
 /// Converts an opcode to matching EVMC call kind.
+/// NOLINTNEXTLINE(misc-use-internal-linkage) fixed in clang-tidy 20.
 consteval evmc_call_kind to_call_kind(Opcode op) noexcept
 {
     switch (op)

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -195,6 +195,7 @@ address compute_create_address(const address& sender, uint64_t sender_nonce) noe
     else  // Prefixed integer encoding.
     {
         // TODO: bit_width returns int after [LWG 3656](https://cplusplus.github.io/LWG/issue3656).
+        // NOLINTNEXTLINE(readability-redundant-casting)
         const auto num_nonzero_bytes = static_cast<int>((std::bit_width(sender_nonce) + 7) / 8);
         *p++ = static_cast<uint8_t>(RLP_STR_BASE + num_nonzero_bytes);
         intx::be::unsafe::store(p, sender_nonce);

--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -92,6 +92,7 @@ PrecompileAnalysis ecpairing_analyze(bytes_view input, evmc_revision rev) noexce
 
 PrecompileAnalysis blake2bf_analyze(bytes_view input, evmc_revision) noexcept
 {
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     return {input.size() == 213 ? intx::be::unsafe::load<uint32_t>(input.data()) : GasCostMax, 64};
 }
 
@@ -103,6 +104,7 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
     const int64_t min_gas = (rev >= EVMC_BERLIN) ? 200 : 0;
 
     uint8_t input_header[input_header_required_size]{};
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     std::copy_n(input.data(), std::min(input.size(), input_header_required_size), input_header);
 
     const auto base_len = be::unsafe::load<uint256>(&input_header[0]);

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -85,7 +85,7 @@ evmc_message build_message(
         rev >= EVMC_OSAKA && !tx.to.has_value() && is_eof_container(tx.data);
 
     return {.kind = is_legacy_eof_create ? EVMC_EOFCREATE :
-                    tx.to.has_value()    ? EVMC_CALL :
+                    tx.to.has_value()    ? EVMC_CALL : // NOLINT(readability-avoid-nested-conditional-operator)
                                            EVMC_CREATE,
         .flags = 0,
         .depth = 0,

--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -378,6 +378,7 @@ TEST_P(evm, signextend_fuzzing)
             input[63] = e;
             execute(code, {input, 64});
             ASSERT_EQ(output.size(), sizeof(uint256));
+            // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
             const auto out = be::unsafe::load<uint256>(output.data());
             const auto expected = signextend_reference(be::unsafe::load<uint256>(input), e);
             ASSERT_EQ(out, expected);

--- a/test/unittests/instructions_test.cpp
+++ b/test/unittests/instructions_test.cpp
@@ -77,6 +77,7 @@ constexpr void validate_traits_of() noexcept
     constexpr auto expected_rev = get_revision_defined_in(Op);
     constexpr auto since =
         tr.since.has_value() ?
+            // NOLINTNEXTLINE(readability-avoid-nested-conditional-operator)
             tr.eof_since.has_value() ? std::min(*tr.since, *tr.eof_since) : *tr.since :
             tr.eof_since;
     static_assert(since.has_value() ? *since == expected_rev : expected_rev == unspecified);


### PR DESCRIPTION
This brings the configuration to the clang-tidy-20 compatibility.