### PR TITLE
eof: Remove duplicated type section size check

### DIFF
--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -205,10 +205,6 @@ std::variant<EOFSectionHeaders, EOFValidationError> validate_section_headers(byt
     if (remaining_container_size < section_bodies_without_data)
         return EOFValidationError::invalid_section_bodies_size;
 
-    if (section_headers[TYPE_SECTION][0] !=
-        section_headers[CODE_SECTION].size() * EOF1Header::TYPE_ENTRY_SIZE)
-        return EOFValidationError::invalid_type_section_size;
-
     return section_headers;
 }
 


### PR DESCRIPTION
The check that type section size matches the number of code sections is done twice in EOF validation:
- in `validate_section_headers()`
- in `validate_header()` which always calls `validate_section_headers()` so this check never fails.

I decided to leave the check in `validate_header()` because it better fits there.