### PR TITLE
eof: Align EOFCREATE args with EXT*CALL

### DIFF
--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -387,10 +387,10 @@ Result eofcreate(
     if (state.in_static_mode())
         return {EVMC_STATIC_MODE_VIOLATION, gas_left};
 
-    const auto endowment = stack.pop();
     const auto salt = stack.pop();
     const auto input_offset_u256 = stack.pop();
     const auto input_size_u256 = stack.pop();
+    const auto endowment = stack.pop();
 
     stack.push(0);  // Assume failure.
     state.return_data.clear();

--- a/test/unittests/eof_example_test.cpp
+++ b/test/unittests/eof_example_test.cpp
@@ -171,15 +171,15 @@ TEST_F(state_transition, eof_examples_eofcreate)
     const auto factory = bytecode(
         //////////////////
         // Factory container
-        //                    Code section: PUSH0 [input size], PUSH0 [input offset], PUSH1 [salt],
-        //                                  PUSH0 [endowment value],
+        //                    Code section: PUSH0 [endowment value], PUSH0 [input size],
+        //                                  PUSH0 [input offset], PUSH1 [salt],
         //                                  EOFCREATE from first subcontainer and STOP
         //                                                               |
         //               Header: 1 code section 8 bytes long             |
         //               |                                               |
         //    version    |                                 Header terminator
         //    |          |___________                      |             |____________________
-        "EF00 01 01 0004 02 0001 0008 03 0001 0030 04 0000 00 00 80 0004 5F 5F 60FF 5F EC00 00"
+        "EF00 01 01 0004 02 0001 0008 03 0001 0030 04 0000 00 00 80 0004 5F 5F 5F 60FF EC00 00"
         //       |‾‾‾‾‾‾              |‾‾‾‾‾‾‾‾‾‾‾ |‾‾‾‾‾‾    |‾‾‾‾‾‾‾‾‾
         //       |                    |            Header: data section 0 bytes long
         //       |                    |                       |

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -640,15 +640,12 @@ public:
     operator bytecode() const
     {
         bytecode code;
-        if constexpr (kind == OP_CREATE2)
-            code += m_salt;
+        if constexpr (kind == OP_CREATE)
+            code += m_input_size + m_input + m_value;
+        else if constexpr (kind == OP_CREATE2)
+            code += m_salt + m_input_size + m_input + m_value;
         else if constexpr (kind == OP_EOFCREATE)
-            code += m_input_size + m_input + m_salt;
-
-        if constexpr (kind == OP_CREATE || kind == OP_CREATE2)
-            code += m_input_size + m_input;
-
-        code += m_value;
+            code += m_value + m_input_size + m_input + m_salt;
 
         code += bytecode{kind};
         if constexpr (kind == OP_EOFCREATE)


### PR DESCRIPTION
Update with https://github.com/ipsilon/eof/pull/156, planned for EOF Osaka-devnet-1. EOFCREATE stack args order to match that of EXT*CALL.

The change in EEST which goes in hand with this: https://github.com/ethereum/execution-spec-tests/pull/1274