### PR TITLE
Check for topic when parsing deposit contract logs

### DIFF
--- a/test/state/requests.cpp
+++ b/test/state/requests.cpp
@@ -36,7 +36,9 @@ Requests collect_deposit_requests(std::span<const TransactionReceipt> receipts)
     {
         for (const auto& log : receipt.logs)
         {
-            if (log.addr == DEPOSIT_CONTRACT_ADDRESS)
+            assert(log.addr != DEPOSIT_CONTRACT_ADDRESS || !log.topics.empty());
+            if (log.addr == DEPOSIT_CONTRACT_ADDRESS &&
+                log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH)
             {
                 // Deposit log definition
                 // https://github.com/ethereum/consensus-specs/blob/dev/solidity_deposit_contract/deposit_contract.sol

--- a/test/state/requests.hpp
+++ b/test/state/requests.hpp
@@ -16,6 +16,10 @@ namespace evmone::state
 /// TODO: This address differs in different chains, so it should be configurable.
 constexpr auto DEPOSIT_CONTRACT_ADDRESS = 0x00000000219ab540356cBB839Cbe05303d7705Fa_address;
 
+/// The topic of deposit log of the deposit contract.
+constexpr auto DEPOSIT_EVENT_SIGNATURE_HASH =
+    0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5_bytes32;
+
 /// `requests` object.
 ///
 /// Defined by EIP-7685: General purpose execution layer requests.


### PR DESCRIPTION
Turns out on Sepolia deposit contract is different and can emit other logs (ERC20's `Transfer`)