### PR TITLE
eof: Rename RETURNCONTRACT to RETURNCODE

### DIFF
--- a/lib/evmone/advanced_instructions.cpp
+++ b/lib/evmone/advanced_instructions.cpp
@@ -313,7 +313,7 @@ constexpr std::array<instruction_exec_fn, 256> instruction_implementations = [](
     table[OP_SWAPN] = op_undefined;
     table[OP_EXCHANGE] = op_undefined;
     table[OP_EOFCREATE] = op_undefined;
-    table[OP_RETURNCONTRACT] = op_undefined;
+    table[OP_RETURNCODE] = op_undefined;
 
     return table;
 }();

--- a/lib/evmone/eof.hpp
+++ b/lib/evmone/eof.hpp
@@ -192,9 +192,9 @@ enum class EOFValidationError
 
 enum class ContainerKind : uint8_t
 {
-    /// Container that uses RETURNCONTRACT. Can be used by EOFCREATE/Creation transaction.
+    /// Container that uses RETURNCODE. Can be used by EOFCREATE/Creation transaction.
     initcode,
-    /// Container that uses STOP/RETURN. Can be returned by RETURNCONTRACT.
+    /// Container that uses STOP/RETURN. Can be returned by RETURNCODE.
     runtime,
 };
 

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -167,7 +167,7 @@ public:
     size_t output_offset = 0;
     size_t output_size = 0;
 
-    /// Container to be deployed returned from RETURNCONTRACT, used only inside EOFCREATE execution.
+    /// Container to be deployed returned from RETURNCODE, used only inside EOFCREATE execution.
     std::optional<bytes> deploy_container;
 
 private:

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -1162,7 +1162,7 @@ inline TermResult return_impl(StackTop stack, int64_t gas_left, ExecutionState& 
 inline constexpr auto return_ = return_impl<EVMC_SUCCESS>;
 inline constexpr auto revert = return_impl<EVMC_REVERT>;
 
-inline TermResult returncontract(
+inline TermResult returncode(
     StackTop stack, int64_t gas_left, ExecutionState& state, code_iterator pos) noexcept
 {
     const auto& offset = stack[0];

--- a/lib/evmone/instructions_opcodes.hpp
+++ b/lib/evmone/instructions_opcodes.hpp
@@ -176,7 +176,7 @@ enum Opcode : uint8_t
     OP_EXCHANGE = 0xe8,
 
     OP_EOFCREATE = 0xec,
-    OP_RETURNCONTRACT = 0xee,
+    OP_RETURNCODE = 0xee,
 
     OP_CREATE = 0xf0,
     OP_CALL = 0xf1,

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -191,7 +191,7 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
     table[EVMC_OSAKA][OP_EXTDELEGATECALL] = warm_storage_read_cost;
     table[EVMC_OSAKA][OP_EXTSTATICCALL] = warm_storage_read_cost;
     table[EVMC_OSAKA][OP_EOFCREATE] = 32000;
-    table[EVMC_OSAKA][OP_RETURNCONTRACT] = 0;
+    table[EVMC_OSAKA][OP_RETURNCODE] = 0;
 
     table[EVMC_EXPERIMENTAL] = table[EVMC_OSAKA];
 
@@ -422,7 +422,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_CREATE2] = {"CREATE2", 0, false, 4, -3, EVMC_CONSTANTINOPLE};
     table[OP_RETURNDATALOAD] = {"RETURNDATALOAD", 0, false, 1, 0, {}, REV_EOF1};
     table[OP_EOFCREATE] = {"EOFCREATE", 1, false, 4, -3, {}, REV_EOF1};
-    table[OP_RETURNCONTRACT] = {"RETURNCONTRACT", 1, true, 2, -2, {}, REV_EOF1};
+    table[OP_RETURNCODE] = {"RETURNCODE", 1, true, 2, -2, {}, REV_EOF1};
     table[OP_EXTCALL] = {"EXTCALL", 0, false, 4, -3, {}, REV_EOF1};
     table[OP_EXTDELEGATECALL] = {"EXTDELEGATECALL", 0, false, 3, -2, {}, REV_EOF1};
     table[OP_STATICCALL] = {"STATICCALL", 0, false, 6, -5, EVMC_BYZANTIUM};

--- a/lib/evmone/instructions_xmacro.hpp
+++ b/lib/evmone/instructions_xmacro.hpp
@@ -284,7 +284,7 @@
     ON_OPCODE_UNDEFINED(0xeb)                                 \
     ON_OPCODE_IDENTIFIER(OP_EOFCREATE, eofcreate)             \
     ON_OPCODE_UNDEFINED(0xed)                                 \
-    ON_OPCODE_IDENTIFIER(OP_RETURNCONTRACT, returncontract)   \
+    ON_OPCODE_IDENTIFIER(OP_RETURNCODE, returncode)           \
     ON_OPCODE_UNDEFINED(0xef)                                 \
                                                               \
     ON_OPCODE_IDENTIFIER(OP_CREATE, create)                   \

--- a/test/unittests/eof_example_test.cpp
+++ b/test/unittests/eof_example_test.cpp
@@ -131,7 +131,7 @@ TEST_F(state_transition, eof_examples_creation_tx)
         //////////////////
         // Initcontainer
         //                        Code section: PUSH0 [aux data size], PUSH0 [aux data offset] and
-        //                                      RETURNCONTRACT first subcontainer
+        //                                      RETURNCODE first subcontainer
         //                                                               |
         //               Header: 1 code section 4 bytes long             |
         //               |                                               |
@@ -191,7 +191,7 @@ TEST_F(state_transition, eof_examples_eofcreate)
         //////////////////
         // Initcontainer
         //                    Code section: PUSH0 [aux data size], PUSH0 [aux data offset],
-        //                                  RETURNCONTRACT first subcontainer
+        //                                  RETURNCODE first subcontainer
         //                                                               |
         //               Header: 1 code section 4 bytes long             |
         //               |                                               |

--- a/test/unittests/evm_eof_test.cpp
+++ b/test/unittests/evm_eof_test.cpp
@@ -262,7 +262,7 @@ TEST_P(evm, eof_eofcreate)
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data, deploy_data_size);
 
     const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + OP_CALLDATASIZE + 0 + OP_RETURNCONTRACT + Opcode{0};
+        calldatacopy(0, 0, OP_CALLDATASIZE) + OP_CALLDATASIZE + 0 + OP_RETURNCODE + Opcode{0};
     const auto init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto create_code = calldatacopy(0, 0, OP_CALLDATASIZE) +
@@ -296,11 +296,11 @@ TEST_P(evm, eofcreate_undefined_in_legacy)
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 }
 
-TEST_P(evm, returncontract_undefined_in_legacy)
+TEST_P(evm, returncode_undefined_in_legacy)
 {
     rev = EVMC_CANCUN;
     const auto code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + OP_CALLDATASIZE + 0 + OP_RETURNCONTRACT + Opcode{0};
+        calldatacopy(0, 0, OP_CALLDATASIZE) + OP_CALLDATASIZE + 0 + OP_RETURNCODE + Opcode{0};
 
     execute(code);
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);

--- a/test/unittests/instructions_test.cpp
+++ b/test/unittests/instructions_test.cpp
@@ -40,7 +40,7 @@ constexpr bool is_terminating(uint8_t op) noexcept
     case OP_RETURN:
     case OP_RETF:
     case OP_JUMPF:
-    case OP_RETURNCONTRACT:
+    case OP_RETURNCODE:
     case OP_REVERT:
     case OP_INVALID:
     case OP_SELFDESTRUCT:
@@ -63,7 +63,7 @@ constexpr void validate_traits_of() noexcept
     else if constexpr (Op == OP_RJUMPV)
         static_assert(tr.immediate_size == 1);
     else if constexpr (Op == OP_DUPN || Op == OP_SWAPN || Op == OP_EXCHANGE || Op == OP_EOFCREATE ||
-                       Op == OP_RETURNCONTRACT)
+                       Op == OP_RETURNCODE)
         static_assert(tr.immediate_size == 1);
     else if constexpr (Op == OP_DATALOADN)
         static_assert(tr.immediate_size == 2);
@@ -138,7 +138,7 @@ constexpr bool instruction_only_in_evmone(evmc_revision rev, Opcode op) noexcept
     case OP_EXTDELEGATECALL:
     case OP_EXTSTATICCALL:
     case OP_EOFCREATE:
-    case OP_RETURNCONTRACT:
+    case OP_RETURNCODE:
         return true;
     default:
         return false;

--- a/test/unittests/state_transition_eof_create_test.cpp
+++ b/test/unittests/state_transition_eof_create_test.cpp
@@ -179,7 +179,7 @@ TEST_F(state_transition, eofcreate_empty_auxdata)
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code = eofcreate().container(0).input(0, 0).salt(Salt) + ret_top();
@@ -204,8 +204,7 @@ TEST_F(state_transition, eofcreate_auxdata_equal_to_declared)
     const auto deploy_container =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto factory_code = calldatacopy(0, 0, OP_CALLDATASIZE) +
@@ -237,8 +236,7 @@ TEST_F(state_transition, eofcreate_auxdata_longer_than_declared)
     const auto deploy_container =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto factory_code = calldatacopy(0, 0, OP_CALLDATASIZE) +
@@ -270,8 +268,7 @@ TEST_F(state_transition, eofcreate_auxdata_shorter_than_declared)
     const auto deploy_container =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const auto init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto factory_code =
@@ -299,7 +296,7 @@ TEST_F(state_transition, eofcreate_dataloadn_referring_to_auxdata)
     const auto deploy_code = bytecode(OP_DATALOADN) + "0040" + ret_top();
     const auto deploy_container = eof_bytecode(deploy_code, 2).data(deploy_data, deploy_data_size);
 
-    const auto init_code = returncontract(0, 0, 32);
+    const auto init_code = returncode(0, 0, 32);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code =
@@ -330,8 +327,7 @@ TEST_F(state_transition, eofcreate_with_auxdata_and_subcontainer)
                                       .container(eof_bytecode(OP_INVALID))
                                       .data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto factory_code =
@@ -430,7 +426,7 @@ TEST_F(state_transition, eofcreate_deploy_container_max_size)
     EXPECT_EQ(deploy_container.size(), 0x6000);
 
     // no aux data
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code =
@@ -461,7 +457,7 @@ TEST_F(state_transition, eofcreate_deploy_container_too_large)
     EXPECT_EQ(deploy_container.size(), 0x6001);
 
     // no aux data
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const auto init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code =
@@ -487,8 +483,7 @@ TEST_F(state_transition, eofcreate_appended_data_size_larger_than_64K)
     const auto deploy_data = "aa"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     static constexpr bytes32 salt2{0xfe};
@@ -528,7 +523,7 @@ TEST_F(state_transition, eofcreate_deploy_container_with_aux_data_too_large)
     EXPECT_EQ(deploy_container.size(), 0x6000);
 
     // 1 byte aux data
-    const auto init_code = returncontract(0, 0, 1);
+    const auto init_code = returncode(0, 0, 1);
     const auto init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code =
@@ -553,11 +548,11 @@ TEST_F(state_transition, eofcreate_nested_eofcreate)
     const auto deploy_container_nested =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data_nested);
 
-    const auto init_code_nested = returncontract(0, 0, 0);
+    const auto init_code_nested = returncode(0, 0, 0);
     const bytecode init_container_nested =
         eof_bytecode(init_code_nested, 2).container(deploy_container_nested);
 
-    const auto init_code = sstore(0, eofcreate().container(1).salt(Salt)) + returncontract(0, 0, 0);
+    const auto init_code = sstore(0, eofcreate().container(1).salt(Salt)) + returncode(0, 0, 0);
     const bytecode init_container =
         eof_bytecode(init_code, 4).container(deploy_container).container(init_container_nested);
 
@@ -588,7 +583,7 @@ TEST_F(state_transition, eofcreate_nested_eofcreate_revert)
     const auto deploy_container_nested =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data_nested);
 
-    const auto init_code_nested = returncontract(0, 0, 0);
+    const auto init_code_nested = returncode(0, 0, 0);
     const auto init_container_nested =
         eof_bytecode(init_code_nested, 2).container(deploy_container_nested);
 
@@ -612,8 +607,7 @@ TEST_F(state_transition, eofcreate_caller_balance_too_low)
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode{Opcode{OP_INVALID}}).data(deploy_data);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const auto init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto factory_code =
@@ -635,7 +629,7 @@ TEST_F(state_transition, eofcreate_not_enough_gas_for_initcode_charge)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     auto init_container = eof_bytecode(init_code, 2).container(deploy_container);
     const uint16_t init_data_size = std::numeric_limits<uint16_t>::max() / 2 -
                                     static_cast<uint16_t>(bytecode(init_container).size());
@@ -669,8 +663,7 @@ TEST_F(state_transition, eofcreate_not_enough_gas_for_mem_expansion)
     EXPECT_EQ(
         bytecode(deploy_container).size() + aux_data_size, std::numeric_limits<uint16_t>::max());
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto factory_code =
@@ -693,7 +686,7 @@ TEST_F(state_transition, eofcreate_not_enough_gas_for_mem_expansion)
     expect.post[*tx.to].storage[0x00_bytes32] = 0x00_bytes32;
 }
 
-TEST_F(state_transition, returncontract_not_enough_gas_for_mem_expansion)
+TEST_F(state_transition, returncode_not_enough_gas_for_mem_expansion)
 {
     rev = EVMC_OSAKA;
     block.gas_limit = 10'000'000;
@@ -708,7 +701,7 @@ TEST_F(state_transition, returncontract_not_enough_gas_for_mem_expansion)
     EXPECT_EQ(
         bytecode(deploy_container).size() + aux_data_size, std::numeric_limits<uint16_t>::max());
 
-    const auto init_code = returncontract(0, 0, aux_data_size);
+    const auto init_code = returncode(0, 0, aux_data_size);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code = eofcreate().container(0).salt(Salt) + OP_POP + OP_STOP;
@@ -735,7 +728,7 @@ TEST_F(state_transition, eofcreate_clears_returndata)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(OP_STOP);
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code = sstore(0, extcall(returning_address)) + sstore(1, returndatasize()) +
@@ -771,7 +764,7 @@ TEST_F(state_transition, eofcreate_failure_after_eofcreate_success)
 
     const auto deploy_container = eof_bytecode(OP_STOP);
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     const auto factory_code = sstore(0, eofcreate().container(0).salt(Salt)) +
@@ -809,8 +802,7 @@ TEST_F(state_transition, eofcreate_call_created_contract)
                              ret_top();
     const auto deploy_container = eof_bytecode(deploy_code, 2).data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     const auto create_address = compute_create2_address(To, Salt, init_container);
@@ -852,7 +844,7 @@ TEST_F(state_transition, creation_tx)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     tx.data = init_container;
@@ -869,7 +861,7 @@ TEST_F(state_transition, creation_tx_deploy_data)
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     tx.data = init_container;
@@ -885,7 +877,7 @@ TEST_F(state_transition, creation_tx_static_auxdata_in_calldata)
     rev = EVMC_OSAKA;
     const auto deploy_data = "abcdef"_hex;
     // aux_data will be appended as calldata to the creation tx input, and later appended to the
-    // deployed contract's data section on RETURNCONTRACT.
+    // deployed contract's data section on RETURNCODE.
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size());
     const auto aux_data_size = static_cast<uint16_t>(aux_data.size());
@@ -894,8 +886,7 @@ TEST_F(state_transition, creation_tx_static_auxdata_in_calldata)
     const auto deploy_container =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data, deploy_data_size + aux_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     tx.data = init_container + bytecode(aux_data);
@@ -912,7 +903,7 @@ TEST_F(state_transition, creation_tx_dynamic_auxdata_in_calldata)
     rev = EVMC_OSAKA;
     const auto deploy_data = "abcdef"_hex;
     // aux_data will be appended as calldata to the creation tx input, and later appended the
-    // deployed contract's data section on RETURNCONTRACT.
+    // deployed contract's data section on RETURNCODE.
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size());
 
@@ -920,8 +911,7 @@ TEST_F(state_transition, creation_tx_dynamic_auxdata_in_calldata)
     const auto deploy_container =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     tx.data = init_container + bytecode(aux_data);
@@ -943,8 +933,7 @@ TEST_F(state_transition, creation_tx_dataloadn_referring_to_auxdata)
     const auto deploy_code = bytecode(OP_DATALOADN) + "0040" + ret_top();
     const auto deploy_container = eof_bytecode(deploy_code, 2).data(deploy_data, deploy_data_size);
 
-    const auto init_code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + returncontract(0, 0, OP_CALLDATASIZE);
+    const auto init_code = calldatacopy(0, 0, OP_CALLDATASIZE) + returncode(0, 0, OP_CALLDATASIZE);
     const bytecode init_container = eof_bytecode(init_code, 3).container(deploy_container);
 
     tx.data = init_container + bytecode(aux_data);
@@ -1002,7 +991,7 @@ TEST_F(state_transition, creation_tx_initcontainer_max_size)
 
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container_no_data = eof_bytecode(init_code, 2).container(deploy_container);
     const auto data_size = 0xc000 - init_container_no_data.size();
     const bytecode init_container =
@@ -1026,7 +1015,7 @@ TEST_F(state_transition, creation_tx_initcontainer_too_large)
 
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container_no_data = eof_bytecode(init_code, 2).container(deploy_container);
     const auto data_size = 0xc001 - init_container_no_data.size();
     const bytecode init_container =
@@ -1052,7 +1041,7 @@ TEST_F(state_transition, creation_tx_deploy_container_max_size)
     EXPECT_EQ(deploy_container.size(), 0x6000);
 
     // no aux data
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     tx.data = init_container;
@@ -1076,7 +1065,7 @@ TEST_F(state_transition, creation_tx_deploy_container_too_large)
     EXPECT_EQ(deploy_container.size(), 0x6001);
 
     // no aux data
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     tx.data = init_container;
@@ -1095,11 +1084,11 @@ TEST_F(state_transition, creation_tx_nested_eofcreate)
     const auto deploy_container_nested =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data_nested);
 
-    const auto init_code_nested = returncontract(0, 0, 0);
+    const auto init_code_nested = returncode(0, 0, 0);
     const bytecode init_container_nested =
         eof_bytecode(init_code_nested, 2).container(deploy_container_nested);
 
-    const auto init_code = sstore(0, eofcreate().container(1).salt(Salt)) + returncontract(0, 0, 0);
+    const auto init_code = sstore(0, eofcreate().container(1).salt(Salt)) + returncode(0, 0, 0);
     const bytecode init_container =
         eof_bytecode(init_code, 4).container(deploy_container).container(init_container_nested);
 
@@ -1121,7 +1110,7 @@ TEST_F(state_transition, creation_tx_invalid_initcode_header)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     bytes init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     assert(init_container[3] == 0x01);
@@ -1139,7 +1128,7 @@ TEST_F(state_transition, creation_tx_invalid_initcode)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytes init_container =
         eof_bytecode(init_code, 123).container(deploy_container);  // Invalid EOF
 
@@ -1155,7 +1144,7 @@ TEST_F(state_transition, creation_tx_truncated_data_initcode)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytes init_container =
         eof_bytecode(init_code, 2).data("", 1).container(deploy_container);  // Truncated data
 
@@ -1171,7 +1160,7 @@ TEST_F(state_transition, creation_tx_invalid_deploycode)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID), 123);  // Invalid EOF
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     const bytes init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     tx.data = init_container;
@@ -1186,7 +1175,7 @@ TEST_F(state_transition, creation_tx_invalid_eof_version)
     rev = EVMC_OSAKA;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
-    const auto init_code = returncontract(0, 0, 0);
+    const auto init_code = returncode(0, 0, 0);
     bytes init_container = eof_bytecode(init_code, 2).container(deploy_container);
 
     assert(init_container[2] == 0x01);

--- a/test/utils/bytecode.hpp
+++ b/test/utils/bytecode.hpp
@@ -382,10 +382,10 @@ inline bytecode ret(bytecode c)
     return c + ret_top();
 }
 
-inline bytecode returncontract(
+inline bytecode returncode(
     uint8_t container_index, bytecode aux_data_offset, bytecode aux_data_size)
 {
-    return aux_data_size + aux_data_offset + OP_RETURNCONTRACT + bytecode{bytes{container_index}};
+    return aux_data_size + aux_data_offset + OP_RETURNCODE + bytecode{bytes{container_index}};
 }
 
 inline bytecode revert(bytecode index, bytecode size)


### PR DESCRIPTION
As title, proposed for eof-devent-1, aligns with https://github.com/ipsilon/eof/pull/182. ~~Requires an update~~ Doesn't really require an update to EEST, but accompanying change drafted in https://github.com/ethereum/execution-spec-tests/pull/1284