### PR TITLE
docs: 404 link in `cmake/cable/README.md`

### DIFF
--- a/cmake/cable/README.md
+++ b/cmake/cable/README.md
@@ -96,7 +96,7 @@ Licensed under the [Apache License, Version 2.0].
 [@chfast]: https://github.com/chfast
 [Apache License, Version 2.0]: LICENSE
 [git submodule]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
-[git subtree]: https://github.com/git/git/blob/master/contrib/subtree/git-subtree.txt
+[git subtree]: https://github.com/git/git/blob/master/contrib/subtree/git-subtree.adoc
 [git subtree tutorial]: https://www.atlassian.com/blog/git/alternatives-to-git-submodule-git-subtree
 [standard readme]: https://github.com/RichardLitt/standard-readme
 


### PR DESCRIPTION
Noticed that the `git-subtree` documentation link in `README.md` was pointing to an outdated `.txt` file. The Git repo has been using `.adoc` for that part of the docs for a while now, so I’ve updated the URL to the correct one.


[git/git@561de07](https://github.com/git/git/commit/561de07b57fcc2057fb6b96043f008a5b83f140c) — shows the replacement of `git-subtree.txt` with `git-subtree.adoc` in Git’s documentation.  