### PR TITLE
precompiles: Use classic EC point add formula

### DIFF
--- a/lib/evmone_precompiles/bn254.cpp
+++ b/lib/evmone_precompiles/bn254.cpp
@@ -27,17 +27,9 @@ bool validate(const Point& pt) noexcept
     return y2 == x3_3;
 }
 
-Point add(const Point& pt1, const Point& pt2) noexcept
+Point add(const Point& p, const Point& q) noexcept
 {
-    if (pt1.is_inf())
-        return pt2;
-    if (pt2.is_inf())
-        return pt1;
-
-    // b3 == 9 for y^2 == x^3 + 3
-    const auto r = ecc::add(Fp, ecc::to_proj(Fp, pt1), ecc::to_proj(Fp, pt2), B3);
-
-    return ecc::to_affine(Fp, r);
+    return ecc::add(Fp, p, q);
 }
 
 Point mul(const Point& pt, const uint256& c) noexcept

--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -27,7 +27,7 @@ bool validate(const Point& pt) noexcept;
 /// Addition in bn254 curve group.
 ///
 /// Computes P ⊕ Q for two points in affine coordinates on the bn254 curve,
-Point add(const Point& pt1, const Point& pt2) noexcept;
+Point add(const Point& p, const Point& q) noexcept;
 
 /// Scalar multiplication in bn254 curve group.
 ///


### PR DESCRIPTION
This makes the BN254 `ecadd` precompile 30% faster.