### PR TITLE
ci: Don't run EOF tests from ethereum/tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -431,11 +431,6 @@ jobs:
             ~/tests/LegacyTests/Cancun/GeneralStateTests
             ~/tests/LegacyTests/Constantinople/GeneralStateTests
       - run:
-          name: "EOF validation tests"
-          working_directory: ~/build
-          command: >
-            bin/evmone-eoftest ~/tests/EOFTests
-      - run:
           name: "Blockchain tests (GeneralStateTests)"
           working_directory: ~/build
           command: >


### PR DESCRIPTION
They are relicts and being migrated to EEST. We don't plan to update these and they will become outdated soon.