### PR TITLE
ci: Upgrade EEST to v4.2.0 develop

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -353,19 +353,8 @@ jobs:
     steps:
       - build
       - download_execution_spec_tests:
-          release: v4.1.0
-      - run:
-          name: "Execution spec tests (state_tests)"
-          working_directory: ~/build
-          command: >
-            bin/evmone-statetest ~/spec-tests/fixtures/state_tests
-      - run:
-          name: "Execution spec tests (blockchain_tests)"
-          working_directory: ~/build
-          command: >
-            bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
-      - download_execution_spec_tests:
-          release: v4.1.0
+          release: v4.2.0
+          # develop includes stable
           fixtures_suffix: develop
       - run:
           name: "Execution spec tests (develop, state_tests)"
@@ -376,6 +365,7 @@ jobs:
       - run:
           name: "Execution spec tests (develop, blockchain_tests)"
           # Tests for in-development EVM revision currently passing.
+          # - the block_hashes_history test is disable because takes too long.
           working_directory: ~/spec-tests/fixtures/blockchain_tests
           command: >
             ~/build/bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests


### PR DESCRIPTION
This upgrades EEST to v4.2.0. It also only runs develop fixtures because they include the stable ones.