### PR TITLE
Handle failing system contracts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -414,6 +414,12 @@ jobs:
       - download_execution_tests:
           rev: v17.0
       - run:
+          name: "Filter-out invalid Prague tests"
+          working_directory: ~/tests
+          command: |
+            sudo apt-get -q update && sudo apt-get -qy install jq
+            find BlockchainTests -name '*.json' -exec sh -c 'jq "with_entries(select(.key | test(\"Prague\") | not))" {} > {}.tmp && mv {}.tmp {}' \;
+      - run:
           name: "State tests"
           working_directory: ~/build
           command: >

--- a/circle.yml
+++ b/circle.yml
@@ -356,19 +356,8 @@ jobs:
     steps:
       - build
       - download_execution_spec_tests:
-          release: v4.1.0
-      - run:
-          name: "Execution spec tests (state_tests)"
-          working_directory: ~/build
-          command: >
-            bin/evmone-statetest ~/spec-tests/fixtures/state_tests
-      - run:
-          name: "Execution spec tests (blockchain_tests)"
-          working_directory: ~/build
-          command: >
-            bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
-      - download_execution_spec_tests:
-          release: v4.1.0
+          release: v4.3.0
+          # develop includes stable
           fixtures_suffix: develop
       - run:
           name: "Execution spec tests (develop, state_tests)"
@@ -379,6 +368,7 @@ jobs:
       - run:
           name: "Execution spec tests (develop, blockchain_tests)"
           # Tests for in-development EVM revision currently passing.
+          # - The block_hashes_history test is disabled because it takes too long.
           working_directory: ~/spec-tests/fixtures/blockchain_tests
           command: >
             ~/build/bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -84,7 +84,12 @@ TransitionResult apply_block(TestState& state, evmc::VM& vm, const state::BlockI
         std::vector<state::Requests> collected;
 
         if (rev >= EVMC_PRAGUE)
-            collected.emplace_back(collect_deposit_requests(receipts));
+        {
+            auto opt_deposits = collect_deposit_requests(receipts);
+            if (!opt_deposits.has_value())
+                return std::nullopt;
+            collected.emplace_back(std::move(*opt_deposits));
+        }
 
         auto requests_result = system_call_block_end(block_state, block, block_hashes, rev, vm);
         if (!requests_result.has_value())

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -24,7 +24,7 @@ struct TransitionResult
 {
     std::vector<state::TransactionReceipt> receipts;
     std::vector<RejectedTransaction> rejected;
-    std::vector<state::Requests> requests;
+    std::optional<std::vector<state::Requests>> requests;
     int64_t gas_used;
     state::BloomFilter bloom;
     int64_t blob_gas_left;
@@ -80,12 +80,19 @@ TransitionResult apply_block(TestState& state, evmc::VM& vm, const state::BlockI
         }
     }
 
-    std::vector<state::Requests> requests;
-    if (rev >= EVMC_PRAGUE)
-        requests.emplace_back(collect_deposit_requests(receipts));
+    auto requests = [&]() -> std::optional<std::vector<state::Requests>> {
+        std::vector<state::Requests> collected;
 
-    auto system_call_requests = system_call_block_end(block_state, block, block_hashes, rev, vm);
-    std::ranges::move(system_call_requests, std::back_inserter(requests));
+        if (rev >= EVMC_PRAGUE)
+            collected.emplace_back(collect_deposit_requests(receipts));
+
+        auto requests_result = system_call_block_end(block_state, block, block_hashes, rev, vm);
+        if (!requests_result.has_value())
+            return std::nullopt;
+        std::ranges::move(*requests_result, std::back_inserter(collected));
+
+        return collected;
+    }();
 
     finalize(block_state, rev, block.coinbase, block_reward, block.ommers, block.withdrawals);
 
@@ -207,6 +214,8 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                 const auto res = apply_block(
                     state, vm, bi, block_hashes, test_block.transactions, rev, mining_reward(rev));
 
+                ASSERT_TRUE(res.requests.has_value());
+
                 block_hashes[test_block.expected_block_header.block_number] =
                     test_block.expected_block_header.hash;
                 state = res.block_state;
@@ -230,7 +239,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     state::mpt_hash(res.receipts), test_block.expected_block_header.receipts_root);
                 if (rev >= EVMC_PRAGUE)
                 {
-                    EXPECT_EQ(calculate_requests_hash(res.requests),
+                    EXPECT_EQ(calculate_requests_hash(*res.requests),
                         test_block.expected_block_header.requests_hash);
                 }
                 EXPECT_EQ(res.gas_used, test_block.expected_block_header.gas_used);
@@ -244,6 +253,8 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
 
                 const auto res = apply_block(
                     state, vm, bi, block_hashes, test_block.transactions, rev, mining_reward(rev));
+                if (!res.requests.has_value())
+                    continue;
                 if (!res.rejected.empty())
                     continue;
                 if (res.blob_gas_left != 0)
@@ -260,7 +271,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
                     continue;
                 if (state::mpt_hash(res.receipts) != test_block.expected_block_header.receipts_root)
                     continue;
-                if (rev >= EVMC_PRAGUE && calculate_requests_hash(res.requests) !=
+                if (rev >= EVMC_PRAGUE && calculate_requests_hash(*res.requests) !=
                                               test_block.expected_block_header.requests_hash)
                     continue;
                 if (res.gas_used != test_block.expected_block_header.gas_used)
@@ -271,7 +282,7 @@ void run_blockchain_tests(std::span<const BlockchainTest> tests, evmc::VM& vm)
 
                 EXPECT_TRUE(false) << "Expected block to be invalid but resulted valid";
 
-                // Apply the resulting state in order to continue testing expectations, even if
+                // Apply the resulting state to continue testing expectations, even if
                 // the test already has gone into failed state here.
                 block_hashes[test_block.expected_block_header.block_number] =
                     test_block.expected_block_header.hash;

--- a/test/state/requests.cpp
+++ b/test/state/requests.cpp
@@ -29,55 +29,67 @@ hash256 calculate_requests_hash(std::span<const Requests> block_requests_list)
     return block_requests_hash;
 }
 
-Requests collect_deposit_requests(std::span<const TransactionReceipt> receipts)
+std::optional<Requests> collect_deposit_requests(std::span<const TransactionReceipt> receipts)
 {
+    // Browse all logs from all transactions.
     Requests requests(Requests::Type::deposit);
     for (const auto& receipt : receipts)
     {
         for (const auto& log : receipt.logs)
         {
-            assert(log.addr != DEPOSIT_CONTRACT_ADDRESS || !log.topics.empty());
-            if (log.addr == DEPOSIT_CONTRACT_ADDRESS &&
-                log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH)
-            {
-                // Deposit log definition
-                // https://github.com/ethereum/consensus-specs/blob/dev/solidity_deposit_contract/deposit_contract.sol
-                // event DepositEvent(
-                //     bytes pubkey,
-                //     bytes withdrawal_credentials,
-                //     bytes amount,
-                //     bytes signature,
-                //     bytes index
-                // );
-                //
-                // In ABI every bytes array data is prepended by a word with its size.
-                // Skip over first 5 words (offsets of the values) and over pubkey size.
-                static constexpr auto PUBKEY_OFFSET = 32 * 5 + 32;
-                static constexpr auto PUBKEY_SIZE = 48;
-                // Pubkey size is 48 bytes, but is padded to word boundary, so takes 64 bytes.
-                // Skip over pubkey and withdrawal credentials size.
-                static constexpr auto WITHDRAWAL_CREDS_OFFSET = PUBKEY_OFFSET + 64 + 32;
-                static constexpr auto WITHDRAWAL_CREDS_SIZE = 32;
-                // Skip over withdrawal credentials and amount size.
-                static constexpr auto AMOUNT_OFFSET = WITHDRAWAL_CREDS_OFFSET + 32 + 32;
-                static constexpr auto AMOUNT_SIZE = 8;
-                // Pubkey size is 8 bytes, but is padded to word boundary, so takes 32 bytes.
-                // Skip over amount and signature size.
-                static constexpr auto SIGNATURE_OFFSET = AMOUNT_OFFSET + 32 + 32;
-                static constexpr auto SIGNATURE_SIZE = 96;
-                // Skip over signature and index size.
-                static constexpr auto INDEX_OFFSET = SIGNATURE_OFFSET + 96 + 32;
-                static constexpr auto INDEX_SIZE = 8;
+            // Follow the EIP-6110 pseudocode for block validity.
+            // https://eips.ethereum.org/EIPS/eip-6110#block-validity
 
-                // Index is padded to word boundary, so takes 32 bytes.
-                assert(log.data.size() == INDEX_OFFSET + 32);
+            // Filter out logs by the contact address and the log first topic.
+            if (log.addr != DEPOSIT_CONTRACT_ADDRESS)
+                continue;
+            if (log.topics.empty() || log.topics[0] != DEPOSIT_EVENT_SIGNATURE_HASH)
+                continue;
 
-                requests.append({&log.data[PUBKEY_OFFSET], PUBKEY_SIZE});
-                requests.append({&log.data[WITHDRAWAL_CREDS_OFFSET], WITHDRAWAL_CREDS_SIZE});
-                requests.append({&log.data[AMOUNT_OFFSET], AMOUNT_SIZE});
-                requests.append({&log.data[SIGNATURE_OFFSET], SIGNATURE_SIZE});
-                requests.append({&log.data[INDEX_OFFSET], INDEX_SIZE});
-            }
+            // Validate the layout of the log. If it doesn't match the EIP spec,
+            // the requests' collection is failed.
+            if (log.data.size() != 576)
+                return std::nullopt;
+
+            // Deposit log definition
+            // https://github.com/ethereum/consensus-specs/blob/dev/solidity_deposit_contract/deposit_contract.sol
+            // event DepositEvent(
+            //     bytes pubkey,
+            //     bytes withdrawal_credentials,
+            //     bytes amount,
+            //     bytes signature,
+            //     bytes index
+            // );
+            //
+            // In ABI a word with its size prepends every bytes array.
+            // Skip over the first 5 words (offsets of the values) and the pubkey size.
+            // TODO: EIP requires to read these offsets and validate them.
+            //       This has not been implemented yet because there are no tests for it.
+            static constexpr auto PUBKEY_OFFSET = 32 * 5 + 32;
+            static constexpr auto PUBKEY_SIZE = 48;
+            // Pubkey size is 48 bytes, but is padded to the word boundary, so takes 64 bytes.
+            // Skip over the pubkey and withdrawal credentials size.
+            static constexpr auto WITHDRAWAL_CREDS_OFFSET = PUBKEY_OFFSET + 64 + 32;
+            static constexpr auto WITHDRAWAL_CREDS_SIZE = 32;
+            // Skip over withdrawal credentials and amount size.
+            static constexpr auto AMOUNT_OFFSET = WITHDRAWAL_CREDS_OFFSET + 32 + 32;
+            static constexpr auto AMOUNT_SIZE = 8;
+            // Pubkey size is 8 bytes, but is padded to the word boundary, so takes 32 bytes.
+            // Skip over amount and signature size.
+            static constexpr auto SIGNATURE_OFFSET = AMOUNT_OFFSET + 32 + 32;
+            static constexpr auto SIGNATURE_SIZE = 96;
+            // Skip over signature and index size.
+            static constexpr auto INDEX_OFFSET = SIGNATURE_OFFSET + 96 + 32;
+            static constexpr auto INDEX_SIZE = 8;
+
+            // Index is padded to the word boundary, so takes 32 bytes.
+            assert(log.data.size() == INDEX_OFFSET + 32);
+
+            requests.append({&log.data[PUBKEY_OFFSET], PUBKEY_SIZE});
+            requests.append({&log.data[WITHDRAWAL_CREDS_OFFSET], WITHDRAWAL_CREDS_SIZE});
+            requests.append({&log.data[AMOUNT_OFFSET], AMOUNT_SIZE});
+            requests.append({&log.data[SIGNATURE_OFFSET], SIGNATURE_SIZE});
+            requests.append({&log.data[INDEX_OFFSET], INDEX_SIZE});
         }
     }
     return requests;

--- a/test/state/requests.hpp
+++ b/test/state/requests.hpp
@@ -65,6 +65,8 @@ struct Requests
 /// Calculate commitment value of block requests list
 hash256 calculate_requests_hash(std::span<const Requests> requests_list);
 
-/// Construct requests object from logs of the deposit contract.
-Requests collect_deposit_requests(std::span<const TransactionReceipt> receipts);
+/// Construct a requests object from logs of the deposit contract.
+///
+/// @return The collected deposit requests or std::nullopt if the collection has failed.
+std::optional<Requests> collect_deposit_requests(std::span<const TransactionReceipt> receipts);
 }  // namespace evmone::state

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -49,7 +49,7 @@ struct RequestsResult
 ///
 /// Executes code of pre-defined accounts via pseudo-transaction from the system sender (0xff...fe).
 /// The sender's nonce is not increased.
-[[nodiscard]] RequestsResult system_call_block_end(const StateView& state_view,
-    const BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev,
-    evmc::VM& vm);
+/// @return The collected requests and state diff or std::nullopt if the execution has failed.
+[[nodiscard]] std::optional<RequestsResult> system_call_block_end(const StateView& state_view,
+    const BlockInfo& block, const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
 }  // namespace evmone::state

--- a/test/state/test_state.cpp
+++ b/test/state/test_state.cpp
@@ -101,11 +101,14 @@ void system_call_block_start(TestState& state, const state::BlockInfo& block,
     state.apply(diff);
 }
 
-std::vector<state::Requests> system_call_block_end(TestState& state, const state::BlockInfo& block,
-    const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
+std::optional<std::vector<state::Requests>> system_call_block_end(TestState& state,
+    const state::BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev,
+    evmc::VM& vm)
 {
-    auto [diff, requests] = state::system_call_block_end(state, block, block_hashes, rev, vm);
-    state.apply(diff);
-    return std::move(requests);
+    auto result = state::system_call_block_end(state, block, block_hashes, rev, vm);
+    if (!result.has_value())
+        return std::nullopt;
+    state.apply(result->state_diff);
+    return std::move(result->requests);
 }
 }  // namespace evmone::test

--- a/test/state/test_state.hpp
+++ b/test/state/test_state.hpp
@@ -97,7 +97,8 @@ void system_call_block_start(TestState& state, const state::BlockInfo& block,
     const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
 
 /// Wrapping of state::system_call_block_end() which operates on TestState.
-std::vector<state::Requests> system_call_block_end(TestState& state, const state::BlockInfo& block,
-    const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
+std::optional<std::vector<state::Requests>> system_call_block_end(TestState& state,
+    const state::BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev,
+    evmc::VM& vm);
 }  // namespace test
 }  // namespace evmone

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -231,7 +231,9 @@ int main(int argc, const char* argv[])
             if (!pre_state_only && rev >= EVMC_PRAGUE)
             {
                 // TODO: Report invalid block if system contracts execution fails.
-                requests.emplace_back(collect_deposit_requests(receipts));
+                auto deposits_result = collect_deposit_requests(receipts);
+                if (deposits_result.has_value())
+                    requests.emplace_back(std::move(*deposits_result));
                 auto requests_result = system_call_block_end(state, block, block_hashes, rev, vm);
                 if (requests_result.has_value())
                     std::ranges::move(*requests_result, std::back_inserter(requests));

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -230,11 +230,11 @@ int main(int argc, const char* argv[])
 
             if (!pre_state_only && rev >= EVMC_PRAGUE)
             {
+                // TODO: Report invalid block if system contracts execution fails.
                 requests.emplace_back(collect_deposit_requests(receipts));
-
-                auto system_call_requests =
-                    system_call_block_end(state, block, block_hashes, rev, vm);
-                std::ranges::move(system_call_requests, std::back_inserter(requests));
+                auto requests_result = system_call_block_end(state, block, block_hashes, rev, vm);
+                if (requests_result.has_value())
+                    std::ranges::move(*requests_result, std::back_inserter(requests));
             }
 
             test::finalize(

--- a/test/unittests/state_deposit_requests_test.cpp
+++ b/test/unittests/state_deposit_requests_test.cpp
@@ -23,7 +23,7 @@ TEST(state_deposit_requests, collect_deposit_requests)
     log_data.replace(13 * 32, 96, 96, 0x04);  // signature
     log_data.replace(17 * 32, 8, 8, 0x05);    // index
 
-    const auto requests = collect_deposit_requests(receipts);
+    const auto requests = collect_deposit_requests(receipts).value();
     EXPECT_EQ(requests.type(), Requests::Type::deposit);
     EXPECT_EQ(requests.data(),
         bytes(48, 0x01) + bytes(32, 0x02) + bytes(8, 0x03) + bytes(96, 0x04) + bytes(8, 0x05));
@@ -38,7 +38,7 @@ TEST(state_deposit_requests, collect_deposit_requests_skips_wrong_topic)
                                .topics = {DUMMPY_EVENT_SIGNATURE_HASH}}}},
     };
 
-    const auto requests = collect_deposit_requests(receipts);
+    const auto requests = collect_deposit_requests(receipts).value();
     EXPECT_EQ(requests.type(), Requests::Type::deposit);
     EXPECT_TRUE(requests.data().empty());
 }


### PR DESCRIPTION
- The EIP-7002 (withdrawal requests) and EIP-7251 (consolidation requests) have been updated to specify that a failing system contract makes the block invalid.

  - https://github.com/ethereum/EIPs/pull/9508
  - https://github.com/ethereum/EIPs/pull/9582

- Add support for minimal EIP-6110 deposit log validation following the spec update. The invalid deposit logs invalidate the block.

  - https://github.com/ethereum/EIPs/pull/9460

- Upgrade EEST to v4.3.0