### PR TITLE
Don't create dummy requests for empty system contracts

### DIFF
--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -73,10 +73,7 @@ std::pair<StateDiff, std::vector<Requests>> system_call(
         // > if no code exists at [address], the call must fail silently.
         const auto code = state_view.get_account_code(addr);
         if (code.empty())
-        {
-            requests.emplace_back(request_type);
             continue;
-        }
 
         bytes32 input32;
         bytes_view input;

--- a/test/unittests/state_system_call_test.cpp
+++ b/test/unittests/state_system_call_test.cpp
@@ -87,11 +87,9 @@ TEST_F(state_system_call, withdrawal)
     ASSERT_EQ(storage.size(), 1);
     EXPECT_EQ(storage.at(0x01_bytes32), 0x01_bytes32);
 
-    ASSERT_EQ(requests.size(), 2);
+    ASSERT_EQ(requests.size(), 1);
     EXPECT_EQ(requests[0].type(), Requests::Type::withdrawal);
     EXPECT_EQ(requests[0].data(), bytes(WITHDRAWAL_REQUEST));
-    EXPECT_EQ(requests[1].type(), Requests::Type::consolidation);
-    EXPECT_TRUE(requests[1].data().empty());
 }
 
 TEST_F(state_system_call, consolidation)
@@ -111,9 +109,7 @@ TEST_F(state_system_call, consolidation)
     ASSERT_EQ(storage.size(), 1);
     EXPECT_EQ(storage.at(0x01_bytes32), 0x01_bytes32);
 
-    ASSERT_EQ(requests.size(), 2);
-    EXPECT_EQ(requests[0].type(), Requests::Type::withdrawal);
-    EXPECT_TRUE(requests[0].data().empty());
-    EXPECT_EQ(requests[1].type(), Requests::Type::consolidation);
-    EXPECT_EQ(requests[1].data(), bytes(CONSOLIDATION_REQUEST));
+    ASSERT_EQ(requests.size(), 1);
+    EXPECT_EQ(requests[0].type(), Requests::Type::consolidation);
+    EXPECT_EQ(requests[0].data(), bytes(CONSOLIDATION_REQUEST));
 }


### PR DESCRIPTION
When executing "requests" system contracts at the end of a block we create single-byte requests for the matching contract. I think this comes from the earlier spec revision. Currently this is not necessary because empty requests are skipped:
- when computing the requests hash: https://github.com/ethereum/evmone/blob/f9f8d5103c14bb0c4e6a3422884d1624adb1dda9/test/state/requests.cpp#L17
- in t8n: https://github.com/ethereum/evmone/blob/5a42fc60c4bdf471d115975c9858550ddc271f6b/test/t8n/t8n.cpp#L267