### PR TITLE
Refactor system contracts execution

### DIFF
--- a/test/state/system_contracts.cpp
+++ b/test/state/system_contracts.cpp
@@ -10,61 +10,83 @@ namespace evmone::state
 {
 namespace
 {
-/// Information about a registered system contract.
-struct SystemContract
+/// Information about a registered "storage" system contract. They are executed at the block start
+/// to store additional information in the State.
+struct StorageSystemContract
 {
     using GetInputFn = bytes32(const BlockInfo&, const BlockHashes&) noexcept;
 
     evmc_revision since = EVMC_MAX_REVISION;  ///< EVM revision in which added.
     address addr;                             ///< Address of the system contract.
     GetInputFn* get_input = nullptr;          ///< How to get the input for the system call.
-    /// Type of requests returned by block end system call.
-    /// Ignored for block start system contracts.
-    Requests::Type request_type = Requests::Type::deposit;
 };
 
-/// Registered system contracts.
-constexpr std::array SYSTEM_CONTRACTS_BLOCK_START{
-    SystemContract{EVMC_CANCUN, BEACON_ROOTS_ADDRESS,
+/// Information about a registered "requests" system contract. They are executed at the block end
+/// and produce requests: typed sequence of bytes.
+struct RequestsSystemContract
+{
+    evmc_revision since = EVMC_MAX_REVISION;                ///< EVM revision in which added.
+    address addr;                                           ///< Address of the system contract.
+    Requests::Type request_type = Requests::Type::deposit;  ///< Type of requests produced.
+};
+
+/// Registered "storage" system contracts.
+constexpr std::array STORAGE_SYSTEM_CONTRACTS{
+    StorageSystemContract{EVMC_CANCUN, BEACON_ROOTS_ADDRESS,
         [](const BlockInfo& block, const BlockHashes&) noexcept {
             return block.parent_beacon_block_root;
         }},
-    SystemContract{EVMC_PRAGUE, HISTORY_STORAGE_ADDRESS,
+    StorageSystemContract{EVMC_PRAGUE, HISTORY_STORAGE_ADDRESS,
         [](const BlockInfo& block, const BlockHashes& block_hashes) noexcept {
             return block_hashes.get_block_hash(block.number - 1);
         }},
 };
 
-static_assert(std::ranges::is_sorted(SYSTEM_CONTRACTS_BLOCK_START,
-                  [](const auto& a, const auto& b) noexcept { return a.since < b.since; }),
-    "system contract entries must be ordered by revision");
-
-constexpr std::array SYSTEM_CONTRACTS_BLOCK_END{
-    SystemContract{
+/// Registered "requests" system contracts.
+constexpr std::array REQUESTS_SYSTEM_CONTRACTS{
+    RequestsSystemContract{
         EVMC_PRAGUE,
         WITHDRAWAL_REQUEST_ADDRESS,
-        nullptr,
         Requests::Type::withdrawal,
     },
-    SystemContract{
+    RequestsSystemContract{
         EVMC_PRAGUE,
         CONSOLIDATION_REQUEST_ADDRESS,
-        nullptr,
         Requests::Type::consolidation,
     },
 };
 
-static_assert(std::ranges::is_sorted(SYSTEM_CONTRACTS_BLOCK_END,
-                  [](const auto& a, const auto& b) noexcept { return a.since < b.since; }),
+constexpr auto by_rev = [](const auto& a, const auto& b) noexcept { return a.since < b.since; };
+static_assert(std::ranges::is_sorted(STORAGE_SYSTEM_CONTRACTS, by_rev),
+    "system contract entries must be ordered by revision");
+static_assert(std::ranges::is_sorted(REQUESTS_SYSTEM_CONTRACTS, by_rev),
     "system contract entries must be ordered by revision");
 
-std::pair<StateDiff, std::vector<Requests>> system_call(
-    std::span<const SystemContract> system_contracts, const StateView& state_view,
-    const BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
+
+evmc::Result execute_system_call(State& state, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm, const address& addr,
+    bytes_view code, bytes_view input)
+{
+    const evmc_message msg{
+        .kind = EVMC_CALL,
+        .gas = 30'000'000,
+        .recipient = addr,
+        .sender = SYSTEM_ADDRESS,
+        .input_data = input.data(),
+        .input_size = input.size(),
+    };
+
+    const Transaction empty_tx{};
+    Host host{rev, vm, state, block, block_hashes, empty_tx};
+    return vm.execute(host, rev, msg, code.data(), code.size());
+}
+}  // namespace
+
+StateDiff system_call_block_start(const StateView& state_view, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
 {
     State state{state_view};
-    std::vector<Requests> requests;
-    for (const auto& [since, addr, get_input, request_type] : system_contracts)
+    for (const auto& [since, addr, get_input] : STORAGE_SYSTEM_CONTRACTS)
     {
         if (rev < since)
             break;  // Because entries are ordered, there are no other contracts for this revision.
@@ -75,47 +97,33 @@ std::pair<StateDiff, std::vector<Requests>> system_call(
         if (code.empty())
             continue;
 
-        bytes32 input32;
-        bytes_view input;
-        if (get_input != nullptr)
-        {
-            input32 = get_input(block, block_hashes);
-            input = input32;
-        }
+        const auto input32 = get_input(block, block_hashes);
+        const auto res =
+            execute_system_call(state, block, block_hashes, rev, vm, addr, code, input32);
+        assert(res.status_code == EVMC_SUCCESS);
+    }
+    // TODO: Should we return empty diff if no system contracts?
+    return state.build_diff(rev);
+}
 
-        const evmc_message msg{
-            .kind = EVMC_CALL,
-            .gas = 30'000'000,
-            .recipient = addr,
-            .sender = SYSTEM_ADDRESS,
-            .input_data = input.data(),
-            .input_size = input.size(),
-        };
+RequestsResult system_call_block_end(const StateView& state_view, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
+{
+    State state{state_view};
+    std::vector<Requests> requests;
+    for (const auto& [since, addr, request_type] : REQUESTS_SYSTEM_CONTRACTS)
+    {
+        if (rev < since)
+            break;  // Because entries are ordered, there are no other contracts for this revision.
 
-        const Transaction empty_tx{};
-        Host host{rev, vm, state, block, block_hashes, empty_tx};
-        const auto res = vm.execute(host, rev, msg, code.data(), code.size());
+        const auto code = state_view.get_account_code(addr);
+        if (code.empty())
+            continue;
+
+        const auto res = execute_system_call(state, block, block_hashes, rev, vm, addr, code, {});
         assert(res.status_code == EVMC_SUCCESS);
         requests.emplace_back(request_type, bytes_view{res.output_data, res.output_size});
     }
-
-    // TODO: Should we return empty diff if no system contracts?
     return {state.build_diff(rev), requests};
-}
-}  // namespace
-
-StateDiff system_call_block_start(const StateView& state_view, const BlockInfo& block,
-    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
-{
-    // No requests are generated in block start system calls.
-    const auto [state_diff, _] =
-        system_call(SYSTEM_CONTRACTS_BLOCK_START, state_view, block, block_hashes, rev, vm);
-    return state_diff;
-}
-
-std::pair<StateDiff, std::vector<Requests>> system_call_block_end(const StateView& state_view,
-    const BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
-{
-    return system_call(SYSTEM_CONTRACTS_BLOCK_END, state_view, block, block_hashes, rev, vm);
 }
 }  // namespace evmone::state

--- a/test/state/system_contracts.hpp
+++ b/test/state/system_contracts.hpp
@@ -38,12 +38,18 @@ class StateView;
 [[nodiscard]] StateDiff system_call_block_start(const StateView& state_view, const BlockInfo& block,
     const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
 
+struct RequestsResult
+{
+    StateDiff state_diff;            ///< State diff of the system contracts execution.
+    std::vector<Requests> requests;  ///< Collected requests.
+};
+
 /// Performs the system call: invokes system contracts that have to be executed
 /// at the end of the block.
 ///
 /// Executes code of pre-defined accounts via pseudo-transaction from the system sender (0xff...fe).
 /// The sender's nonce is not increased.
-[[nodiscard]] std::pair<StateDiff, std::vector<Requests>> system_call_block_end(
-    const StateView& state_view, const BlockInfo& block, const state::BlockHashes& block_hashes,
-    evmc_revision rev, evmc::VM& vm);
+[[nodiscard]] RequestsResult system_call_block_end(const StateView& state_view,
+    const BlockInfo& block, const state::BlockHashes& block_hashes, evmc_revision rev,
+    evmc::VM& vm);
 }  // namespace evmone::state

--- a/test/state/test_state.cpp
+++ b/test/state/test_state.cpp
@@ -104,8 +104,8 @@ void system_call_block_start(TestState& state, const state::BlockInfo& block,
 std::vector<state::Requests> system_call_block_end(TestState& state, const state::BlockInfo& block,
     const state::BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
 {
-    const auto [diff, requests] = state::system_call_block_end(state, block, block_hashes, rev, vm);
+    auto [diff, requests] = state::system_call_block_end(state, block, block_hashes, rev, vm);
     state.apply(diff);
-    return requests;
+    return std::move(requests);
 }
 }  // namespace evmone::test


### PR DESCRIPTION
Split execution for "storage" and "requests" system contract. The differences between executing these sets of system contracts are already big enough and are going to increase in the future.