### PR TITLE
Fix misplaced parenthesis & duplicate 

### DIFF
--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -41,7 +41,7 @@ private:
     static constexpr UintT compute_r_squared(const UintT& mod) noexcept
     {
         // R is 2^num_bits, R² is 2^(2*num_bits) and needs 2*num_bits+1 bits to represent,
-        // rounded to 2*num_bits+64) for intx requirements.
+        // rounded to (2*num_bits+64) for intx requirements.
         constexpr auto r2 = intx::uint<UintT::num_bits * 2 + 64>{1} << (UintT::num_bits * 2);
         return intx::udivrem(r2, mod).rem;
     }

--- a/lib/evmone/advanced_analysis.cpp
+++ b/lib/evmone/advanced_analysis.cpp
@@ -56,7 +56,7 @@ AdvancedCodeAnalysis analyze(evmc_revision rev, bytes_view code) noexcept
     analysis.instrs.emplace_back(opx_beginblock_fn);
     auto block = BlockAnalysis{0};
 
-    // TODO: Iterators are not used here because because push_end may point way outside of code
+    // TODO: Iterators are not used here because push_end may point way outside of code
     //       and this is not allowed and MSVC will detect it with instrumented iterators.
     const auto code_begin = code.data();
     const auto code_end = code_begin + code.size();


### PR DESCRIPTION
- include/evmmax/evmmax.hpp: add missing opening parenthesis (`2*num_bits+64)` → `(2*num_bits+64)`).
- lib/evmone/advanced_analysis.cpp: remove duplicate “because”.
No functional changes.