### PR TITLE
build,ci: Improve clang's source based coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,10 @@ if(CABLE_COMPILER_GNULIKE)
     )
 
     if(CABLE_COMPILER_CLANG)
-        set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")
+        # Enable Clang's Source Based Coverage.
+        # https://clang.llvm.org/docs/SourceBasedCodeCoverage.html
+        # We can enable optimizations and disable asserts.
+        set(CMAKE_CXX_FLAGS_COVERAGE "-O2 -DNDEBUG -fprofile-instr-generate -fcoverage-mapping")
     elseif(CABLE_COMPILER_GNU)
         set(CMAKE_CXX_FLAGS_COVERAGE "--coverage")
     endif()

--- a/circle.yml
+++ b/circle.yml
@@ -560,11 +560,9 @@ jobs:
 
   clang-latest-coverage:
     executor: linux-clang-latest
-    resource_class: small
     environment:
-      CMAKE_BUILD_PARALLEL_LEVEL: 2
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
       BUILD_TYPE: Coverage
-      TESTS_FILTER: unittests|integration
     steps:
       - build
       - test
@@ -572,13 +570,12 @@ jobs:
           name: "Coverage report"
           working_directory: ~/build
           command: |
-            ARGS='lib/libevmone.so -Xdemangler llvm-cxxfilt -instr-profile=evmone.profdata -ignore-filename-regex=include/evmc'
-            SHOW_ARGS='-format=html -show-branches=count -show-regions -show-expansions'
+            OBJECTS="-object bin/evmone-unittests -object bin/evmone-statetest -object bin/evmone-blockchaintest -object bin/evmone-t8n"
+            ARGS="lib/libevmone.so $OBJECTS -Xdemangler llvm-cxxfilt -instr-profile=evmone.profdata -ignore-filename-regex=include/evmc"
             
             mkdir ~/coverage
             llvm-profdata merge -sparse *.profraw -o evmone.profdata
-            llvm-cov show $ARGS $SHOW_ARGS > ~/coverage/full.html
-            llvm-cov show $ARGS $SHOW_ARGS -region-coverage-lt=100 > ~/coverage/missing.html
+            llvm-cov show $ARGS -format=html -show-directory-coverage -show-line-counts-or-regions -o ~/coverage/html
 
             llvm-cov report $ARGS > ~/coverage/report.txt
             llvm-cov report $ARGS -use-color


### PR DESCRIPTION
- Enable optimization in the clang's coverage build.
- Disable asserts in the clang's coverage build. Asserts are not good for coverage because they always have an uncovered branch.
- Generate better HTML report on CI.
- Extend coverage collection to all source code (not only libevmone).

Here is the HTML report for this PR: https://output.circle-artifacts.com/output/job/bd5443f4-1c3e-425b-a7ab-7fae838f229b/artifacts/0/coverage/html/coverage/home/builder/index.html.