### PR TITLE
Mark the EVM stack pointer as 32-byte aligned

### DIFF
--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -21,7 +21,9 @@ class StackTop
     uint256* m_end;  ///< Pointer to the stack end (1 slot above the stack top item).
 
 public:
-    explicit(false) StackTop(uint256* end) noexcept : m_end{end} {}
+    explicit(false) StackTop(uint256* end) noexcept
+      : m_end{std::assume_aligned<sizeof(uint256)>(end)}
+    {}
 
     /// Returns the pointer to the stack end (the stack slot above the top item).
     [[nodiscard]] uint256* end() noexcept { return m_end; }


### PR DESCRIPTION
This is guaranteed by the stack space allocation.

This allows the compiler to use aligned vector load instructions. Unfortunately, no performance gains on latest CPUs because aligned/unaligned instructions have the same cost there.