### PR TITLE
test: Support withdrawals blockchain tests with fields wider than uint64

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -441,7 +441,6 @@ jobs:
           working_directory: ~/build
           command: >
             bin/evmone-blockchaintest
-            --gtest_filter='*:-bc4895-withdrawals.*'
             ~/tests/BlockchainTests/InvalidBlocks
             ~/tests/LegacyTests/Cancun/BlockchainTests/InvalidBlocks
       - collect_coverage_gcc

--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -48,6 +48,7 @@ struct TestBlock
 {
     state::BlockInfo block_info;
     std::vector<state::Transaction> transactions;
+    bool withdrawals_parse_success = true;
     bool valid = true;
 
     BlockHeader expected_block_header;

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -103,10 +103,21 @@ static TestBlock load_test_block(const json::json& j, const RevisionSchedule& re
         }
     }
 
-    if (auto it = j.find("withdrawals"); it != j.end())
+    if (const auto withdrawals_it = j.find("withdrawals"); withdrawals_it != j.end())
     {
-        for (const auto& withdrawal : *it)
-            tb.block_info.withdrawals.emplace_back(from_json<Withdrawal>(withdrawal));
+        try
+        {
+            for (const auto& withdrawal : *withdrawals_it)
+                tb.block_info.withdrawals.push_back(from_json<state::Withdrawal>(withdrawal));
+        }
+        catch (const std::out_of_range&)
+        {
+            tb.withdrawals_parse_success = false;
+        }
+        catch (const std::invalid_argument&)
+        {
+            tb.withdrawals_parse_success = false;
+        }
     }
 
     if (auto it = j.find("transactions"); it != j.end())

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -181,6 +181,11 @@ bool validate_block(
             test_block.block_info.blob_gas_used.has_value())
             return false;
     }
+
+    // Block is invalid if some of the withdrawal fields failed to be parsed.
+    if (!test_block.withdrawals_parse_success)
+        return false;
+
     return true;
 }
 

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -85,7 +85,10 @@ bytes from_json<bytes>(const json::json& j)
 template <>
 address from_json<address>(const json::json& j)
 {
-    return evmc::from_hex<address>(j.get<std::string>()).value();
+    const auto v = evmc::from_hex<address>(j.get<std::string>());
+    if (!v.has_value())
+        throw std::invalid_argument("from_json<address>: must be hexadecimal string");
+    return *v;
 }
 
 template <>
@@ -187,7 +190,7 @@ template <>
 state::Withdrawal from_json<state::Withdrawal>(const json::json& j)
 {
     return {from_json<uint64_t>(j.at("index")), from_json<uint64_t>(j.at("validatorIndex")),
-        from_json<evmc::address>(j.at("address")), from_json<uint64_t>(j.at("amount"))};
+        from_json<address>(j.at("address")), from_json<uint64_t>(j.at("amount"))};
 }
 
 state::BlockInfo from_json_with_rev(const json::json& j, evmc_revision rev)

--- a/test/unittests/blockchaintest_loader_test.cpp
+++ b/test/unittests/blockchaintest_loader_test.cpp
@@ -154,12 +154,12 @@ TEST(json_loader, blockchain_test)
     EXPECT_EQ(btt[0].test_blocks[0].block_info.ommers[0].beneficiary,
         0xb94f5374fce5ed0000000097c15331677e6ebf0b_address);
     EXPECT_EQ(btt[0].test_blocks[0].block_info.ommers[0].delta, 2);
-    EXPECT_EQ(btt[0].test_blocks[0].block_info.withdrawals.size(), 1);
-    EXPECT_EQ(btt[0].test_blocks[0].block_info.withdrawals[0].recipient,
-        0xc000000000000000000000000000000000000001_address);
-    EXPECT_EQ(btt[0].test_blocks[0].block_info.withdrawals[0].amount_in_gwei, 0x0186a0);
-    EXPECT_EQ(btt[0].test_blocks[0].block_info.withdrawals[0].index, 0);
-    EXPECT_EQ(btt[0].test_blocks[0].block_info.withdrawals[0].validator_index, 0);
+    const auto& withdrawals = btt[0].test_blocks[0].block_info.withdrawals;
+    EXPECT_EQ(withdrawals.size(), 1);
+    EXPECT_EQ(withdrawals[0].recipient, 0xc000000000000000000000000000000000000001_address);
+    EXPECT_EQ(withdrawals[0].amount_in_gwei, 0x0186a0);
+    EXPECT_EQ(withdrawals[0].index, 0);
+    EXPECT_EQ(withdrawals[0].validator_index, 0);
 }
 
 TEST(json_loader, blockchain_test_post_state_hash)

--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -193,11 +193,12 @@ TEST(statetest_loader, block_info_withdrawals)
     EXPECT_EQ(bi.base_fee, 7);
     EXPECT_EQ(bi.timestamp, 0);
     EXPECT_EQ(bi.number, 0);
-    EXPECT_EQ(bi.withdrawals.size(), 2);
-    EXPECT_EQ(bi.withdrawals[0].recipient, 0x0000000000000000000000000000000000000100_address);
-    EXPECT_EQ(bi.withdrawals[0].get_amount(), intx::uint256{0x800000000} * 1'000'000'000);
-    EXPECT_EQ(bi.withdrawals[1].recipient, 0x0000000000000000000000000000000000000200_address);
-    EXPECT_EQ(bi.withdrawals[1].get_amount(), intx::uint256{0xffffffffffffffff} * 1'000'000'000);
+    const auto& withdrawals = bi.withdrawals;
+    EXPECT_EQ(withdrawals.size(), 2);
+    EXPECT_EQ(withdrawals[0].recipient, 0x0000000000000000000000000000000000000100_address);
+    EXPECT_EQ(withdrawals[0].get_amount(), intx::uint256{0x800000000} * 1'000'000'000);
+    EXPECT_EQ(withdrawals[1].recipient, 0x0000000000000000000000000000000000000200_address);
+    EXPECT_EQ(withdrawals[1].get_amount(), intx::uint256{0xffffffffffffffff} * 1'000'000'000);
 }
 
 TEST(statetest_loader, block_info_ommers)


### PR DESCRIPTION
There are InvalidBlocks tests that check that Withdrawal's fields fit uint64.

Also note that the tests with fields wider than uint256 are being deleted: https://github.com/ethereum/legacytests/pull/14