### PR TITLE
eof: Move to EVMC_EXPERIMENTAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ docker run --entrypoint evmone-bench ethereum/evmone /src/test/benchmarks
 evmone supports EOFv1. Since EOF validation is done once during deploy-time, evmone does not revalidate during execution of bytecode. To force EOF revalidation, you can use the `validate_eof` option, example:
 
 ```
-evmc run --vm libevmone.so,validate_eof --rev 14 "EF00"
+evmc run --vm libevmone.so,validate_eof --rev 15 "EF00"
 ```
 
 ## References

--- a/circle.yml
+++ b/circle.yml
@@ -384,7 +384,7 @@ jobs:
     steps:
       - build
       - download_execution_spec_tests:
-          release: v4.4.0
+          release: eip7692@v3.0.0
           fixtures_suffix: eip7692
       - run:
           name: "EOF pre-release execution spec tests (state_tests)"

--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -33,7 +33,7 @@ evmc_result execute(evmc_vm* /*unused*/, const evmc_host_interface* host, evmc_h
     const bytes_view container = {code, code_size};
     if (is_eof_container(container))
     {
-        if (rev >= EVMC_OSAKA)
+        if (rev >= EVMC_EXPERIMENTAL)
         {
             const auto eof1_header = read_valid_eof1_header(container);
             analysis = analyze(rev, eof1_header.get_code(container, 0));

--- a/lib/evmone/eof.cpp
+++ b/lib/evmone/eof.cpp
@@ -246,7 +246,7 @@ std::variant<EOF1Header, EOFValidationError> validate_header(
     if (version != 1)
         return EOFValidationError::eof_version_unknown;
 
-    if (rev < EVMC_OSAKA)
+    if (rev < EVMC_EXPERIMENTAL)
         return EOFValidationError::eof_version_unknown;
 
     // `offset` variable handled below is known to not be greater than the container size, as

--- a/lib/evmone/instructions_calls.cpp
+++ b/lib/evmone/instructions_calls.cpp
@@ -360,7 +360,7 @@ Result create_impl(StackTop stack, int64_t gas_left, ExecutionState& state) noex
         msg.input_data = &state.memory[init_code_offset];
         msg.input_size = init_code_size;
 
-        if (state.rev >= EVMC_OSAKA)
+        if (state.rev >= EVMC_EXPERIMENTAL)
         {
             // EOF initcode is not allowed for legacy creation
             if (is_eof_container({msg.input_data, msg.input_size}))

--- a/lib/evmone/instructions_storage.cpp
+++ b/lib/evmone/instructions_storage.cpp
@@ -41,6 +41,7 @@ constexpr auto storage_cost_spec = []() noexcept {
     tbl[EVMC_CANCUN] = tbl[EVMC_LONDON];
     tbl[EVMC_PRAGUE] = tbl[EVMC_LONDON];
     tbl[EVMC_OSAKA] = tbl[EVMC_LONDON];
+    tbl[EVMC_EXPERIMENTAL] = tbl[EVMC_LONDON];
     return tbl;
 }();
 

--- a/lib/evmone/instructions_traits.hpp
+++ b/lib/evmone/instructions_traits.hpp
@@ -173,28 +173,29 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
     table[EVMC_PRAGUE] = table[EVMC_CANCUN];
 
     table[EVMC_OSAKA] = table[EVMC_PRAGUE];
-    table[EVMC_OSAKA][OP_DUPN] = 3;
-    table[EVMC_OSAKA][OP_SWAPN] = 3;
-    table[EVMC_OSAKA][OP_EXCHANGE] = 3;
-    table[EVMC_OSAKA][OP_RJUMP] = 2;
-    table[EVMC_OSAKA][OP_RJUMPI] = 4;
-    table[EVMC_OSAKA][OP_RJUMPV] = 4;
-    table[EVMC_OSAKA][OP_CALLF] = 5;
-    table[EVMC_OSAKA][OP_RETF] = 3;
-    table[EVMC_OSAKA][OP_JUMPF] = 5;
-    table[EVMC_OSAKA][OP_DATALOAD] = 4;
-    table[EVMC_OSAKA][OP_DATALOADN] = 3;
-    table[EVMC_OSAKA][OP_DATASIZE] = 2;
-    table[EVMC_OSAKA][OP_DATACOPY] = 3;
-    table[EVMC_OSAKA][OP_RETURNDATALOAD] = 3;
-    table[EVMC_OSAKA][OP_EXTCALL] = warm_storage_read_cost;
-    table[EVMC_OSAKA][OP_EXTDELEGATECALL] = warm_storage_read_cost;
-    table[EVMC_OSAKA][OP_EXTSTATICCALL] = warm_storage_read_cost;
-    table[EVMC_OSAKA][OP_EOFCREATE] = 32000;
-    table[EVMC_OSAKA][OP_TXCREATE] = 32000;
-    table[EVMC_OSAKA][OP_RETURNCODE] = 0;
 
     table[EVMC_EXPERIMENTAL] = table[EVMC_OSAKA];
+
+    table[EVMC_EXPERIMENTAL][OP_DUPN] = 3;
+    table[EVMC_EXPERIMENTAL][OP_SWAPN] = 3;
+    table[EVMC_EXPERIMENTAL][OP_EXCHANGE] = 3;
+    table[EVMC_EXPERIMENTAL][OP_RJUMP] = 2;
+    table[EVMC_EXPERIMENTAL][OP_RJUMPI] = 4;
+    table[EVMC_EXPERIMENTAL][OP_RJUMPV] = 4;
+    table[EVMC_EXPERIMENTAL][OP_CALLF] = 5;
+    table[EVMC_EXPERIMENTAL][OP_RETF] = 3;
+    table[EVMC_EXPERIMENTAL][OP_JUMPF] = 5;
+    table[EVMC_EXPERIMENTAL][OP_DATALOAD] = 4;
+    table[EVMC_EXPERIMENTAL][OP_DATALOADN] = 3;
+    table[EVMC_EXPERIMENTAL][OP_DATASIZE] = 2;
+    table[EVMC_EXPERIMENTAL][OP_DATACOPY] = 3;
+    table[EVMC_EXPERIMENTAL][OP_RETURNDATALOAD] = 3;
+    table[EVMC_EXPERIMENTAL][OP_EXTCALL] = warm_storage_read_cost;
+    table[EVMC_EXPERIMENTAL][OP_EXTDELEGATECALL] = warm_storage_read_cost;
+    table[EVMC_EXPERIMENTAL][OP_EXTSTATICCALL] = warm_storage_read_cost;
+    table[EVMC_EXPERIMENTAL][OP_EOFCREATE] = 32000;
+    table[EVMC_EXPERIMENTAL][OP_TXCREATE] = 32000;
+    table[EVMC_EXPERIMENTAL][OP_RETURNCODE] = 0;
 
     return table;
 }();
@@ -202,7 +203,7 @@ constexpr inline GasCostTable gas_costs = []() noexcept {
 static_assert(gas_costs[EVMC_MAX_REVISION][OP_ADD] > 0, "gas costs missing for a revision");
 
 /// The revision related to introduction of the EOFv1.
-constexpr auto REV_EOF1 = EVMC_OSAKA;
+constexpr auto REV_EOF1 = EVMC_EXPERIMENTAL;
 
 
 /// The EVM instruction traits.
@@ -423,7 +424,7 @@ constexpr inline std::array<Traits, 256> traits = []() noexcept {
     table[OP_CREATE2] = {"CREATE2", 0, false, 4, -3, EVMC_CONSTANTINOPLE};
     table[OP_RETURNDATALOAD] = {"RETURNDATALOAD", 0, false, 1, 0, {}, REV_EOF1};
     table[OP_EOFCREATE] = {"EOFCREATE", 1, false, 4, -3, {}, REV_EOF1};
-    table[OP_TXCREATE] = {"TXCREATE", 0, false, 5, -4, EVMC_OSAKA, REV_EOF1};
+    table[OP_TXCREATE] = {"TXCREATE", 0, false, 5, -4, EVMC_EXPERIMENTAL, REV_EOF1};
     table[OP_RETURNCODE] = {"RETURNCODE", 1, true, 2, -2, {}, REV_EOF1};
     table[OP_EXTCALL] = {"EXTCALL", 0, false, 4, -3, {}, REV_EOF1};
     table[OP_EXTDELEGATECALL] = {"EXTDELEGATECALL", 0, false, 3, -2, {}, REV_EOF1};

--- a/test/eofparse/eofparse.cpp
+++ b/test/eofparse/eofparse.cpp
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
             }
 
             const auto& eof = *o;
-            const auto err = evmone::validate_eof(EVMC_OSAKA, container_kind, eof);
+            const auto err = evmone::validate_eof(EVMC_EXPERIMENTAL, container_kind, eof);
             if (err != evmone::EOFValidationError::success)
             {
                 std::cout << "err: " << evmone::get_error_message(err) << "\n";

--- a/test/eofparsefuzz/eofparsefuzz.cpp
+++ b/test/eofparsefuzz/eofparsefuzz.cpp
@@ -7,7 +7,7 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t data_size) noexcept
 {
     const evmone::bytes_view eof{data, data_size};
-    if (evmone::validate_eof(EVMC_OSAKA, evmone::ContainerKind::runtime, eof) ==
+    if (evmone::validate_eof(EVMC_EXPERIMENTAL, evmone::ContainerKind::runtime, eof) ==
         evmone::EOFValidationError::success)
         (void)evmone::read_valid_eof1_header(eof);
     return 0;

--- a/test/eoftest/eoftest_runner.cpp
+++ b/test/eoftest/eoftest_runner.cpp
@@ -22,7 +22,7 @@ struct EOFValidationTest
     {
         struct Expectation
         {
-            evmc_revision rev = EVMC_OSAKA;
+            evmc_revision rev = EVMC_EXPERIMENTAL;
             bool result = false;
         };
         std::string name;

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -29,22 +29,22 @@ DUP1,4
 {\"pc\":6,\"op\":3,\"gas\":\"0xf4234\",\"gasCost\":\"0x3\",\"memSize\":0,\"stack\":\\[\"0x0\",\"0x4\"\\],\"depth\":1,\"refund\":0,\"opName\":\"SUB\"}
 ")
 
-    add_test(NAME ${PREFIX}/validate_eof COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 14 EF0001)
+    add_test(NAME ${PREFIX}/validate_eof COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 15 EF0001)
     set_tests_properties(
         ${PREFIX}/validate_eof PROPERTIES PASS_REGULAR_EXPRESSION
         "contract validation failure")
         
-    add_test(NAME ${PREFIX}/validate_eof_success COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 14 EF00010100040200010001FF0000000080000000)
+    add_test(NAME ${PREFIX}/validate_eof_success COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 15 EF00010100040200010001FF0000000080000000)
     set_tests_properties(
         ${PREFIX}/validate_eof_success PROPERTIES PASS_REGULAR_EXPRESSION
         "Result:   success")
         
-    add_test(NAME ${PREFIX}/validate_eof_create COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 14 --create EF00010100040200010001FF0000000080000000)
+    add_test(NAME ${PREFIX}/validate_eof_create COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 15 --create EF00010100040200010001FF0000000080000000)
     set_tests_properties(
         ${PREFIX}/validate_eof_create PROPERTIES PASS_REGULAR_EXPRESSION
         "contract validation failure")
         
-    add_test(NAME ${PREFIX}/validate_eof_create_success COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 14 --create EF0001010004020001000403000100000014FF000000008000025F5FEE00EF00010100040200010001FF0000000080000000)
+    add_test(NAME ${PREFIX}/validate_eof_create_success COMMAND evmc::tool --vm $<TARGET_FILE:evmone>,validate_eof run --rev 15 --create EF0001010004020001000403000100000014FF000000008000025F5FEE00EF00010100040200010001FF0000000080000000)
     set_tests_properties(
         ${PREFIX}/validate_eof_create_success PROPERTIES PASS_REGULAR_EXPRESSION
         "Result:   success")

--- a/test/integration/statetest/eof/invalid_eof_in_state.json
+++ b/test/integration/statetest/eof/invalid_eof_in_state.json
@@ -11,7 +11,7 @@
       "currentTimestamp": "0x03e8"
     },
     "post": {
-      "Osaka": [
+      "EOFv1": [
         {
           "hash": "0xe8010ce590f401c9d61fef8ab05bea9bcec24281b795e5868809bc4e515aa530",
           "indexes": {

--- a/test/state/host.cpp
+++ b/test/state/host.cpp
@@ -322,7 +322,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     const auto initcode = (msg.kind == EVMC_EOFCREATE ? bytes_view{msg.code, msg.code_size} :
                                                         bytes_view{msg.input_data, msg.input_size});
 
-    if (m_rev >= EVMC_OSAKA && msg.kind != EVMC_EOFCREATE && msg.depth == 0)
+    if (m_rev >= EVMC_EXPERIMENTAL && msg.kind != EVMC_EOFCREATE && msg.depth == 0)
     {
         // EOF initcode is not allowed for legacy creation tx
         // We cannot let the EVM handle that on the initial `EF` invalid instruction,
@@ -372,7 +372,7 @@ evmc::Result Host::create(const evmc_message& msg) noexcept
     {
         if (code[0] == 0xEF)
         {
-            if (m_rev >= EVMC_OSAKA)
+            if (m_rev >= EVMC_EXPERIMENTAL)
             {
                 // Only EOFCREATE/TXCREATE is allowed to deploy code starting with
                 // EF. It must be valid EOF, which was validated before execution.

--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -460,7 +460,7 @@ std::variant<TransactionProperties, std::error_code> validate_transaction(
         break;
 
     case Transaction::Type::initcodes:
-        if (rev < EVMC_OSAKA)
+        if (rev < EVMC_EXPERIMENTAL)
             return make_error_code(TX_TYPE_NOT_SUPPORTED);
         if (tx.initcodes.size() > MAX_INITCODE_COUNT)
             return make_error_code(INIT_CODE_COUNT_LIMIT_EXCEEDED);

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -512,7 +512,7 @@ void validate_state(const TestState& state, evmc_revision rev)
             throw std::invalid_argument("unexpected code at precompile address " + hex0x(addr));
 
         const bool allowedEF = (rev >= EVMC_PRAGUE && is_code_delegated(acc.code)) ||
-                               (rev >= EVMC_OSAKA && is_eof_container(acc.code)) ||
+                               (rev >= EVMC_EXPERIMENTAL && is_eof_container(acc.code)) ||
                                // exceptions to EIP-3541 rule existing on Mainnet
                                acc.code == "EF"_hex || acc.code == "EFF09f918bf09f9fa9"_hex;
         if (rev >= EVMC_LONDON && !allowedEF && !acc.code.empty() && acc.code[0] == 0xEF)
@@ -529,7 +529,7 @@ void validate_state(const TestState& state, evmc_revision rev)
                 "EIP-7702 delegation designator at " + hex0x(addr) + " has invalid size");
         }
 
-        if (rev >= EVMC_OSAKA && is_eof_container(acc.code))
+        if (rev >= EVMC_EXPERIMENTAL && is_eof_container(acc.code))
         {
             if (const auto result = validate_eof(rev, ContainerKind::runtime, acc.code);
                 result != EOFValidationError::success)

--- a/test/unittests/analysis_test.cpp
+++ b/test/unittests/analysis_test.cpp
@@ -261,7 +261,7 @@ TEST(analysis, example1_eof1)
         eof_bytecode(push(0x2a) + push(0x1e) + OP_MSTORE8 + OP_MSIZE + push(0) + OP_SSTORE, 2)
             .data("deadbeef");
     const auto header = evmone::read_valid_eof1_header(code);
-    const auto analysis = analyze(EVMC_OSAKA, header.get_code(code, 0));
+    const auto analysis = analyze(EVMC_EXPERIMENTAL, header.get_code(code, 0));
 
     ASSERT_EQ(analysis.instrs.size(), 8);
 

--- a/test/unittests/eof_example_test.cpp
+++ b/test/unittests/eof_example_test.cpp
@@ -17,7 +17,7 @@ TEST_F(state_transition, eof_examples_minimal)
     //
     // A minimal valid EOF container doing nothing.
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const auto eof_code = bytecode(
         //                                                  Code section: STOP
@@ -50,7 +50,7 @@ TEST_F(state_transition, eof_examples_static_relative_jump_loop)
     //
     // EOF container looping infinitely using the static relative jump instruction RJUMP.
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const auto eof_code = bytecode(
         //                                                  Code section: RJUMP back to start (-3)
@@ -87,7 +87,7 @@ TEST_F(state_transition, eof_examples_callf)
     // EOF container with two code sections, one calling the other passing a single argument on the
     // stack and retrieving the same single value back from the stack on return.
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const auto eof_code = bytecode(
         //                                                   First code section: PUSH1(0x2A),
@@ -126,7 +126,7 @@ TEST_F(state_transition, eof_examples_eofcreate)
     // A factory contract with an EOFCREATE instruction is being called in order
     // to deploy its subcontainer as a new EOF contract.
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const auto factory = bytecode(
         //////////////////
@@ -187,7 +187,7 @@ TEST_F(state_transition, eof_examples_data)
     //
     // A basic EOF contract with a data section being used to load a byte of data onto the stack.
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     // clang-format off
     const auto eof_code = bytecode(

--- a/test/unittests/eof_test.cpp
+++ b/test/unittests/eof_test.cpp
@@ -95,8 +95,8 @@ TEST(eof, read_valid_eof1_header)
     for (const auto& test_case : test_cases)
     {
         const auto code = from_spaced_hex(test_case.code).value();
-        EXPECT_EQ(
-            validate_eof(EVMC_OSAKA, ContainerKind::runtime, code), EOFValidationError::success)
+        EXPECT_EQ(validate_eof(EVMC_EXPERIMENTAL, ContainerKind::runtime, code),
+            EOFValidationError::success)
             << test_case.code;
 
         const auto header = read_valid_eof1_header(code);

--- a/test/unittests/eof_validation.hpp
+++ b/test/unittests/eof_validation.hpp
@@ -35,7 +35,7 @@ protected:
         std::string name;
     };
 
-    evmc_revision rev = EVMC_OSAKA;
+    evmc_revision rev = EVMC_EXPERIMENTAL;
     std::vector<TestCase> test_cases;
 
     /// Adds the case to test cases.

--- a/test/unittests/eof_validation_test.cpp
+++ b/test/unittests/eof_validation_test.cpp
@@ -297,7 +297,7 @@ TEST_F(eof_validation, EOF1_too_many_code_sections)
 
 TEST_F(eof_validation, EOF1_undefined_opcodes)
 {
-    const auto& gas_table = evmone::instr::gas_costs[EVMC_OSAKA];
+    const auto& gas_table = evmone::instr::gas_costs[EVMC_EXPERIMENTAL];
 
     for (uint16_t opcode = 0; opcode <= 0xff; ++opcode)
     {

--- a/test/unittests/evm_calls_test.cpp
+++ b/test/unittests/evm_calls_test.cpp
@@ -764,28 +764,28 @@ TEST_P(evm, returndatacopy_outofrange_highbits)
 
 TEST_P(evm, returndataload_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(staticcall(0) + returndataload(0));
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 }
 
 TEST_P(evm, extcall_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(extcall(0));
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 }
 
 TEST_P(evm, extdelegatecall_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(extdelegatecall(0));
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 }
 
 TEST_P(evm, extstaticcall_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(extstaticcall(0));
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 }

--- a/test/unittests/evm_eip663_dupn_swapn_test.cpp
+++ b/test/unittests/evm_eip663_dupn_swapn_test.cpp
@@ -12,7 +12,7 @@ TEST_P(evm, dupn)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     auto pushes = bytecode{};
     for (uint64_t i = 1; i <= 20; ++i)
@@ -37,7 +37,7 @@ TEST_P(evm, swapn)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     auto pushes = bytecode{};
     for (uint64_t i = 1; i <= 20; ++i)
@@ -74,7 +74,7 @@ TEST_P(evm, dupn_full_stack)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto full_stack_code = bytecode{};
     for (uint64_t i = 1022; i >= 1; --i)
         full_stack_code += push(i);
@@ -98,7 +98,7 @@ TEST_P(evm, swapn_full_stack)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto full_stack_code = bytecode{};
     for (uint64_t i = 1023; i >= 1; --i)
         full_stack_code += push(i);
@@ -126,7 +126,7 @@ TEST_P(evm, dupn_dup_consistency)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto pushes = bytecode{};
     for (uint64_t i = 32; i >= 1; --i)
         pushes += push(i);
@@ -154,7 +154,7 @@ TEST_P(evm, swapn_swap_consistency)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto pushes = bytecode{};
     for (uint64_t i = 32; i >= 1; --i)
         pushes += push(i);
@@ -178,7 +178,7 @@ TEST_P(evm, swapn_swap_consistency)
 
 TEST_P(evm, dupn_swapn_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     execute(push(1) + push(2) + OP_SWAPN + "00");
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);

--- a/test/unittests/evm_eip663_exchange_test.cpp
+++ b/test/unittests/evm_eip663_exchange_test.cpp
@@ -13,7 +13,7 @@ TEST_P(evm, exchange)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     auto pushes = bytecode{};
     for (uint64_t i = 1; i <= 20; ++i)
@@ -86,7 +86,7 @@ TEST_P(evm, exchange_deep_stack)
     if (evm::is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto full_stack_code = bytecode{};
     for (uint64_t i = 255; i >= 1; --i)
         full_stack_code += push(i);
@@ -104,7 +104,7 @@ TEST_P(evm, exchange_deep_stack)
 
 TEST_P(evm, exchange_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     execute(push(1) + push(2) + push(3) + OP_EXCHANGE + "00");
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);

--- a/test/unittests/evm_eof_calls_test.cpp
+++ b/test/unittests/evm_eof_calls_test.cpp
@@ -20,7 +20,7 @@ TEST_P(evm, extdelegatecall)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     host.access_account(callee);
     host.accounts[callee].code = "EF00"_hex;
@@ -60,7 +60,7 @@ TEST_P(evm, extdelegatecall_oog_depth_limit)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     host.access_account(callee);
     host.accounts[callee].code = "EF00"_hex;
@@ -85,7 +85,7 @@ TEST_P(evm, extcall_failing_with_value)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     host.access_account(callee);
     host.accounts[callee] = {};
@@ -114,7 +114,7 @@ TEST_P(evm, extcall_with_value_depth_limit)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     constexpr auto call_dst = 0x00000000000000000000000000000000000000aa_address;
     host.accounts[call_dst] = {};
@@ -133,7 +133,7 @@ TEST_P(evm, extcall_depth_limit)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     host.access_account(callee);
     host.accounts[callee].code = "EF00"_hex;
@@ -155,7 +155,7 @@ TEST_P(evm, extcall_value_zero_to_nonexistent_account)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     host.call_result.gas_left = 1000;
 
     const auto code = eof_bytecode(extcall(0xaa).input(0, 0x40) + OP_STOP, 4);
@@ -187,7 +187,7 @@ TEST_P(evm, extcall_new_account_creation_cost)
 
     msg.recipient = msg_dst;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     {
         auto gas_before_call = 3 * 3 + 3 + 3 + 2600;
         auto gas_left = safe_call_gas - gas_before_call;
@@ -247,7 +247,7 @@ TEST_P(evm, extcall_oog_after_balance_check)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // Create the call destination account.
     host.accounts[0x0000000000000000000000000000000000000000_address] = {};
     auto code = eof_bytecode(extcall(0).value(1) + OP_POP + OP_STOP, 4);
@@ -261,7 +261,7 @@ TEST_P(evm, extcall_oog_after_depth_check)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // Create the call recipient account.
     host.accounts[0x0000000000000000000000000000000000000000_address] = {};
     msg.depth = 1024;
@@ -277,7 +277,7 @@ TEST_P(evm, returndataload)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto call_output =
         0x497f3c9f61479c1cfa53f0373d39d2bf4e5f73f71411da62f1d6b85c03a60735_bytes32;
     host.call_result.output_data = std::data(call_output.bytes);
@@ -295,7 +295,7 @@ TEST_P(evm, returndataload_cost)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[32]{};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
@@ -314,7 +314,7 @@ TEST_P(evm, returndataload_oog)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[32]{};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
@@ -340,7 +340,7 @@ TEST_P(evm, returndataload_outofrange)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     {
         const auto call_output =
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"_hex;  // 31 bytes
@@ -456,7 +456,7 @@ TEST_P(evm, returndataload_empty)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(eof_bytecode(extstaticcall(0) + returndataload(0) + ret_top(), 3));
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
     EXPECT_EQ(bytes_view(result.output_data, result.output_size), evmc::bytes32(0));
@@ -476,7 +476,7 @@ TEST_P(evm, returndataload_outofrange_highbits)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[34]{};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
@@ -495,7 +495,7 @@ TEST_P(evm, extcall_gas_refund_aggregation_different_calls)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     host.access_account(callee);
     host.accounts[callee].code = "EF00"_hex;
@@ -516,7 +516,7 @@ TEST_P(evm, extcall_gas_refund_aggregation_same_calls)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xaa_address;
     host.access_account(callee);
     host.accounts[callee].code = "EF00"_hex;
@@ -543,7 +543,7 @@ TEST_P(evm, eof_returndatacopy)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto call_output =
         0x497f3c9f61479c1cfa53f0373d39d2bf4e5f73f71411da62f1d6b85c03a60735_bytes32;
     host.call_result.output_data = std::data(call_output.bytes);
@@ -562,7 +562,7 @@ TEST_P(evm, eof_returndatacopy_empty)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(eof_bytecode(extcall(0) + returndatacopy(0, 0, 0) + ret(0, 32), 4));
     EXPECT_EQ(result.status_code, EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(0);
@@ -574,7 +574,7 @@ TEST_P(evm, eof_returndatacopy_oog)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[1]{};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
@@ -601,7 +601,7 @@ TEST_P(evm, eof_returndatacopy_cost)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[1]{};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
@@ -621,7 +621,7 @@ TEST_P(evm, eof_returndatacopy_outofrange)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[2]{0xab, 0xcd};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);
@@ -654,7 +654,7 @@ TEST_P(evm, eof_returndatacopy_outofrange_highbits)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const uint8_t call_output[2]{0xab, 0xcd};
     host.call_result.output_data = std::data(call_output);
     host.call_result.output_size = std::size(call_output);

--- a/test/unittests/evm_eof_function_test.cpp
+++ b/test/unittests/evm_eof_function_test.cpp
@@ -13,7 +13,7 @@ TEST_P(evm, eof_function_example1)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(push(1) + push(8) + OP_CALLF + "0001" + ret_top(), 2)
                               .code(bytecode{OP_SUB} + OP_RETF, 2, 1);
 
@@ -28,7 +28,7 @@ TEST_P(evm, eof_function_example2)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto code =
         "ef0001 01000c 020003 003b 0017 001d FF0000 00 00800004 01010002 01010003"
         "60043560003560e01c63c76652678114e1001c63c6c2ea178114e100065050600080fd50e30002600052602060"
@@ -57,7 +57,7 @@ TEST_P(evm, callf_stack_size_1024)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(1023 * push(1) + OP_CALLF + "0001" + 1021 * OP_POP + OP_RETURN, 1023)
             .code(push(1) + OP_POP + OP_RETF, 0, 0, 1);
@@ -72,7 +72,7 @@ TEST_P(evm, callf_with_inputs_stack_size_1024)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(1023 * push(1) + OP_CALLF + "0001" + 1021 * OP_POP + OP_RETURN, 1023)
             .code(push(1) + OP_POP + OP_RETF, 3, 3, 1);
@@ -87,7 +87,7 @@ TEST_P(evm, callf_stack_overflow)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(1023 * push(1) + OP_CALLF + "0001" + 1021 * OP_POP + OP_RETURN, 1023)
             .code(push(1) + OP_CALLF + "0002" + OP_POP + OP_RETF, 0, 0, 1)
@@ -103,7 +103,7 @@ TEST_P(evm, callf_with_inputs_stack_overflow)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(1023 * push(1) + OP_CALLF + "0001" + 1021 * OP_POP + OP_RETURN, 1023)
             .code(push(1) + OP_CALLF + "0002" + OP_POP + OP_RETF, 3, 3, 1)
@@ -119,7 +119,7 @@ TEST_P(evm, callf_call_stack_size_1024)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(push(1023) + OP_CALLF + "0001" + OP_STOP, 1)
                               .code(bytecode{OP_DUP1} + OP_RJUMPI + "0002" + OP_POP + OP_RETF +
                                         push(1) + OP_SWAP1 + OP_SUB + OP_CALLF + "0001" + OP_RETF,
@@ -135,7 +135,7 @@ TEST_P(evm, callf_call_stack_size_1025)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(push(1024) + OP_CALLF + "0001" + OP_STOP, 1)
                               .code(bytecode{OP_DUP1} + OP_RJUMPI + "0002" + OP_POP + OP_RETF +
                                         push(1) + OP_SWAP1 + OP_SUB + OP_CALLF + "0001" + OP_RETF,
@@ -151,7 +151,7 @@ TEST_P(evm, minimal_jumpf)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(bytecode{OP_JUMPF} + "0001").code(bytecode{OP_STOP}, 0, 0x80);
 
@@ -165,7 +165,7 @@ TEST_P(evm, jumpf_to_returning_function)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(
         bytecode{OP_CALLF} + "0001" + OP_PUSH0 + OP_MSTORE + OP_PUSH1 + "20" + OP_PUSH0 + OP_RETURN,
         2)
@@ -183,7 +183,7 @@ TEST_P(evm, jumpf_to_function_with_fewer_outputs)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(
         bytecode{OP_CALLF} + "0001" + OP_PUSH0 + OP_MSTORE + OP_PUSH1 + "20" + OP_PUSH0 + OP_RETURN,
         3)
@@ -201,7 +201,7 @@ TEST_P(evm, jumpf_stack_size_1024)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(1023 * push0() + OP_JUMPF + "0001", 1023).code(push0() + OP_STOP, 0, 0x80, 1);
 
@@ -215,7 +215,7 @@ TEST_P(evm, jumpf_with_inputs_stack_size_1024)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code =
         eof_bytecode(1023 * push0() + OP_JUMPF + "0001", 1023).code(push0() + OP_STOP, 3, 0x80, 1);
 
@@ -229,7 +229,7 @@ TEST_P(evm, jumpf_stack_overflow)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(1023 * push0() + OP_JUMPF + "0001", 1023)
                               .code(push0() + OP_JUMPF + "0002", 0, 0x80, 1)
                               .code(push0() + OP_STOP, 0, 0x80, 1);
@@ -244,7 +244,7 @@ TEST_P(evm, jumpf_with_inputs_stack_overflow)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const bytecode code = eof_bytecode(1023 * push0() + OP_JUMPF + "0001", 1023)
                               .code(push0() + OP_JUMPF + "0002", 3, 0x80, 1)
                               .code(push0() + OP_STOP, 3, 0x80, 1);
@@ -257,7 +257,7 @@ TEST_P(evm, jumpf_with_inputs_stack_overflow)
 
 TEST_P(evm, functions_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = bytecode{OP_CALLF} + "0001" + OP_STOP;
     execute(code);
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);

--- a/test/unittests/evm_eof_rjump_test.cpp
+++ b/test/unittests/evm_eof_rjump_test.cpp
@@ -13,7 +13,7 @@ TEST_P(evm, eof1_rjump)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(rjumpi(3, 0) + rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1), 2);
 
     execute(code);
@@ -36,7 +36,7 @@ TEST_P(evm, eof1_rjump_backward)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(rjumpi(10, 1) + mstore8(0, 1) + ret(0, 1) + rjump(-13), 2);
 
     execute(code);
@@ -58,7 +58,7 @@ TEST_P(evm, eof1_rjump_0_offset)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(rjump(0) + mstore8(0, 1) + ret(0, 1), 2);
 
     execute(code);
@@ -73,7 +73,7 @@ TEST_P(evm, eof1_rjumpi)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(
         rjumpi(10, calldataload(0)) + mstore8(0, 2) + ret(0, 1) + mstore8(0, 1) + ret(0, 1), 2);
 
@@ -96,7 +96,7 @@ TEST_P(evm, eof1_rjumpi_backwards)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(rjumpi(10, 1) + mstore8(0, 1) + ret(0, 1) +
                                  rjumpi(-16, calldataload(0)) + mstore8(0, 2) + ret(0, 1),
         2);
@@ -120,7 +120,7 @@ TEST_P(evm, eof1_rjumpi_0_offset)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(rjumpi(0, calldataload(0)) + mstore8(0, 1) + ret(0, 1), 2);
 
     // RJUMPI condition is true
@@ -142,7 +142,7 @@ TEST_P(evm, eof1_rjumpv_single_offset)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = eof_bytecode(rjumpv({3}, 0) + OP_JUMPDEST + OP_JUMPDEST + OP_STOP + 20 + 0 + 0 +
                                  OP_DATACOPY + ret(0, 20),
         3)
@@ -161,7 +161,7 @@ TEST_P(evm, eof1_rjumpv_multiple_offsets)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto code =
         eof_bytecode(rjumpi(12, 1) + 10 + 0 + 0 + OP_DATACOPY + ret(0, 10) +
                          rjumpv({12, -23, 0}, calldataload(0)) + 10 + 10 + 0 + OP_DATACOPY +
@@ -197,7 +197,7 @@ TEST_P(evm, eof1_rjumpv_long_jumps)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto code_ret_7 = push(7) + ret_top();
     // code_ret_7 and jumpdests together make up 0x7fff bytes
     const auto jumpdests = (0x7fff - static_cast<int>(code_ret_7.size())) * bytecode{OP_JUMPDEST};
@@ -228,7 +228,7 @@ TEST_P(evm, eof1_rjumpv_long_jumps)
 
 TEST_P(evm, rjump_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto code = rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1);
     execute(code);
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
@@ -236,7 +236,7 @@ TEST_P(evm, rjump_undefined_in_legacy)
 
 TEST_P(evm, rjumpi_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto code = rjumpi(10, 1) + mstore8(0, 2) + ret(0, 1) + mstore8(0, 1) + ret(0, 1);
     execute(code);
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
@@ -244,7 +244,7 @@ TEST_P(evm, rjumpi_undefined_in_legacy)
 
 TEST_P(evm, rjumpv_undefined_in_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto code = rjumpv({0}, calldataload(0)) + OP_STOP;
     execute(code);
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);

--- a/test/unittests/evm_eof_test.cpp
+++ b/test/unittests/evm_eof_test.cpp
@@ -16,14 +16,14 @@ TEST_P(evm, eof1_execution)
     execute(code);
     EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     execute(code);
     EXPECT_STATUS(EVMC_SUCCESS);
 }
 
 TEST_P(evm, eof1_execution_with_data_section)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // data section contains ret(0, 1)
     const auto code = eof_bytecode(mstore8(0, 1) + OP_STOP, 2).data(ret(0, 1));
 
@@ -34,7 +34,7 @@ TEST_P(evm, eof1_execution_with_data_section)
 
 TEST_P(evm, eof_data_only_contract)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto code = "EF0001 010004 020001 0001 FFdaaa 00 00800000 FE"_hex;
     const auto data_size_ptr = &code[code.find(0xda)];
 
@@ -57,7 +57,7 @@ TEST_P(evm, eof1_dataload)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // data is 64 bytes long
     const auto data = bytes(8, 0x0) + bytes(8, 0x11) + bytes(8, 0x22) + bytes(8, 0x33) +
                       bytes(8, 0xaa) + bytes(8, 0xbb) + bytes(8, 0xcc) + bytes(8, 0xdd);
@@ -106,7 +106,7 @@ TEST_P(evm, eof1_dataloadn)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // data is 64 bytes long
     const auto data = bytes(8, 0x0) + bytes(8, 0x11) + bytes(8, 0x22) + bytes(8, 0x33) +
                       bytes(8, 0xaa) + bytes(8, 0xbb) + bytes(8, 0xcc) + bytes(8, 0xdd);
@@ -139,7 +139,7 @@ TEST_P(evm, eof1_datasize)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     // no data section
     auto code = eof_bytecode(bytecode(OP_DATASIZE) + ret_top(), 2);
@@ -179,7 +179,7 @@ TEST_P(evm, eof1_datacopy)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // data is 64 bytes long
     const auto data = bytes(8, 0x0) + bytes(8, 0x11) + bytes(8, 0x22) + bytes(8, 0x33) +
                       bytes(8, 0xaa) + bytes(8, 0xbb) + bytes(8, 0xcc) + bytes(8, 0xdd);
@@ -239,7 +239,7 @@ TEST_P(evm, datacopy_memory_cost)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto data = bytes{0};
     const auto code = eof_bytecode(bytecode(1) + 0 + 0 + OP_DATACOPY + OP_STOP, 3).data(data);
     execute(18, code);
@@ -254,7 +254,7 @@ TEST_P(evm, eof_eofcreate)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -311,7 +311,7 @@ TEST_P(evm, eofcreate_staticmode)
     if (is_advanced())
         return;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     msg.flags |= EVMC_STATIC;
     const auto code = eof_bytecode(4 * push0() + OP_EOFCREATE + "00" + OP_STOP, 4)
                           .container(eof_bytecode(push0() + push0() + OP_REVERT, 2));

--- a/test/unittests/evm_fixture.hpp
+++ b/test/unittests/evm_fixture.hpp
@@ -80,7 +80,7 @@ protected:
             host.access_account(msg.recipient);
         }
 
-        if (rev >= EVMC_OSAKA && is_eof_container(code))
+        if (rev >= EVMC_EXPERIMENTAL && is_eof_container(code))
         {
             ASSERT_EQ(get_error_message(validate_eof(rev, ContainerKind::runtime, code)),
                 get_error_message(EOFValidationError::success));

--- a/test/unittests/evm_memory_test.cpp
+++ b/test/unittests/evm_memory_test.cpp
@@ -176,7 +176,7 @@ struct
 
 TEST_P(evm, memory_access)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // This test checks if instructions accessing memory properly respond with out-of-gas
     // error for combinations of memory offset and memory size arguments.
 

--- a/test/unittests/state_transition_eip663_test.cpp
+++ b/test/unittests/state_transition_eip663_test.cpp
@@ -10,7 +10,7 @@ using namespace evmone::test;
 
 TEST_F(state_transition, dupn)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.to = To;
     pre.insert(*tx.to,
         {
@@ -23,7 +23,7 @@ TEST_F(state_transition, dupn)
 
 TEST_F(state_transition, swapn)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.to = To;
     pre.insert(*tx.to,
         {
@@ -36,7 +36,7 @@ TEST_F(state_transition, swapn)
 
 TEST_F(state_transition, exchange)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.to = To;
     pre.insert(*tx.to, {
                            .code = eof_bytecode(push(1) + push(2) + push(3) + OP_EXCHANGE + "00" +

--- a/test/unittests/state_transition_eip7702_test.cpp
+++ b/test/unittests/state_transition_eip7702_test.cpp
@@ -240,7 +240,7 @@ TEST_F(state_transition, eip7702_delegated_mode_propagation_call)
 
 TEST_F(state_transition, eip7702_delegated_mode_propagation_extcall)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     constexpr auto delegate = 0xde1e_address;
     constexpr auto identity_precompile = 0x04_address;

--- a/test/unittests/state_transition_eof_calls_test.cpp
+++ b/test/unittests/state_transition_eof_calls_test.cpp
@@ -10,7 +10,7 @@ using namespace evmone::test;
 
 TEST_F(state_transition, eof1_extdelegatecall_eof1)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     constexpr auto callee = 0xca11ee_address;
     pre.insert(callee,
@@ -35,7 +35,7 @@ TEST_F(state_transition, eof1_extdelegatecall_eof1)
 
 TEST_F(state_transition, eof1_extdelegatecall_legacy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     constexpr auto callee = 0xca11ee_address;
     pre.insert(callee, {
@@ -61,7 +61,7 @@ TEST_F(state_transition, eof1_extdelegatecall_legacy)
 
 TEST_F(state_transition, extdelegatecall_static)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     // Checks if EXTDELEGATECALL forwards the "static" flag.
     constexpr auto callee1 = 0xca11ee01_address;
     constexpr auto callee2 = 0xca11ee02_address;
@@ -93,7 +93,7 @@ TEST_F(state_transition, extdelegatecall_static)
 
 TEST_F(state_transition, extcall_static_with_value)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     constexpr auto callee1 = 0xca11ee01_address;
     constexpr auto callee2 = 0xca11ee02_address;
@@ -117,7 +117,7 @@ TEST_F(state_transition, extcall_static_with_value)
 
 TEST_F(state_transition, extcall_failing_with_value_balance_check)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -138,7 +138,7 @@ TEST_F(state_transition, extcall_failing_with_value_balance_check)
 
 TEST_F(state_transition, extcall_failing_with_value_additional_cost)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -163,7 +163,7 @@ TEST_F(state_transition, extcall_failing_with_value_additional_cost)
 
 TEST_F(state_transition, extcall_with_value)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -186,7 +186,7 @@ TEST_F(state_transition, extcall_with_value)
 
 TEST_F(state_transition, extcall_min_callee_gas_failure_mode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -208,7 +208,7 @@ TEST_F(state_transition, extcall_min_callee_gas_failure_mode)
 
 TEST_F(state_transition, extcall_output)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -228,7 +228,7 @@ TEST_F(state_transition, extcall_output)
 
 TEST_F(state_transition, extdelegatecall_output)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -249,7 +249,7 @@ TEST_F(state_transition, extdelegatecall_output)
 
 TEST_F(state_transition, extstaticcall_output)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -270,7 +270,7 @@ TEST_F(state_transition, extstaticcall_output)
 
 TEST_F(state_transition, extcall_memory)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -284,7 +284,7 @@ TEST_F(state_transition, extcall_memory)
 
 TEST_F(state_transition, extdelegatecall_memory)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -299,7 +299,7 @@ TEST_F(state_transition, extdelegatecall_memory)
 
 TEST_F(state_transition, extstaticcall_memory)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -314,7 +314,7 @@ TEST_F(state_transition, extstaticcall_memory)
 
 TEST_F(state_transition, extcall_ase_ready_violation)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee =
         0x0000000000000000000000010000000000000000000000000000000000000000_bytes32;
 
@@ -329,7 +329,7 @@ TEST_F(state_transition, extcall_ase_ready_violation)
 
 TEST_F(state_transition, extdelegatecall_ase_ready_violation)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee =
         0x0000000000000000000000010000000000000000000000000000000000000000_bytes32;
 
@@ -344,7 +344,7 @@ TEST_F(state_transition, extdelegatecall_ase_ready_violation)
 
 TEST_F(state_transition, extstaticcall_ase_ready_violation)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee =
         0x0000000000000000000000010000000000000000000000000000000000000000_bytes32;
 
@@ -359,7 +359,7 @@ TEST_F(state_transition, extstaticcall_ase_ready_violation)
 
 TEST_F(state_transition, extcall_cold_oog)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -374,7 +374,7 @@ TEST_F(state_transition, extcall_cold_oog)
 
 TEST_F(state_transition, extdelegatecall_cold_oog)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -389,7 +389,7 @@ TEST_F(state_transition, extdelegatecall_cold_oog)
 
 TEST_F(state_transition, extstaticcall_cold_oog)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -404,7 +404,7 @@ TEST_F(state_transition, extstaticcall_cold_oog)
 
 TEST_F(state_transition, extcall_value_zero_to_nonexistent_account)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     tx.to = To;
@@ -418,7 +418,7 @@ TEST_F(state_transition, extcall_value_zero_to_nonexistent_account)
 
 TEST_F(state_transition, extcall_then_oog)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -443,7 +443,7 @@ TEST_F(state_transition, extcall_then_oog)
 
 TEST_F(state_transition, extdelegatecall_then_oog)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -468,7 +468,7 @@ TEST_F(state_transition, extdelegatecall_then_oog)
 
 TEST_F(state_transition, extstaticcall_then_oog)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -492,7 +492,7 @@ TEST_F(state_transition, extstaticcall_then_oog)
 
 TEST_F(state_transition, extcall_callee_revert)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -511,7 +511,7 @@ TEST_F(state_transition, extcall_callee_revert)
 
 TEST_F(state_transition, extdelegatecall_callee_revert)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -530,7 +530,7 @@ TEST_F(state_transition, extdelegatecall_callee_revert)
 
 TEST_F(state_transition, extstaticcall_callee_revert)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -549,7 +549,7 @@ TEST_F(state_transition, extstaticcall_callee_revert)
 
 TEST_F(state_transition, extcall_callee_abort)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -568,7 +568,7 @@ TEST_F(state_transition, extcall_callee_abort)
 
 TEST_F(state_transition, extdelegatecall_callee_abort)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -587,7 +587,7 @@ TEST_F(state_transition, extdelegatecall_callee_abort)
 
 TEST_F(state_transition, extstaticcall_callee_abort)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -606,7 +606,7 @@ TEST_F(state_transition, extstaticcall_callee_abort)
 
 TEST_F(state_transition, extcall_input)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -626,7 +626,7 @@ TEST_F(state_transition, extcall_input)
 
 TEST_F(state_transition, extdelegatecall_input)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -647,7 +647,7 @@ TEST_F(state_transition, extdelegatecall_input)
 
 TEST_F(state_transition, extstaticcall_input)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -668,7 +668,7 @@ TEST_F(state_transition, extstaticcall_input)
 
 TEST_F(state_transition, extcall_with_value_enough_gas)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {.balance = 0x1});
@@ -689,7 +689,7 @@ TEST_F(state_transition, extcall_with_value_enough_gas)
 
 TEST_F(state_transition, extcall_with_value_low_gas)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {.balance = 0x1});
@@ -709,7 +709,7 @@ TEST_F(state_transition, extcall_with_value_low_gas)
 
 TEST_F(state_transition, extcall_recipient_and_code_address)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee,
@@ -729,7 +729,7 @@ TEST_F(state_transition, extcall_recipient_and_code_address)
 
 TEST_F(state_transition, extdelegatecall_recipient_and_code_address)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee,
@@ -749,7 +749,7 @@ TEST_F(state_transition, extdelegatecall_recipient_and_code_address)
 
 TEST_F(state_transition, extstaticcall_recipient_and_code_address)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee,
@@ -770,7 +770,7 @@ TEST_F(state_transition, extstaticcall_recipient_and_code_address)
 
 TEST_F(state_transition, extcall_value)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -789,7 +789,7 @@ TEST_F(state_transition, extcall_value)
 
 TEST_F(state_transition, returndatasize_before_extcall)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     tx.to = To;
     pre.insert(*tx.to, {
@@ -801,7 +801,7 @@ TEST_F(state_transition, returndatasize_before_extcall)
 
 TEST_F(state_transition, extdelegatecall_returndatasize)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -820,7 +820,7 @@ TEST_F(state_transition, extdelegatecall_returndatasize)
 
 TEST_F(state_transition, extdelegatecall_returndatasize_abort)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -839,7 +839,7 @@ TEST_F(state_transition, extdelegatecall_returndatasize_abort)
 
 TEST_F(state_transition, returndatacopy)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     const auto call_output =
         0x497f3c9f61479c1cfa53f0373d39d2bf4e5f73f71411da62f1d6b85c03a60735_bytes32;
@@ -863,7 +863,7 @@ TEST_F(state_transition, returndatacopy)
 
 TEST_F(state_transition, returndataload)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     const auto call_output =
         0x497f3c9f61479c1cfa53f0373d39d2bf4e5f73f71411da62f1d6b85c03a60735_bytes32;
@@ -885,7 +885,7 @@ TEST_F(state_transition, returndataload)
 
 TEST_F(state_transition, extcall_clears_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
     const auto call_output =
         0x497f3c9f61479c1cfa53f0373d39d2bf4e5f73f71411da62f1d6b85c03a60735_bytes32;
@@ -908,7 +908,7 @@ TEST_F(state_transition, extcall_clears_returndata)
 
 TEST_F(state_transition, extcall_gas_refund_propagation)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {
@@ -927,7 +927,7 @@ TEST_F(state_transition, extcall_gas_refund_propagation)
 
 TEST_F(state_transition, extdelegatecall_gas_refund_propagation)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     constexpr auto callee = 0xca11ee_address;
 
     pre.insert(callee, {

--- a/test/unittests/state_transition_eof_create_test.cpp
+++ b/test/unittests/state_transition_eof_create_test.cpp
@@ -16,7 +16,7 @@ constexpr bytes32 Salt{0xff};
 
 TEST_F(state_transition, create_tx_with_eof_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const bytecode init_container = eof_bytecode(ret(0, 1));
 
@@ -30,7 +30,7 @@ TEST_F(state_transition, create_tx_with_eof_initcode)
 
 TEST_F(state_transition, create_with_eof_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -74,7 +74,7 @@ TEST_F(state_transition, create_with_eof_initcode_cancun)
 
 TEST_F(state_transition, create2_with_eof_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -120,7 +120,7 @@ TEST_F(state_transition, create2_with_eof_initcode_cancun)
 
 TEST_F(state_transition, creation_tx_deploying_eof)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const bytecode deploy_container = eof_bytecode(bytecode(OP_INVALID));
     const auto init_code = mstore(0, push(deploy_container)) +
@@ -137,7 +137,7 @@ TEST_F(state_transition, creation_tx_deploying_eof)
 
 TEST_F(state_transition, create_deploying_eof)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -163,7 +163,7 @@ TEST_F(state_transition, create_deploying_eof)
 
 TEST_F(state_transition, create2_deploying_eof)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -190,7 +190,7 @@ TEST_F(state_transition, create2_deploying_eof)
 
 TEST_F(state_transition, eofcreate_empty_auxdata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -212,7 +212,7 @@ TEST_F(state_transition, eofcreate_empty_auxdata)
 
 TEST_F(state_transition, eofcreate_auxdata_equal_to_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -243,7 +243,7 @@ TEST_F(state_transition, eofcreate_auxdata_equal_to_declared)
 
 TEST_F(state_transition, eofcreate_auxdata_longer_than_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data1 = "aabbccdd"_hex;
     const auto aux_data2 = "eeff"_hex;
@@ -276,7 +276,7 @@ TEST_F(state_transition, eofcreate_auxdata_longer_than_declared)
 
 TEST_F(state_transition, eofcreate_auxdata_shorter_than_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size() + 1);
@@ -303,7 +303,7 @@ TEST_F(state_transition, eofcreate_auxdata_shorter_than_declared)
 
 TEST_F(state_transition, eofcreate_dataloadn_referring_to_auxdata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = bytes(64, 0);
     const auto aux_data = bytes(32, 0);
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -334,7 +334,7 @@ TEST_F(state_transition, eofcreate_dataloadn_referring_to_auxdata)
 
 TEST_F(state_transition, eofcreate_with_auxdata_and_subcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -371,7 +371,7 @@ TEST_F(state_transition, eofcreate_with_auxdata_and_subcontainer)
 
 TEST_F(state_transition, eofcreate_revert_empty_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = revert(0, 0);
     const auto init_container = eof_bytecode(init_code, 2);
 
@@ -391,7 +391,7 @@ TEST_F(state_transition, eofcreate_revert_empty_returndata)
 
 TEST_F(state_transition, eofcreate_revert_non_empty_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = mstore8(0, 0xaa) + revert(0, 1);
     const auto init_container = eof_bytecode(init_code, 2);
 
@@ -411,7 +411,7 @@ TEST_F(state_transition, eofcreate_revert_non_empty_returndata)
 
 TEST_F(state_transition, eofcreate_initcontainer_aborts)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{Opcode{OP_INVALID}};
     const auto init_container = eof_bytecode(init_code, 0);
 
@@ -429,7 +429,7 @@ TEST_F(state_transition, eofcreate_initcontainer_aborts)
 
 TEST_F(state_transition, eofcreate_deploy_container_max_size)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -460,7 +460,7 @@ TEST_F(state_transition, eofcreate_deploy_container_max_size)
 
 TEST_F(state_transition, eofcreate_deploy_container_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -489,7 +489,7 @@ TEST_F(state_transition, eofcreate_deploy_container_too_large)
 
 TEST_F(state_transition, eofcreate_appended_data_size_larger_than_64K)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -526,7 +526,7 @@ TEST_F(state_transition, eofcreate_appended_data_size_larger_than_64K)
 
 TEST_F(state_transition, eofcreate_deploy_container_with_aux_data_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -555,7 +555,7 @@ TEST_F(state_transition, eofcreate_deploy_container_with_aux_data_too_large)
 
 TEST_F(state_transition, eofcreate_nested_eofcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -591,7 +591,7 @@ TEST_F(state_transition, eofcreate_nested_eofcreate)
 
 TEST_F(state_transition, eofcreate_nested_eofcreate_revert)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const auto deploy_data_nested = "ffffff"_hex;
     const auto deploy_container_nested =
@@ -617,7 +617,7 @@ TEST_F(state_transition, eofcreate_nested_eofcreate_revert)
 
 TEST_F(state_transition, eofcreate_caller_balance_too_low)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode{Opcode{OP_INVALID}}).data(deploy_data);
 
@@ -640,7 +640,7 @@ TEST_F(state_transition, eofcreate_caller_balance_too_low)
 
 TEST_F(state_transition, eofcreate_not_enough_gas_for_initcode_charge)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -668,7 +668,7 @@ TEST_F(state_transition, eofcreate_not_enough_gas_for_initcode_charge)
 
 TEST_F(state_transition, eofcreate_not_enough_gas_for_mem_expansion)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
     // max size aux data
     const auto aux_data_size = static_cast<uint16_t>(
@@ -702,7 +702,7 @@ TEST_F(state_transition, eofcreate_not_enough_gas_for_mem_expansion)
 
 TEST_F(state_transition, returncode_not_enough_gas_for_mem_expansion)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -739,7 +739,7 @@ TEST_F(state_transition, eofcreate_clears_returndata)
 {
     static constexpr auto returning_address = 0x3000_address;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_STOP);
 
     const auto init_code = returncode(0, 0, 0);
@@ -771,7 +771,7 @@ TEST_F(state_transition, eofcreate_clears_returndata)
 
 TEST_F(state_transition, eofcreate_failure_after_eofcreate_success)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -802,7 +802,7 @@ TEST_F(state_transition, eofcreate_failure_after_eofcreate_success)
 
 TEST_F(state_transition, eofcreate_call_created_contract)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;  // 3 bytes
     const auto static_aux_data =
         "aabbccdd00000000000000000000000000000000000000000000000000000000"_hex;  // 32 bytes

--- a/test/unittests/state_transition_extcode_test.cpp
+++ b/test/unittests/state_transition_extcode_test.cpp
@@ -44,7 +44,7 @@ TEST_F(state_transition, legacy_extcodesize_eof)
 {
     pre.insert(target, {.code = eof_bytecode("FE")});
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.to = To;
     pre.insert(*tx.to, {
                            .code = bytecode(push(target) + sstore(1, OP_EXTCODESIZE)),
@@ -57,7 +57,7 @@ TEST_F(state_transition, legacy_extcodehash_eof)
 {
     pre.insert(target, {.code = eof_bytecode("FE")});
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.to = To;
     pre.insert(*tx.to, {
                            .code = bytecode(push(target) + sstore(1, OP_EXTCODEHASH)),
@@ -72,7 +72,7 @@ TEST_F(state_transition, legacy_extcodecopy_eof)
         0x1111111111111111111111111111111111111111111111111111111111111111_bytes32;
     pre.insert(target, {.code = eof_bytecode("FE")});
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.to = To;
     pre.insert(*tx.to, {
                            .code = bytecode(mstore(0, ones) + push(20) + push0() + push0() +

--- a/test/unittests/state_transition_txcreate_test.cpp
+++ b/test/unittests/state_transition_txcreate_test.cpp
@@ -15,7 +15,7 @@ constexpr bytes32 Salt{0xff};
 
 TEST_F(state_transition, txcreate_empty_auxdata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -40,7 +40,7 @@ TEST_F(state_transition, txcreate_empty_auxdata)
 
 TEST_F(state_transition, txcreate_auxdata_equal_to_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -73,7 +73,7 @@ TEST_F(state_transition, txcreate_auxdata_equal_to_declared)
 
 TEST_F(state_transition, txcreate_auxdata_longer_than_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data1 = "aabbccdd"_hex;
     const auto aux_data2 = "eeff"_hex;
@@ -108,7 +108,7 @@ TEST_F(state_transition, txcreate_auxdata_longer_than_declared)
 
 TEST_F(state_transition, txcreate_auxdata_shorter_than_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size() + 1);
@@ -136,7 +136,7 @@ TEST_F(state_transition, txcreate_auxdata_shorter_than_declared)
 
 TEST_F(state_transition, txcreate_stray_data_initcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -163,7 +163,7 @@ TEST_F(state_transition, txcreate_stray_data_initcontainer)
 
 TEST_F(state_transition, txcreate_dataloadn_referring_to_auxdata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = bytes(64, 0);
     const auto aux_data = bytes(32, 0);
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -197,7 +197,7 @@ TEST_F(state_transition, txcreate_dataloadn_referring_to_auxdata)
 
 TEST_F(state_transition, txcreate_revert_empty_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = revert(0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2);
 
@@ -221,7 +221,7 @@ TEST_F(state_transition, txcreate_revert_empty_returndata)
 
 TEST_F(state_transition, txcreate_revert_non_empty_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = mstore8(0, 0xaa) + revert(0, 1);
     const bytecode init_container = eof_bytecode(init_code, 2);
 
@@ -245,7 +245,7 @@ TEST_F(state_transition, txcreate_revert_non_empty_returndata)
 
 TEST_F(state_transition, txcreate_initcontainer_aborts)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{Opcode{OP_INVALID}};
     const bytecode init_container = eof_bytecode(init_code, 0);
 
@@ -268,7 +268,7 @@ TEST_F(state_transition, txcreate_initcontainer_aborts)
 
 TEST_F(state_transition, txcreate_initcontainer_return)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{0xaa + ret_top()};
     const bytecode init_container = eof_bytecode(init_code, 2);
 
@@ -291,7 +291,7 @@ TEST_F(state_transition, txcreate_initcontainer_return)
 
 TEST_F(state_transition, txcreate_initcontainer_stop)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{Opcode{OP_STOP}};
     const bytecode init_container = eof_bytecode(init_code, 0);
 
@@ -314,7 +314,7 @@ TEST_F(state_transition, txcreate_initcontainer_stop)
 
 TEST_F(state_transition, txcreate_initcontainer_max_size)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -346,7 +346,7 @@ TEST_F(state_transition, txcreate_initcontainer_max_size)
 
 TEST_F(state_transition, txcreate_initcontainer_empty)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const bytecode empty_init_container{};
 
@@ -371,7 +371,7 @@ TEST_F(state_transition, txcreate_initcontainer_empty)
 
 TEST_F(state_transition, txcreate_no_initcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     tx.type = Transaction::Type::initcodes;
 
@@ -387,7 +387,7 @@ TEST_F(state_transition, txcreate_no_initcontainer)
 
 TEST_F(state_transition, txcreate_initcontainer_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -417,7 +417,7 @@ TEST_F(state_transition, txcreate_initcontainer_too_large)
 
 TEST_F(state_transition, txcreate_too_many_initcontainers)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -460,7 +460,7 @@ TEST_F(state_transition, initcode_transaction_before_prague)
 
 TEST_F(state_transition, txcreate_deploy_container_max_size)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -496,7 +496,7 @@ TEST_F(state_transition, txcreate_deploy_container_max_size)
 
 TEST_F(state_transition, txcreate_deploy_container_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -530,7 +530,7 @@ TEST_F(state_transition, txcreate_deploy_container_too_large)
 
 TEST_F(state_transition, txcreate_appended_data_size_larger_than_64K)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -569,7 +569,7 @@ TEST_F(state_transition, txcreate_appended_data_size_larger_than_64K)
 
 TEST_F(state_transition, txcreate_deploy_container_with_aux_data_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -603,7 +603,7 @@ TEST_F(state_transition, txcreate_deploy_container_with_aux_data_too_large)
 
 TEST_F(state_transition, txcreate_nested_txcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -644,7 +644,7 @@ TEST_F(state_transition, txcreate_nested_txcreate)
 
 TEST_F(state_transition, txcreate_nested_txcreate_revert)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data_nested = "ffffff"_hex;
     const auto deploy_container_nested =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data_nested);
@@ -674,7 +674,7 @@ TEST_F(state_transition, txcreate_nested_txcreate_revert)
 
 TEST_F(state_transition, txcreate_nested_eofcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -713,7 +713,7 @@ TEST_F(state_transition, txcreate_nested_eofcreate)
 
 TEST_F(state_transition, txcreate_called_balance_too_low)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -744,7 +744,7 @@ TEST_F(state_transition, txcreate_clears_returndata)
 {
     static constexpr auto returning_address = 0x3000_address;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_STOP);
 
     const auto init_code = returncode(0, 0, 0);
@@ -779,7 +779,7 @@ TEST_F(state_transition, txcreate_clears_returndata)
 
 TEST_F(state_transition, txcreate_failure_after_txcreate_success)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -814,7 +814,7 @@ TEST_F(state_transition, txcreate_failure_after_txcreate_success)
 
 TEST_F(state_transition, txcreate_invalid_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -842,7 +842,7 @@ TEST_F(state_transition, txcreate_invalid_initcode)
 
 TEST_F(state_transition, txcreate_truncated_data_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -870,7 +870,7 @@ TEST_F(state_transition, txcreate_truncated_data_initcode)
 
 TEST_F(state_transition, txcreate_invalid_deploycode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID), 123);  // Invalid EOF
 
     const auto init_code = returncode(0, 0, 0);
@@ -896,7 +896,7 @@ TEST_F(state_transition, txcreate_invalid_deploycode)
 
 TEST_F(state_transition, txcreate_missing_initcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -921,7 +921,7 @@ TEST_F(state_transition, txcreate_missing_initcontainer)
 
 TEST_F(state_transition, txcreate_light_failure_stack)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -947,7 +947,7 @@ TEST_F(state_transition, txcreate_light_failure_stack)
 
 TEST_F(state_transition, txcreate_missing_deploycontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = returncode(0, 0, 0);
     const bytes init_container = eof_bytecode(init_code, 2);
 
@@ -971,7 +971,7 @@ TEST_F(state_transition, txcreate_missing_deploycontainer)
 
 TEST_F(state_transition, txcreate_deploy_code_with_dataloadn_invalid)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = bytes(32, 0);
     // DATALOADN{64} - referring to offset out of bounds even after appending aux_data later
     const auto deploy_code = bytecode(OP_DATALOADN) + "0040" + ret_top();
@@ -1002,7 +1002,7 @@ TEST_F(state_transition, txcreate_deploy_code_with_dataloadn_invalid)
 
 TEST_F(state_transition, txcreate_call_created_contract)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;  // 3 bytes
     const auto static_aux_data =
         "aabbccdd00000000000000000000000000000000000000000000000000000000"_hex;  // 32 bytes
@@ -1060,7 +1060,7 @@ TEST_F(state_transition, txcreate_call_created_contract)
 
 TEST_F(state_transition, create_nested_in_txcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_STOP);
 
     const auto init_code = bytecode{OP_DATASIZE} + OP_PUSH0 + OP_PUSH0 + OP_DATACOPY +
@@ -1085,7 +1085,7 @@ TEST_F(state_transition, create_nested_in_txcreate)
 
 TEST_F(state_transition, create2_nested_in_txcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_INVALID);
 
     const auto init_code = bytecode{OP_DATASIZE} + OP_PUSH0 + OP_PUSH0 + OP_DATACOPY +
@@ -1111,7 +1111,7 @@ TEST_F(state_transition, create2_nested_in_txcreate)
 
 TEST_F(state_transition, txcreate_from_legacy_tx)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.type = Transaction::Type::legacy;
 
     const auto factory_code = sstore(0, txcreate().initcode(keccak256({})).input(0, 0).salt(Salt)) +
@@ -1129,7 +1129,7 @@ TEST_F(state_transition, txcreate_from_legacy_tx)
 
 TEST_F(state_transition, txcreate_from_1559_tx)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.type = Transaction::Type::eip1559;
 
     const auto factory_code = sstore(0, txcreate().initcode(keccak256({})).input(0, 0).salt(Salt)) +
@@ -1147,7 +1147,7 @@ TEST_F(state_transition, txcreate_from_1559_tx)
 
 TEST_F(state_transition, txcreate_from_blob_tx)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     block.blob_base_fee = 1;
 
@@ -1172,7 +1172,7 @@ TEST_F(state_transition, txcreate_from_blob_tx)
 
 TEST_F(state_transition, txcreate_loop_valid)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 30'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1209,7 +1209,7 @@ TEST_F(state_transition, txcreate_loop_valid)
 
 TEST_F(state_transition, txcreate_loop_invalid)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 30'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1237,7 +1237,7 @@ TEST_F(state_transition, txcreate_loop_invalid)
 
 TEST_F(state_transition, legacy_txcreate_empty_auxdata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -1261,7 +1261,7 @@ TEST_F(state_transition, legacy_txcreate_empty_auxdata)
 
 TEST_F(state_transition, legacy_txcreate_auxdata_equal_to_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -1293,7 +1293,7 @@ TEST_F(state_transition, legacy_txcreate_auxdata_equal_to_declared)
 
 TEST_F(state_transition, legacy_txcreate_auxdata_longer_than_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data1 = "aabbccdd"_hex;
     const auto aux_data2 = "eeff"_hex;
@@ -1327,7 +1327,7 @@ TEST_F(state_transition, legacy_txcreate_auxdata_longer_than_declared)
 
 TEST_F(state_transition, legacy_txcreate_auxdata_shorter_than_declared)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto aux_data = "aabbccddeeff"_hex;
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size() + 1);
@@ -1354,7 +1354,7 @@ TEST_F(state_transition, legacy_txcreate_auxdata_shorter_than_declared)
 
 TEST_F(state_transition, legacy_txcreate_stray_data_initcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -1380,7 +1380,7 @@ TEST_F(state_transition, legacy_txcreate_stray_data_initcontainer)
 
 TEST_F(state_transition, legacy_txcreate_dataloadn_referring_to_auxdata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = bytes(64, 0);
     const auto aux_data = bytes(32, 0);
     const auto deploy_data_size = static_cast<uint16_t>(deploy_data.size() + aux_data.size());
@@ -1413,7 +1413,7 @@ TEST_F(state_transition, legacy_txcreate_dataloadn_referring_to_auxdata)
 
 TEST_F(state_transition, legacy_txcreate_revert_empty_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = revert(0, 0);
     const bytecode init_container = eof_bytecode(init_code, 2);
 
@@ -1436,7 +1436,7 @@ TEST_F(state_transition, legacy_txcreate_revert_empty_returndata)
 
 TEST_F(state_transition, legacy_txcreate_revert_non_empty_returndata)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = mstore8(0, 0xaa) + revert(0, 1);
     const bytecode init_container = eof_bytecode(init_code, 2);
 
@@ -1459,7 +1459,7 @@ TEST_F(state_transition, legacy_txcreate_revert_non_empty_returndata)
 
 TEST_F(state_transition, legacy_txcreate_initcontainer_aborts)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{Opcode{OP_INVALID}};
     const bytecode init_container = eof_bytecode(init_code, 0);
 
@@ -1481,7 +1481,7 @@ TEST_F(state_transition, legacy_txcreate_initcontainer_aborts)
 
 TEST_F(state_transition, legacy_txcreate_initcontainer_return)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{0xaa + ret_top()};
     const bytecode init_container = eof_bytecode(init_code, 2);
 
@@ -1503,7 +1503,7 @@ TEST_F(state_transition, legacy_txcreate_initcontainer_return)
 
 TEST_F(state_transition, legacy_txcreate_initcontainer_stop)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = bytecode{Opcode{OP_STOP}};
     const bytecode init_container = eof_bytecode(init_code, 0);
 
@@ -1525,7 +1525,7 @@ TEST_F(state_transition, legacy_txcreate_initcontainer_stop)
 
 TEST_F(state_transition, legacy_txcreate_initcontainer_max_size)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1556,7 +1556,7 @@ TEST_F(state_transition, legacy_txcreate_initcontainer_max_size)
 
 TEST_F(state_transition, legacy_txcreate_initcontainer_empty)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     const bytecode empty_init_container{};
 
@@ -1580,7 +1580,7 @@ TEST_F(state_transition, legacy_txcreate_initcontainer_empty)
 
 TEST_F(state_transition, legacy_txcreate_no_initcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     tx.type = Transaction::Type::initcodes;
 
@@ -1595,7 +1595,7 @@ TEST_F(state_transition, legacy_txcreate_no_initcontainer)
 
 TEST_F(state_transition, legacy_txcreate_initcontainer_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1624,7 +1624,7 @@ TEST_F(state_transition, legacy_txcreate_initcontainer_too_large)
 
 TEST_F(state_transition, legacy_txcreate_too_many_initcontainers)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1666,7 +1666,7 @@ TEST_F(state_transition, legacy_initcode_transaction_before_prague)
 
 TEST_F(state_transition, legacy_txcreate_deploy_container_max_size)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1701,7 +1701,7 @@ TEST_F(state_transition, legacy_txcreate_deploy_container_max_size)
 
 TEST_F(state_transition, legacy_txcreate_deploy_container_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1734,7 +1734,7 @@ TEST_F(state_transition, legacy_txcreate_deploy_container_too_large)
 
 TEST_F(state_transition, legacy_txcreate_appended_data_size_larger_than_64K)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1772,7 +1772,7 @@ TEST_F(state_transition, legacy_txcreate_appended_data_size_larger_than_64K)
 
 TEST_F(state_transition, legacy_txcreate_deploy_container_with_aux_data_too_large)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -1805,7 +1805,7 @@ TEST_F(state_transition, legacy_txcreate_deploy_container_with_aux_data_too_larg
 
 TEST_F(state_transition, legacy_txcreate_nested_txcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -1845,7 +1845,7 @@ TEST_F(state_transition, legacy_txcreate_nested_txcreate)
 
 TEST_F(state_transition, legacy_txcreate_nested_txcreate_revert)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data_nested = "ffffff"_hex;
     const auto deploy_container_nested =
         eof_bytecode(bytecode(OP_INVALID)).data(deploy_data_nested);
@@ -1874,7 +1874,7 @@ TEST_F(state_transition, legacy_txcreate_nested_txcreate_revert)
 
 TEST_F(state_transition, legacy_txcreate_nested_eofcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -1912,7 +1912,7 @@ TEST_F(state_transition, legacy_txcreate_nested_eofcreate)
 
 TEST_F(state_transition, legacy_txcreate_called_balance_too_low)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID)).data(deploy_data);
 
@@ -1942,7 +1942,7 @@ TEST_F(state_transition, legacy_txcreate_clears_returndata)
 {
     static constexpr auto returning_address = 0x3000_address;
 
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_STOP);
 
     const auto init_code = returncode(0, 0, 0);
@@ -1977,7 +1977,7 @@ TEST_F(state_transition, legacy_txcreate_clears_returndata)
 
 TEST_F(state_transition, legacy_txcreate_failure_after_txcreate_success)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 10'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -2011,7 +2011,7 @@ TEST_F(state_transition, legacy_txcreate_failure_after_txcreate_success)
 
 TEST_F(state_transition, legacy_txcreate_invalid_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -2038,7 +2038,7 @@ TEST_F(state_transition, legacy_txcreate_invalid_initcode)
 
 TEST_F(state_transition, legacy_txcreate_truncated_data_initcode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -2065,7 +2065,7 @@ TEST_F(state_transition, legacy_txcreate_truncated_data_initcode)
 
 TEST_F(state_transition, legacy_txcreate_invalid_deploycode)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID), 123);  // Invalid EOF
 
     const auto init_code = returncode(0, 0, 0);
@@ -2090,7 +2090,7 @@ TEST_F(state_transition, legacy_txcreate_invalid_deploycode)
 
 TEST_F(state_transition, legacy_txcreate_missing_initcontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -2114,7 +2114,7 @@ TEST_F(state_transition, legacy_txcreate_missing_initcontainer)
 
 TEST_F(state_transition, legacy_txcreate_light_failure_stack)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(bytecode(OP_INVALID));
 
     const auto init_code = returncode(0, 0, 0);
@@ -2140,7 +2140,7 @@ TEST_F(state_transition, legacy_txcreate_light_failure_stack)
 
 TEST_F(state_transition, legacy_txcreate_missing_deploycontainer)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto init_code = returncode(0, 0, 0);
     const bytes init_container = eof_bytecode(init_code, 2);
 
@@ -2163,7 +2163,7 @@ TEST_F(state_transition, legacy_txcreate_missing_deploycontainer)
 
 TEST_F(state_transition, legacy_txcreate_deploy_code_with_dataloadn_invalid)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = bytes(32, 0);
     // DATALOADN{64} - referring to offset out of bounds even after appending aux_data later
     const auto deploy_code = bytecode(OP_DATALOADN) + "0040" + ret_top();
@@ -2193,7 +2193,7 @@ TEST_F(state_transition, legacy_txcreate_deploy_code_with_dataloadn_invalid)
 
 TEST_F(state_transition, legacy_txcreate_call_created_contract)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_data = "abcdef"_hex;  // 3 bytes
     const auto static_aux_data =
         "aabbccdd00000000000000000000000000000000000000000000000000000000"_hex;  // 32 bytes
@@ -2250,7 +2250,7 @@ TEST_F(state_transition, legacy_txcreate_call_created_contract)
 
 TEST_F(state_transition, legacy_create_nested_in_txcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_STOP);
 
     const auto init_code = bytecode{OP_DATASIZE} + OP_PUSH0 + OP_PUSH0 + OP_DATACOPY +
@@ -2274,7 +2274,7 @@ TEST_F(state_transition, legacy_create_nested_in_txcreate)
 
 TEST_F(state_transition, legacy_create2_nested_in_txcreate)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     const auto deploy_container = eof_bytecode(OP_INVALID);
 
     const auto init_code = bytecode{OP_DATASIZE} + OP_PUSH0 + OP_PUSH0 + OP_DATACOPY +
@@ -2299,7 +2299,7 @@ TEST_F(state_transition, legacy_create2_nested_in_txcreate)
 
 TEST_F(state_transition, legacy_txcreate_from_legacy_tx)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.type = Transaction::Type::legacy;
 
     const auto factory_code = sstore(0, txcreate().initcode(keccak256({})).input(0, 0).salt(Salt)) +
@@ -2316,7 +2316,7 @@ TEST_F(state_transition, legacy_txcreate_from_legacy_tx)
 
 TEST_F(state_transition, legacy_txcreate_from_1559_tx)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     tx.type = Transaction::Type::eip1559;
 
     const auto factory_code = sstore(0, txcreate().initcode(keccak256({})).input(0, 0).salt(Salt)) +
@@ -2333,7 +2333,7 @@ TEST_F(state_transition, legacy_txcreate_from_1559_tx)
 
 TEST_F(state_transition, legacy_txcreate_from_blob_tx)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
 
     block.blob_base_fee = 1;
 
@@ -2357,7 +2357,7 @@ TEST_F(state_transition, legacy_txcreate_from_blob_tx)
 
 TEST_F(state_transition, legacy_txcreate_loop_valid)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 30'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;
@@ -2393,7 +2393,7 @@ TEST_F(state_transition, legacy_txcreate_loop_valid)
 
 TEST_F(state_transition, legacy_txcreate_loop_invalid)
 {
-    rev = EVMC_OSAKA;
+    rev = EVMC_EXPERIMENTAL;
     block.gas_limit = 30'000'000;
     tx.gas_limit = block.gas_limit;
     pre.get(tx.sender).balance = tx.gas_limit * tx.max_gas_price + tx.value + 1;

--- a/test/unittests/state_tx_test.cpp
+++ b/test/unittests/state_tx_test.cpp
@@ -154,7 +154,7 @@ TEST(state_tx, validate_eof_create_transaction)
     EXPECT_FALSE(holds_alternative<std::error_code>(
         validate_transaction(state, block, tx, EVMC_PRAGUE, 60000, 0)));
     EXPECT_FALSE(holds_alternative<std::error_code>(
-        validate_transaction(state, block, tx, EVMC_OSAKA, 60000, 0)));
+        validate_transaction(state, block, tx, EVMC_EXPERIMENTAL, 60000, 0)));
 }
 
 TEST(state_tx, validate_tx_data_cost)

--- a/test/unittests/statetest_loader_test.cpp
+++ b/test/unittests/statetest_loader_test.cpp
@@ -165,7 +165,7 @@ TEST(statetest_loader, load_minimal_test)
 TEST(statetest_loader, validate_state_invalid_eof)
 {
     TestState state{{0xadd4_address, {.code = "EF0001010000020001000103000100FEDA"_hex}}};
-    EXPECT_THAT([&] { validate_state(state, EVMC_OSAKA); },
+    EXPECT_THAT([&] { validate_state(state, EVMC_EXPERIMENTAL); },
         ThrowsMessage<std::invalid_argument>(
             "EOF container at 0x000000000000000000000000000000000000add4 is invalid: "
             "zero_section_size"));

--- a/test/unittests/tracing_test.cpp
+++ b/test/unittests/tracing_test.cpp
@@ -305,7 +305,7 @@ TEST_F(tracing, trace_eof)
     vm.add_tracer(evmone::create_instruction_tracer(trace_stream));
 
     trace_stream << '\n';
-    EXPECT_EQ(trace(bytecode{eof_bytecode(add(2, 3) + OP_STOP, 2)}, 0, 0, EVMC_OSAKA), R"(
+    EXPECT_EQ(trace(bytecode{eof_bytecode(add(2, 3) + OP_STOP, 2)}, 0, 0, EVMC_EXPERIMENTAL), R"(
 {"pc":0,"op":96,"gas":"0xf4240","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":2,"op":96,"gas":"0xf423d","gasCost":"0x3","memSize":0,"stack":["0x3"],"depth":1,"refund":0,"opName":"PUSH1"}
 {"pc":4,"op":1,"gas":"0xf423a","gasCost":"0x3","memSize":0,"stack":["0x3","0x2"],"depth":1,"refund":0,"opName":"ADD"}

--- a/test/utils/utils.cpp
+++ b/test/utils/utils.cpp
@@ -39,6 +39,10 @@ evmc_revision to_rev(std::string_view s)
         return EVMC_PRAGUE;
     if (s == "Osaka")
         return EVMC_OSAKA;
+    if (s == "EOFv1")
+        return EVMC_EXPERIMENTAL;
+    if (s == "Experimental")
+        return EVMC_EXPERIMENTAL;
     throw std::invalid_argument{"unknown revision: " + std::string{s}};
 }
 


### PR DESCRIPTION
As title. Opening as draft b/c I'd like to update CI to some EEST release (if not too much hassle), while we still can fill these tests easily.

As such it translates the EEST's `EOFv1` fork to `EVMC_EXPERIMENTAL`. We might want something else in the long term there.