### PR TITLE
cmake: Upgrade Hunter to v0.26.0

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -4,11 +4,6 @@
 
 include(hunter_cmake_args)
 
-hunter_cmake_args(
-    ethash
-    CMAKE_ARGS -DETHASH_BUILD_ETHASH=OFF
-)
-
 hunter_config(
     intx
     VERSION 0.13.0
@@ -17,7 +12,7 @@ hunter_config(
 )
 
 # Propagate BENCHMARK_ENABLE_LIBPFM to google/benchmark.
-# https://github.com/google/benchmark/blob/v1.9.3/CMakeLists.txt#L42
+# https://github.com/google/benchmark/blob/v1.9.4/CMakeLists.txt#L42
 option(BENCHMARK_ENABLE_LIBPFM "Enable performance counters provided by libpfm" OFF)
 
 hunter_config(

--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -8,7 +8,7 @@ set(HUNTER_USE_CACHE_SERVERS NO CACHE STRING "Download binaries from Hunter cach
 include(HunterGate)
 
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.25.8.tar.gz"
-    SHA1 "26c79d587883ec910bce168e25f6ac4595f97033"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.26.0.tar.gz"
+    SHA1 "b1944539bad88a7cc006b4f3e4028a72a8ae46d1"
     LOCAL
 )

--- a/cmake/cable/HunterGate.cmake
+++ b/cmake/cable/HunterGate.cmake
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.5)
+#     cmake_minimum_required(VERSION 3.10)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -45,10 +45,10 @@
 option(HUNTER_ENABLED "Enable Hunter package manager support" ON)
 
 if(HUNTER_ENABLED)
-  if(CMAKE_VERSION VERSION_LESS "3.5")
+  if(CMAKE_VERSION VERSION_LESS "3.10")
     message(
         FATAL_ERROR
-        "At least CMake version 3.5 required for Hunter dependency management."
+        "At least CMake version 3.10 required for Hunter dependency management."
         " Update CMake or set HUNTER_ENABLED to OFF."
     )
   endif()
@@ -253,7 +253,7 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.5)\n"
+      "cmake_minimum_required(VERSION 3.10)\n"
       "if(POLICY CMP0114)\n"
       "  cmake_policy(SET CMP0114 NEW)\n"
       "endif()\n"


### PR DESCRIPTION
This fixes compatibility with cmake 4.0.

Fixes https://github.com/ethereum/evmone/issues/1183.