### PR TITLE
precompiles: Use std::span in modexp implementation

### DIFF
--- a/test/state/precompiles_gmp.cpp
+++ b/test/state/precompiles_gmp.cpp
@@ -8,7 +8,8 @@
 
 namespace evmone::state
 {
-void expmod_gmp(bytes_view base, bytes_view exp, bytes_view mod, uint8_t* output) noexcept
+void expmod_gmp(std::span<const uint8_t> base, std::span<const uint8_t> exp,
+    std::span<const uint8_t> mod, uint8_t* output) noexcept
 {
     mpz_t b, e, m, r;  // NOLINT(*-isolate-declaration)
     mpz_inits(b, e, m, r, nullptr);

--- a/test/state/precompiles_gmp.hpp
+++ b/test/state/precompiles_gmp.hpp
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <evmc/evmc.hpp>
+#include <cstdint>
+#include <span>
 
 namespace evmone::state
 {
-using evmc::bytes_view;
-
 /// Executes the expmod precompile using the GMP library.
 ///
 /// Requires mod not to be zero (having at least one non-zero byte).
-void expmod_gmp(bytes_view base, bytes_view exp, bytes_view mod, uint8_t* output) noexcept;
+void expmod_gmp(std::span<const uint8_t> base, std::span<const uint8_t> exp,
+    std::span<const uint8_t> mod, uint8_t* output) noexcept;
 }  // namespace evmone::state

--- a/test/state/precompiles_stubs.cpp
+++ b/test/state/precompiles_stubs.cpp
@@ -3,12 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "precompiles_stubs.hpp"
+#include <evmc/evmc.hpp>
 #include <algorithm>
 #include <cassert>
 #include <iostream>
 
 namespace evmone::state
 {
+using evmc::bytes;
+using evmc::bytes_view;
+
 namespace
 {
 /// Returns the expmod result for the known inputs or empty bytes if not found.
@@ -102,8 +106,13 @@ bytes expmod_lookup_result(bytes_view base, bytes_view exp, bytes_view mod)
 }  // namespace
 
 
-void expmod_stub(bytes_view base, bytes_view exp, bytes_view mod, uint8_t* output) noexcept
+void expmod_stub(std::span<const uint8_t> in_base, std::span<const uint8_t> in_exp,
+    std::span<const uint8_t> in_mod, uint8_t* output) noexcept
 {
+    bytes_view base{in_base.data(), in_base.size()};
+    bytes_view exp{in_exp.data(), in_exp.size()};
+    bytes_view mod{in_mod.data(), in_mod.size()};
+
     // Keep the output size before the mod normalization.
     const auto output_size = mod.size();
 

--- a/test/state/precompiles_stubs.hpp
+++ b/test/state/precompiles_stubs.hpp
@@ -3,13 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "precompiles_internal.hpp"
+#include <cstdint>
+#include <span>
 
 namespace evmone::state
 {
-using evmc::bytes;
-using evmc::bytes_view;
-
 /// Executes the expmod precompile for trivial and pre-defined inputs.
-void expmod_stub(bytes_view base, bytes_view exp, bytes_view mod, uint8_t* output) noexcept;
+void expmod_stub(std::span<const uint8_t> base, std::span<const uint8_t> exp,
+    std::span<const uint8_t> mod, uint8_t* output) noexcept;
 }  // namespace evmone::state


### PR DESCRIPTION
Use std::span instead of evmc::bytes_view.