### PR TITLE
Add p256verify precompile ID/address

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -439,13 +439,13 @@ jobs:
           working_directory: ~/build
           command: >
             bin/evmone-statetest ~/spec-tests/fixtures/state_tests/
-            --gtest_filter='-frontier/precompiles/precompiles.precompiles:osaka/eip7951_p256verify_precompiles/*.*:prague/eip7702_set_code_tx/set_code_txs.set_code_to_precompile'
+            --gtest_filter='-osaka/eip7951_p256verify_precompiles/*.*'
       - run:
           name: "Fusaka pre-release execution spec tests (blockchain_tests)"
           working_directory: ~/build
           command: >
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests/
-            --gtest_filter='-frontier/precompiles/precompiles.precompiles:osaka/eip7934_block_rlp_limit/max_block_rlp_size.block_at_rlp_size_limit_boundary:osaka/eip7951_p256verify_precompiles/*.*:prague/eip7702_set_code_tx/set_code_txs.set_code_to_precompile'
+            --gtest_filter='-osaka/eip7934_block_rlp_limit/max_block_rlp_size.block_at_rlp_size_limit_boundary:osaka/eip7951_p256verify_precompiles/*.*'
       - collect_coverage_clang
       - upload_coverage:
           flags: eest-fusaka

--- a/test/state/precompiles.hpp
+++ b/test/state/precompiles.hpp
@@ -27,6 +27,7 @@ enum class PrecompileId : uint8_t
     bls12_pairing_check,
     bls12_map_fp_to_g1,
     bls12_map_fp2_to_g2,
+    p256verify,
 };
 
 /// Checks if the address @p addr is considered a precompiled contract in the revision @p rev.

--- a/test/unittests/state_precompiles_test.cpp
+++ b/test/unittests/state_precompiles_test.cpp
@@ -43,6 +43,9 @@ TEST(state_precompiles, is_precompile)
         EXPECT_EQ(is_precompile(rev, 0x10_address), rev >= EVMC_PRAGUE);
         EXPECT_EQ(is_precompile(rev, 0x11_address), rev >= EVMC_PRAGUE);
 
+        // Osaka:
+        EXPECT_EQ(is_precompile(rev, 0x0100_address), rev >= EVMC_OSAKA);
+
         // Future?
         EXPECT_FALSE(is_precompile(rev, 0x12_address));
         EXPECT_FALSE(is_precompile(rev, 0x13_address));


### PR DESCRIPTION
Introduce the `p256verify` ID for the secp256r1 precompile (EIP-7951). For now the implementation is omitted but the precompile recognition and gas cost work correctly.