### PR TITLE
tests: Fix blockchaintest EIP-7918

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -402,7 +402,7 @@ jobs:
           command: >
             LLVM_PROFILE_FILE=blockchain_tests.profraw
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
-            --gtest_filter='-cancun/eip4844_blobs.test_fork_transition_excess_blob_gas_post_blob_genesis:osaka/eip7918_blob_reserve_price.*:osaka/eip7934_block_rlp_limit.*:osaka/eip7951_p256verify_precompiles.*'
+            --gtest_filter='-osaka/eip7918_blob_reserve_price.*:osaka/eip7934_block_rlp_limit.*:osaka/eip7951_p256verify_precompiles.*'
       - collect_coverage_clang
       - upload_coverage:
           flags: eest-develop

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -166,6 +166,8 @@ bool validate_block(
             return false;
 
         // Check that the excess blob gas was updated correctly.
+        // According to EIP-7918 current blocks schedule (`rev`) should be used for parent base fee
+        // calculation.
         const auto parent_blob_base_fee =
             state::compute_blob_gas_price(rev, parent_header->excess_blob_gas.value_or(0));
         if (*test_block.block_info.excess_blob_gas !=

--- a/test/state/block.cpp
+++ b/test/state/block.cpp
@@ -89,7 +89,7 @@ uint64_t calc_excess_blob_gas(evmc_revision rev, uint64_t parent_blob_gas_used,
 
     if (rev >= EVMC_OSAKA && BLOB_BASE_COST * parent_base_fee > GAS_PER_BLOB * parent_blob_base_fee)
         return parent_excess_blob_gas +
-               parent_blob_gas_used * (schedule.max - schedule.target) / schedule.target;
+               parent_blob_gas_used * (schedule.max - schedule.target) / schedule.max;
 
     return parent_excess_blob_gas + parent_blob_gas_used - target_blob_gas_per_block;
 }


### PR DESCRIPTION
as title, EIP-7918 formula was incorrectly implemented, should be:

```
... OB * get_base_fee_per_blob_gas(parent):
...  * (blobSchedule.max - blobSchedule.target) // blobSchedule.max      <==== not target
... 
...  - target_blob_gas
```

This activates one skipped test