### PR TITLE
fix: Remove potentially dead, uncovered code in ExecutionState

### DIFF
--- a/lib/evmone/advanced_execution.cpp
+++ b/lib/evmone/advanced_execution.cpp
@@ -23,7 +23,7 @@ evmc_result execute(AdvancedExecutionState& state, const AdvancedCodeAnalysis& a
 
     assert(state.output_size != 0 || state.output_offset == 0);
     return evmc::make_result(state.status, gas_left, gas_refund,
-        state.memory.data() + state.output_offset, state.output_size);
+        state.output_size != 0 ? &state.memory[state.output_offset] : nullptr, state.output_size);
 }
 
 evmc_result execute(evmc_vm* /*unused*/, const evmc_host_interface* host, evmc_host_context* ctx,

--- a/lib/evmone/execution_state.hpp
+++ b/lib/evmone/execution_state.hpp
@@ -89,7 +89,6 @@ public:
 
     uint8_t& operator[](size_t index) noexcept { return m_data[index]; }
 
-    [[nodiscard]] const uint8_t* data() const noexcept { return m_data.get(); }
     [[nodiscard]] size_t size() const noexcept { return m_size; }
 
     /// Grows the memory to the given size. The extent is filled with zeros.

--- a/test/unittests/execution_state_test.cpp
+++ b/test/unittests/execution_state_test.cpp
@@ -131,7 +131,7 @@ TEST(execution_state, memory_view)
     evmone::Memory memory;
     memory.grow(32);
 
-    const evmone::bytes_view view{memory.data(), memory.size()};
+    const evmone::bytes_view view{&memory[0], memory.size()};
     ASSERT_EQ(view.size(), 32);
     EXPECT_EQ(view[0], 0x00);
     EXPECT_EQ(view[1], 0x00);


### PR DESCRIPTION
Coverage picks up the line in execution_state.hpp as uncovered, because it is used only in advanced execution. But maybe that can do away with the same method baseline uses?

Treat this more as a question - I'm unsure if these methods are actually fully equivalent. @chfast ?