### PR TITLE
precompiles: Use g1_mul and g2_mul for single-input multiplication

### DIFF
--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -606,8 +606,17 @@ ExecutionResult bls12_g1msm_execute(const uint8_t* input, size_t input_size, uin
 
     assert(output_size == BLS12_G1_POINT_SIZE);
 
-    if (!crypto::bls::g1_msm(output, &output[64], input, input_size))
-        return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (input_size == BLS12_G1_MUL_INPUT_SIZE)
+    {
+        // Optimize single multiplication case.
+        if (!crypto::bls::g1_mul(output, &output[64], input, &input[64], &input[128]))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+    else
+    {
+        if (!crypto::bls::g1_msm(output, &output[64], input, input_size))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
 }
@@ -634,8 +643,17 @@ ExecutionResult bls12_g2msm_execute(const uint8_t* input, size_t input_size, uin
 
     assert(output_size == BLS12_G2_POINT_SIZE);
 
-    if (!crypto::bls::g2_msm(output, &output[128], input, input_size))
-        return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (input_size == BLS12_G2_MUL_INPUT_SIZE)
+    {
+        // Optimize single multiplication case.
+        if (!crypto::bls::g2_mul(output, &output[128], input, &input[128], &input[256]))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+    else
+    {
+        if (!crypto::bls::g2_msm(output, &output[128], input, input_size))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
 }


### PR DESCRIPTION
I'm new to the bls party, but the coverage was telling me these functions are uncovered, and the EIP told me we should dispatch to them: https://eips.ethereum.org/EIPS/eip-2537#no-dedicated-mul-call 

So a quick take - is this the way to go? (bls.cpp is at 100% now)