### PR TITLE
docs: Add comments explaining coverage misses in ecc.hpp

### DIFF
--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -265,7 +265,8 @@ ProjPoint<Curve> add(const ProjPoint<Curve>& p, const ProjPoint<Curve>& q) noexc
     if (p == 0)
         return q;
     if (q == 0)
-        return p;  // TODO: Untested.
+        // TODO: Untested and untestable via precompile call (for secp256k1 and secp256r1).
+        return p;
 
     if (p == q)
         return dbl(p);
@@ -318,6 +319,7 @@ ProjPoint<Curve> add(const ProjPoint<Curve>& p, const AffinePoint<Curve>& q) noe
     assert(p != ProjPoint(q));
 
     if (q == 0)
+        // TODO: Untested and untestable via precompile call (for secp256k1 and secp256r1).
         return p;
     if (p == 0)
         return ProjPoint(q);
@@ -443,6 +445,7 @@ ProjPoint<Curve> mul(const AffinePoint<Curve>& p, typename Curve::uint_type c) n
         const auto [reduced_c, less_than] = subc(c, Curve::ORDER);
         if (less_than) [[likely]]
             break;
+        // TODO: Untested and untestable via precompile call (for secp256k1 and secp256r1).
         c = reduced_c;
     }
 

--- a/lib/evmone_precompiles/secp256k1.cpp
+++ b/lib/evmone_precompiles/secp256k1.cpp
@@ -92,6 +92,7 @@ std::optional<AffinePoint> secp256k1_ecdsa_recover(
 
     // 6. Calculate public key point Q.
     const auto R = AffinePoint{AffinePoint::FE::wrap(r_mont), AffinePoint::FE::wrap(*y_mont)};
+    // u1 and u2 are less than `Curve::ORDER`, so the multiplications will not reduce.
     const auto T1 = ecc::mul(G, u1);
     const auto T2 = ecc::mul(R, u2);
     assert(T2 != 0);  // Because u2 != 0 and R != 0.

--- a/lib/evmone_precompiles/secp256r1.cpp
+++ b/lib/evmone_precompiles/secp256r1.cpp
@@ -50,8 +50,10 @@ bool verify(const ethash::hash256& h, const uint256& r, const uint256& s, const 
     const auto u2 = n.from_mont(n.mul(n.to_mont(r), s_inv));
 
     // 5. Calculate the curve point R = (x₁, y₁) = u₁×G + u₂×Q.
+    // u1 and u2 are less than `Curve::ORDER`, so the multiplications will not reduce.
     const auto T1 = ecc::mul(G, u1);
     const auto T2 = ecc::mul(Q, u2);
+    assert(T2 != 0);  // Because u2 != 0 and R != 0.
     const auto jR = ecc::add(T1, T2);
     const auto R = ecc::to_affine(jR);
 


### PR DESCRIPTION
`ecc.hpp` has some lines missing coverage, when tested via EEST state_tests, which naturally test on the precompile surface and cannot excite certain cases in the ecc code.

Here I'm adding some more or less obvious comments which would prevent from anyone delving into why the missed lines.