### PR TITLE
fix: remove dead code - secp256k1 affine point mul

### DIFF
--- a/lib/evmone_precompiles/secp256k1.cpp
+++ b/lib/evmone_precompiles/secp256k1.cpp
@@ -29,12 +29,6 @@ std::optional<uint256> calculate_y(
     return (candidate_parity == y_parity) ? *y : m.sub(0, *y);
 }
 
-AffinePoint mul(const AffinePoint& p, const uint256& c) noexcept
-{
-    const auto r = ecc::mul(p, c);
-    return ecc::to_affine<Curve>(r);
-}
-
 evmc::address to_address(const AffinePoint& pt) noexcept
 {
     // This performs Ethereum's address hashing on an uncompressed pubkey.

--- a/lib/evmone_precompiles/secp256k1.hpp
+++ b/lib/evmone_precompiles/secp256k1.hpp
@@ -43,11 +43,6 @@ std::optional<uint256> field_sqrt(const ModArith<uint256>& m, const uint256& x) 
 std::optional<uint256> calculate_y(
     const ModArith<uint256>& m, const uint256& x, bool y_parity) noexcept;
 
-/// Scalar multiplication in secp256k1.
-///
-/// Computes [c]P for a point in affine coordinate on the secp256k1 curve,
-AffinePoint mul(const AffinePoint& p, const uint256& c) noexcept;
-
 /// Convert the secp256k1 point (uncompressed public key) to Ethereum address.
 evmc::address to_address(const AffinePoint& pt) noexcept;
 

--- a/test/unittests/evmmax_secp256k1_test.cpp
+++ b/test/unittests/evmmax_secp256k1_test.cpp
@@ -10,6 +10,19 @@ using namespace evmmax::secp256k1;
 using namespace evmc::literals;
 using namespace evmone::test;
 
+namespace
+{
+/// Scalar multiplication in secp256k1.
+///
+/// Computes [c]P for a point in affine coordinate on the secp256k1 curve.
+/// Convenience wrapper for point multiplication test.
+AffinePoint mul(const AffinePoint& p, const uint256& c) noexcept
+{
+    const auto r = evmmax::ecc::mul(p, c);
+    return evmmax::ecc::to_affine<Curve>(r);
+}
+}  // namespace
+
 TEST(secp256k1, field_sqrt)
 {
     const auto& m = Curve::Fp;


### PR DESCRIPTION
This PR is more of a question - is it OK to move this code into the unittest convenience wrapper? It is not used in any code covered by precompile tests.