### PR TITLE
fix: check block difficulty in blockchaintest

### DIFF
--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -23,6 +23,7 @@ struct UnsupportedTestFeature : std::runtime_error
 struct BlockHeader
 {
     hash256 parent_hash;
+    hash256 uncle_hash;
     address coinbase;
     hash256 state_root;
     hash256 receipts_root;

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -33,6 +33,7 @@ BlockHeader from_json<BlockHeader>(const json::json& j)
 {
     return {
         .parent_hash = from_json<hash256>(j.at("parentHash")),
+        .uncle_hash = from_json<hash256>(j.at("uncleHash")),
         .coinbase = from_json<address>(j.at("coinbase")),
         .state_root = from_json<hash256>(j.at("stateRoot")),
         .receipts_root = from_json<hash256>(j.at("receiptTrie")),
@@ -68,6 +69,7 @@ static TestBlock load_test_block(
         tb.block_info.timestamp = tb.expected_block_header.timestamp;
         tb.block_info.hash = tb.expected_block_header.hash;
         tb.block_info.parent_hash = tb.expected_block_header.parent_hash;
+        tb.block_info.uncle_hash = tb.expected_block_header.uncle_hash;
 
         const auto rev = to_rev_schedule(network).get_revision(tb.block_info.timestamp);
         const auto blob_params = get_blob_params(network, blob_schedule, tb.block_info.timestamp);

--- a/test/blockchaintest/blockchaintest_runner.cpp
+++ b/test/blockchaintest/blockchaintest_runner.cpp
@@ -5,6 +5,7 @@
 #include "../state/mpt_hash.hpp"
 #include "../state/requests.hpp"
 #include "../state/rlp.hpp"
+#include "../test/state/ethash_difficulty.hpp"
 #include "../test/statetest/statetest.hpp"
 #include "blockchaintest.hpp"
 #include <gtest/gtest.h>
@@ -120,6 +121,13 @@ bool validate_block(evmc_revision rev, state::BlobParams blob_params, const Test
 
     // Fail if parent header was not found.
     if (parent_header == nullptr)
+        return false;
+
+    const auto expected_difficulty = state::calculate_difficulty(parent_header->difficulty,
+        parent_header->uncle_hash != EmptyListHash, parent_header->timestamp,
+        test_block.block_info.timestamp, test_block.block_info.number, rev);
+
+    if (test_block.block_info.difficulty != expected_difficulty)
         return false;
 
     if (test_block.block_info.gas_used > test_block.block_info.gas_limit)

--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -37,6 +37,7 @@ struct BlockInfo
     int64_t timestamp = 0;
     hash256 hash;
     hash256 parent_hash;
+    hash256 uncle_hash;
     int64_t parent_timestamp = 0;
     int64_t gas_limit = 0;
     int64_t gas_used = 0;


### PR DESCRIPTION
Not sure if we still care for difficulty validation logic coverage, but I went down the rabbit hole and here it is :shrug: 