### PR TITLE
Move state::BlobSchedule → test::BlobSchedule

### DIFF
--- a/test/blockchaintest/blockchaintest.hpp
+++ b/test/blockchaintest/blockchaintest.hpp
@@ -7,6 +7,7 @@
 #include "../state/bloom_filter.hpp"
 #include "../state/test_state.hpp"
 #include "../state/transaction.hpp"
+#include "../utils/blob_schedule.hpp"
 #include "../utils/utils.hpp"
 #include <evmc/evmc.hpp>
 #include <span>
@@ -70,7 +71,7 @@ struct BlockchainTest
     TestState pre_state;
     RevisionSchedule rev;
     std::string network;
-    state::BlobSchedule blob_schedule;
+    BlobSchedule blob_schedule;
 
     Expectation expectation;
 };

--- a/test/blockchaintest/blockchaintest_loader.cpp
+++ b/test/blockchaintest/blockchaintest_loader.cpp
@@ -2,7 +2,6 @@
 // Copyright 2023 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "../state/blob_schedule.hpp"
 #include "../statetest/statetest.hpp"
 #include "../utils/utils.hpp"
 #include "blockchaintest.hpp"
@@ -56,7 +55,7 @@ BlockHeader from_json<BlockHeader>(const json::json& j)
 }
 
 static TestBlock load_test_block(
-    const json::json& j, const std::string& network, const state::BlobSchedule& blob_schedule)
+    const json::json& j, const std::string& network, const BlobSchedule& blob_schedule)
 {
     using namespace state;
     TestBlock tb;

--- a/test/state/CMakeLists.txt
+++ b/test/state/CMakeLists.txt
@@ -9,8 +9,7 @@ target_include_directories(evmone-state PRIVATE ${evmone_private_include_dir})
 target_sources(
     evmone-state PRIVATE
     account.hpp
-    blob_schedule.hpp
-    blob_schedule.cpp
+    blob_params.hpp
     block.hpp
     block.cpp
     bloom_filter.hpp

--- a/test/state/blob_params.hpp
+++ b/test/state/blob_params.hpp
@@ -1,0 +1,23 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2025 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+
+namespace evmone::state
+{
+/// The cost of a single blob in gas units (EIP-4844).
+constexpr auto GAS_PER_BLOB = 0x20000;  // 2**17
+
+/// The maximum number of blobs that can be included in a transaction (EIP-7594).
+constexpr auto MAX_TX_BLOB_COUNT = 6;
+
+/// The blob schedule entry for an EVM revision (EIP-7840).
+struct BlobParams
+{
+    uint16_t target = 0;
+    uint16_t max = 0;
+    uint32_t base_fee_update_fraction = 0;
+};
+}  // namespace evmone::state

--- a/test/state/block.cpp
+++ b/test/state/block.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "block.hpp"
-#include "blob_schedule.hpp"
 #include "rlp.hpp"
 #include "transaction.hpp"
 

--- a/test/state/block.hpp
+++ b/test/state/block.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "blob_schedule.hpp"
+#include "blob_params.hpp"
 #include "hash_utils.hpp"
 #include <intx/intx.hpp>
 #include <vector>

--- a/test/state/transaction.hpp
+++ b/test/state/transaction.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "blob_schedule.hpp"
+#include "blob_params.hpp"
 #include "bloom_filter.hpp"
 #include "state_diff.hpp"
 #include <intx/intx.hpp>

--- a/test/statetest/statetest.hpp
+++ b/test/statetest/statetest.hpp
@@ -7,6 +7,7 @@
 #include "../state/errors.hpp"
 #include "../state/test_state.hpp"
 #include "../state/transaction.hpp"
+#include "../utils/blob_schedule.hpp"
 #include <nlohmann/json.hpp>
 
 namespace json = nlohmann;
@@ -63,7 +64,7 @@ struct StateTransitionTest
     TestMultiTransaction multi_tx;
     std::vector<Case> cases;
     std::unordered_map<uint64_t, std::string> input_labels;
-    state::BlobSchedule blob_schedule;
+    BlobSchedule blob_schedule;
 };
 
 template <typename T>
@@ -109,7 +110,7 @@ template <>
 state::BlobParams from_json<state::BlobParams>(const json::json& j);
 
 template <>
-state::BlobSchedule from_json<state::BlobSchedule>(const json::json& j);
+BlobSchedule from_json<BlobSchedule>(const json::json& j);
 
 /// Exports the State (accounts) to JSON format (aka pre/post/alloc state).
 json::json to_json(const TestState& state);

--- a/test/statetest/statetest_loader.cpp
+++ b/test/statetest/statetest_loader.cpp
@@ -179,9 +179,9 @@ state::BlobParams from_json<state::BlobParams>(const json::json& j)
 }
 
 template <>
-state::BlobSchedule from_json<state::BlobSchedule>(const json::json& j)
+BlobSchedule from_json<BlobSchedule>(const json::json& j)
 {
-    state::BlobSchedule blob_schedule;
+    BlobSchedule blob_schedule;
     assert(j.is_object());
     for (const auto& [name, jschedule] : j.items())
     {
@@ -530,12 +530,12 @@ static void from_json(const json::json& j_t, StateTransitionTest& o)
     if (const auto config_it = j_t.find("config"); config_it != j_t.end())
     {
         if (const auto bs_it = config_it->find("blobSchedule"); bs_it != config_it->end())
-            o.blob_schedule = from_json<state::BlobSchedule>(*bs_it);
+            o.blob_schedule = from_json<BlobSchedule>(*bs_it);
     }
 
     for (const auto& [rev_name, expectations] : j_t.at("post").items())
     {
-        const auto blob_params = state::get_blob_params(to_rev(rev_name), o.blob_schedule);
+        const auto blob_params = get_blob_params(to_rev(rev_name), o.blob_schedule);
         o.cases.emplace_back(to_rev(rev_name),
             expectations.get<std::vector<StateTransitionTest::Case::Expectation>>(),
             from_json_with_rev(j_t.at("env"), to_rev(rev_name), blob_params));

--- a/test/statetest/statetest_runner.cpp
+++ b/test/statetest/statetest_runner.cpp
@@ -26,7 +26,7 @@ void run_state_test(const StateTransitionTest& test, evmc::VM& vm, bool trace_su
             const auto& expected = cases[case_index];
             const auto tx = test.multi_tx.get(expected.indexes);
             auto state = test.pre_state;
-            const auto blob_params = state::get_blob_params(rev, test.blob_schedule);
+            const auto blob_params = get_blob_params(rev, test.blob_schedule);
 
             const auto res = test::transition(state, block, test.block_hashes, tx, rev, vm,
                 block.gas_limit, static_cast<int64_t>(state::max_blob_gas_per_block(blob_params)));

--- a/test/t8n/t8n.cpp
+++ b/test/t8n/t8n.cpp
@@ -103,7 +103,7 @@ int main(int argc, const char* argv[])
         else
         {
             // Use hardcoded blob schedule if no blob config file is provided.
-            blob_params = state::get_blob_params(rev);
+            blob_params = get_blob_params(rev);
         }
 
         if (!alloc_file.empty())

--- a/test/unittests/state_block_test.cpp
+++ b/test/unittests/state_block_test.cpp
@@ -4,8 +4,10 @@
 
 #include <gtest/gtest.h>
 #include <test/state/state.hpp>
+#include <test/utils/blob_schedule.hpp>
 
 using namespace evmone::state;
+using namespace evmone::test;
 using namespace intx::literals;
 
 TEST(state_block, blob_gas_price)

--- a/test/unittests/state_transition_block_test.cpp
+++ b/test/unittests/state_transition_block_test.cpp
@@ -2,6 +2,7 @@
 // Copyright 2023 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "../utils/blob_schedule.hpp"
 #include "../utils/bytecode.hpp"
 #include "state_transition.hpp"
 
@@ -70,7 +71,7 @@ TEST_F(state_transition, eip7516_blob_base_fee)
     // 0x1d is the result of ref implementation in EIP-4844
     static constexpr auto price = 0x1d;
     block.blob_base_fee = price;
-    assert(state::compute_blob_gas_price(state::get_blob_params(rev), *block.excess_blob_gas) ==
+    assert(state::compute_blob_gas_price(get_blob_params(rev), *block.excess_blob_gas) ==
            *block.blob_base_fee);
 
     tx.to = To;

--- a/test/unittests/state_tx_test.cpp
+++ b/test/unittests/state_tx_test.cpp
@@ -6,6 +6,7 @@
 #include <test/state/errors.hpp>
 #include <test/state/state.hpp>
 #include <test/state/test_state.hpp>
+#include <test/utils/blob_schedule.hpp>
 #include <test/utils/utils.hpp>
 
 using namespace evmc::literals;

--- a/test/unittests/statetest_loader_block_info_test.cpp
+++ b/test/unittests/statetest_loader_block_info_test.cpp
@@ -20,7 +20,7 @@ TEST(statetest_loader, block_info)
             "withdrawals": []
         })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -49,7 +49,7 @@ TEST(statetest_loader, block_info_hex)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -78,7 +78,7 @@ TEST(statetest_loader, block_info_dec)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -105,7 +105,7 @@ TEST(statetest_loader, block_info_0_current_difficulty)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -132,7 +132,7 @@ TEST(statetest_loader, block_info_0_parent_difficulty)
         "parentUncleHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
     })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -156,7 +156,7 @@ TEST(statetest_loader, block_info_0_random)
             "withdrawals": []
         })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -192,7 +192,7 @@ TEST(statetest_loader, block_info_withdrawals)
             ]
         })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -231,7 +231,7 @@ TEST(statetest_loader, block_info_ommers)
             "withdrawals": []
         })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -263,7 +263,7 @@ TEST(statetest_loader, block_info_parent_blob_gas)
             "parentBlobGasUsed": "0x60000"
         })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -288,7 +288,7 @@ TEST(statetest_loader, block_info_current_blob_gas)
             "currentExcessBlobGas": "2"
         })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.coinbase, 0x1111111111111111111111111111111111111111_address);
     EXPECT_EQ(bi.prev_randao, 0x00_bytes32);
@@ -309,7 +309,7 @@ TEST(statetest_loader, block_info_parent_beacon_block_root)
         "parentBeaconBlockRoot": "0xbeac045007"
     })";
 
-    const auto blob_params = state::get_blob_params(EVMC_CANCUN);
+    const auto blob_params = test::get_blob_params(EVMC_CANCUN);
     const auto bi = test::from_json_with_rev(json::json::parse(input), EVMC_CANCUN, blob_params);
     EXPECT_EQ(bi.parent_beacon_block_root, 0xbeac045007_bytes32);
 }

--- a/test/utils/CMakeLists.txt
+++ b/test/utils/CMakeLists.txt
@@ -12,6 +12,8 @@ target_include_directories(testutils INTERFACE ${PROJECT_SOURCE_DIR} ${evmone_pr
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.19)
     target_sources(
         testutils PRIVATE
+        blob_schedule.hpp
+        blob_schedule.cpp
         bytecode.hpp
         stdx/utility.hpp
         utils.hpp

--- a/test/utils/blob_schedule.cpp
+++ b/test/utils/blob_schedule.cpp
@@ -1,11 +1,10 @@
 #include "blob_schedule.hpp"
-#include "../utils/utils.hpp"
-#include <cstdint>
+#include "utils.hpp"
 #include <string_view>
 
-namespace evmone::state
+namespace evmone::test
 {
-BlobParams get_blob_params(evmc_revision rev)
+state::BlobParams get_blob_params(evmc_revision rev)
 {
     if (rev == EVMC_PRAGUE || rev == EVMC_EXPERIMENTAL)
         return {6, 9, 5007716};
@@ -16,12 +15,12 @@ BlobParams get_blob_params(evmc_revision rev)
         return {3, 6, 3338477};
 }
 
-BlobParams get_blob_params(evmc_revision rev, const BlobSchedule& blob_schedule)
+state::BlobParams get_blob_params(evmc_revision rev, const BlobSchedule& blob_schedule)
 {
     return get_blob_params(evmc::to_string(rev), blob_schedule, 0);
 }
 
-BlobParams get_blob_params(
+state::BlobParams get_blob_params(
     std::string_view network, const BlobSchedule& blob_schedule, int64_t timestamp)
 {
     std::string fork;
@@ -40,7 +39,7 @@ BlobParams get_blob_params(
     if (const auto it = blob_schedule.find(fork); it != blob_schedule.end())
         return it->second;
     else
-        return get_blob_params(test::to_rev_schedule(network).get_revision(timestamp));
+        return get_blob_params(to_rev_schedule(network).get_revision(timestamp));
 }
 
-}  // namespace evmone::state
+}  // namespace evmone::test

--- a/test/utils/blob_schedule.hpp
+++ b/test/utils/blob_schedule.hpp
@@ -1,38 +1,23 @@
 // evmone: Fast Ethereum Virtual Machine implementation
 // Copyright 2025 The evmone Authors.
 // SPDX-License-Identifier: Apache-2.0
-
 #pragma once
 
-#include <evmc/evmc.hpp>
+#include "../state/blob_params.hpp"
 
-namespace evmone::state
+namespace evmone::test
 {
-/// The cost of a single blob in gas units (EIP-4844).
-constexpr auto GAS_PER_BLOB = 0x20000;  // 2**17
-
-/// The maximum number of blobs that can be included in a transaction (EIP-7594).
-constexpr auto MAX_TX_BLOB_COUNT = 6;
-
-/// The blob schedule entry for an EVM revision (EIP-7840).
-struct BlobParams
-{
-    uint16_t target = 0;
-    uint16_t max = 0;
-    uint32_t base_fee_update_fraction = 0;
-};
-
 using BlobSchedule = std::unordered_map<std::string, state::BlobParams>;
 
 /// Returns the hardcoded blob params for the given EVM revision.
 /// After Prague, the blob params must be derived from config.
-BlobParams get_blob_params(evmc_revision rev);
+state::BlobParams get_blob_params(evmc_revision rev);
 
 /// Returns the blob params for the given EVM revision and a blob schedule.
-BlobParams get_blob_params(evmc_revision rev, const BlobSchedule& blob_schedule);
+state::BlobParams get_blob_params(evmc_revision rev, const BlobSchedule& blob_schedule);
 
 /// Returns the blob params for given a description of a test network (e.g. transitioning
 /// across two forks at some time), a blob schedule and the timestamp.
-BlobParams get_blob_params(
+state::BlobParams get_blob_params(
     std::string_view network, const BlobSchedule& blob_schedule, int64_t timestamp);
-}  // namespace evmone::state
+}  // namespace evmone::test


### PR DESCRIPTION
Move the `BlobSchedule` helpers from the `evmone::state` library to tests utils because these depend on the test utils already. Otherwise, this breaks linking of the tools which only need the `state` library without test utils.