### PR TITLE
build: Upgrade minimum CMake to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2019 The evmone Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.18...3.27)
+cmake_minimum_required(VERSION 3.19...4.0)
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/evmc/.git)
     message(FATAL_ERROR "Git submodules not initialized, execute:\n  git submodule update --init")

--- a/circle.yml
+++ b/circle.yml
@@ -609,7 +609,7 @@ jobs:
     executor: linux-base
     steps:
       - install_cmake:
-          version: 3.18.4
+          version: 3.19.8
       - build
       - test
 


### PR DESCRIPTION
This fixes some linking issues in CMake 3.18.
Also upgrade policies to CMake 4.0.