### PR TITLE
crypto: specialize modexp_impl for 48 bytes

### DIFF
--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -149,6 +149,8 @@ void modexp(std::span<const uint8_t> base, std::span<const uint8_t> exp,
         modexp_impl<16>(base, exp, mod, output);
     else if (size <= 32)
         modexp_impl<32>(base, exp, mod, output);
+    else if (size <= 48)
+        modexp_impl<48>(base, exp, mod, output);
     else if (size <= 64)
         modexp_impl<64>(base, exp, mod, output);
     else if (size <= 128)


### PR DESCRIPTION
Starting as draft as it is more of a question.

We can see that we have [many uncovered instantiations of templates in evmmax.hpp, for 384 bit scalars](https://output.circle-artifacts.com/output/job/e2910ae5-0b13-40c4-aac1-1b9bf9d42912/artifacts/0/coverage/html/coverage/home/builder/project/include/evmmax/evmmax.hpp.html). I suspect it is so because they're used in low level unit tests, but never in EEST tests (I suppose they could be called by bls12-384 tests, but aren't since for bls a library is used).

I came up with a trick to run these instantiations like in this PR - by specializing modexp for such width we can exercise these paths. But not all, add, sub and inv still remain not covered. Two questions:

1/ is this "trick" ok and makes sense beyond artificially boosting coverage? I don't know the reasons for such particular choice of modexp specializations
2/ any idea how to cover the remaining cases? I see they could be called from `Fp` functionality but not sure how to "get there" for 384 bits.