### PR TITLE
tests: Move tests for undefined instructions to own file

### DIFF
--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
     evm_storage_test.cpp
     evm_other_test.cpp
     evm_benchmark_test.cpp
+    evm_undefined_instructions_test.cpp
     evmmax_bn254_add_test.cpp
     evmmax_bn254_mul_test.cpp
     evmmax_bn254_pairing_test.cpp

--- a/test/unittests/evm_calls_test.cpp
+++ b/test/unittests/evm_calls_test.cpp
@@ -762,34 +762,6 @@ TEST_P(evm, returndatacopy_outofrange_highbits)
     EXPECT_EQ(result.status_code, EVMC_INVALID_MEMORY_ACCESS);
 }
 
-TEST_P(evm, returndataload_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    execute(staticcall(0) + returndataload(0));
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
-TEST_P(evm, extcall_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    execute(extcall(0));
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
-TEST_P(evm, extdelegatecall_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    execute(extdelegatecall(0));
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
-TEST_P(evm, extstaticcall_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    execute(extstaticcall(0));
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
 TEST_P(evm, call_gas_refund_propagation)
 {
     rev = EVMC_LONDON;

--- a/test/unittests/evm_eip663_dupn_swapn_test.cpp
+++ b/test/unittests/evm_eip663_dupn_swapn_test.cpp
@@ -175,14 +175,3 @@ TEST_P(evm, swapn_swap_consistency)
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(17);
 }
-
-TEST_P(evm, dupn_swapn_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-
-    execute(push(1) + push(2) + OP_SWAPN + "00");
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-
-    execute(push(1) + OP_DUPN + "00");
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}

--- a/test/unittests/evm_eip663_exchange_test.cpp
+++ b/test/unittests/evm_eip663_exchange_test.cpp
@@ -101,11 +101,3 @@ TEST_P(evm, exchange_deep_stack)
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(17);
 }
-
-TEST_P(evm, exchange_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-
-    execute(push(1) + push(2) + push(3) + OP_EXCHANGE + "00");
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}

--- a/test/unittests/evm_eof_function_test.cpp
+++ b/test/unittests/evm_eof_function_test.cpp
@@ -254,19 +254,3 @@ TEST_P(evm, jumpf_with_inputs_stack_overflow)
     execute(code);
     EXPECT_STATUS(EVMC_STACK_OVERFLOW);
 }
-
-TEST_P(evm, functions_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    auto code = bytecode{OP_CALLF} + "0001" + OP_STOP;
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-
-    code = bytecode{OP_RETF};
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-
-    code = bytecode{OP_JUMPF} + "0001";
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}

--- a/test/unittests/evm_eof_rjump_test.cpp
+++ b/test/unittests/evm_eof_rjump_test.cpp
@@ -225,27 +225,3 @@ TEST_P(evm, eof1_rjumpv_long_jumps)
     EXPECT_STATUS(EVMC_SUCCESS);
     EXPECT_OUTPUT_INT(7);
 }
-
-TEST_P(evm, rjump_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    const auto code = rjump(1) + OP_INVALID + mstore8(0, 1) + ret(0, 1);
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
-TEST_P(evm, rjumpi_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    const auto code = rjumpi(10, 1) + mstore8(0, 2) + ret(0, 1) + mstore8(0, 1) + ret(0, 1);
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
-TEST_P(evm, rjumpv_undefined_in_legacy)
-{
-    rev = EVMC_EXPERIMENTAL;
-    const auto code = rjumpv({0}, calldataload(0)) + OP_STOP;
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}

--- a/test/unittests/evm_eof_test.cpp
+++ b/test/unittests/evm_eof_test.cpp
@@ -286,26 +286,6 @@ TEST_P(evm, eof_eofcreate)
     EXPECT_EQ(output, "000000000000000000000000cc010203040506070809010203040506070809ce"_hex);
 }
 
-TEST_P(evm, eofcreate_undefined_in_legacy)
-{
-    rev = EVMC_CANCUN;
-    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) +
-                      eofcreate().input(0, OP_CALLDATASIZE).salt(0xff) + ret_top();
-
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
-TEST_P(evm, returncode_undefined_in_legacy)
-{
-    rev = EVMC_CANCUN;
-    const auto code =
-        calldatacopy(0, 0, OP_CALLDATASIZE) + OP_CALLDATASIZE + 0 + OP_RETURNCODE + Opcode{0};
-
-    execute(code);
-    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
-}
-
 TEST_P(evm, eofcreate_staticmode)
 {
     if (is_advanced())

--- a/test/unittests/evm_undefined_instructions_test.cpp
+++ b/test/unittests/evm_undefined_instructions_test.cpp
@@ -1,0 +1,120 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Tests checking if in-development instructions remain undefined before activation.
+
+#include "evm_fixture.hpp"
+
+using namespace evmone::test;
+
+TEST_P(evm, dupn_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(push(1) + OP_DUPN + "00");
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, swapn_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(push(1) + push(2) + OP_SWAPN + "00");
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, exchange_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(push(1) + push(2) + push(3) + OP_EXCHANGE + "00");
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, rjump_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(bytecode{OP_RJUMP} + "0001" + OP_INVALID + mstore8(0, 1) + ret(0, 1));
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, rjumpi_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    const auto code =
+        push(1) + OP_RJUMPI + "000a" + mstore8(0, 2) + ret(0, 1) + mstore8(0, 1) + ret(0, 1);
+    execute(code);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, rjumpv_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(calldataload(0) + OP_RJUMPV + "000000" + OP_STOP);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, callf_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(bytecode{OP_CALLF} + "0001" + OP_STOP);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, retf_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(bytecode{OP_RETF});
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, jumpf_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(bytecode{OP_JUMPF} + "0001");
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, returndataload_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(staticcall(0) + push(0) + OP_RETURNDATALOAD);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, extcall_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(4 * push(0) + OP_EXTCALL);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, extdelegatecall_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(3 * push(0) + OP_EXTDELEGATECALL);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, extstaticcall_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    execute(3 * push(0) + OP_EXTSTATICCALL);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, eofcreate_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + push(0) + OP_CALLDATASIZE + push(0) +
+                      push(0xff) + OP_EOFCREATE + "00" + ret_top();
+    execute(code);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}
+
+TEST_P(evm, returncode_undefined)
+{
+    rev = EVMC_MAX_REVISION;
+    const auto code =
+        calldatacopy(0, 0, OP_CALLDATASIZE) + OP_CALLDATASIZE + 0 + OP_RETURNCODE + "00";
+    execute(code);
+    EXPECT_STATUS(EVMC_UNDEFINED_INSTRUCTION);
+}


### PR DESCRIPTION
Move tests checking that in-development instructions and not enabled in an EVM revision before activation. These tests mostly exercise EOF instruction and we want to keep the tests after EOF removal.

Avoid bytecode helpers for to-be-removed instructions.