### PR TITLE
fix: constexpr away LOG0 topcis and gas==0 OOG

### DIFF
--- a/lib/evmone/baseline_execution.cpp
+++ b/lib/evmone/baseline_execution.cpp
@@ -80,8 +80,11 @@ inline evmc_status_code check_requirements(const CostTable& cost_table, int64_t&
             return EVMC_STACK_UNDERFLOW;
     }
 
-    if (INTX_UNLIKELY((gas_left -= gas_cost) < 0))
-        return EVMC_OUT_OF_GAS;
+    if constexpr (!instr::has_const_gas_cost(Op) || instr::gas_costs[EVMC_FRONTIER][Op] > 0)
+    {
+        if (INTX_UNLIKELY((gas_left -= gas_cost) < 0))
+            return EVMC_OUT_OF_GAS;
+    }
 
     return EVMC_SUCCESS;
 }

--- a/lib/evmone/instructions.hpp
+++ b/lib/evmone/instructions.hpp
@@ -925,8 +925,11 @@ inline Result log(StackTop stack, int64_t gas_left, ExecutionState& state) noexc
         return {EVMC_OUT_OF_GAS, gas_left};
 
     std::array<evmc::bytes32, NumTopics> topics;  // NOLINT(cppcoreguidelines-pro-type-member-init)
-    for (auto& topic : topics)
-        topic = intx::be::store<evmc::bytes32>(stack.pop());
+    if constexpr (NumTopics > 0)
+    {
+        for (auto& topic : topics)
+            topic = intx::be::store<evmc::bytes32>(stack.pop());
+    }
 
     const auto data = s != 0 ? &state.memory[o] : nullptr;
     state.host.emit_log(state.msg->recipient, data, s, topics.data(), NumTopics);


### PR DESCRIPTION
I've started wondering if this isn't overdoing it. The gain is somewhat more readable coverage report - one doesn't have to stop by each uncovered line to "tick it off" as "yea, this cannot be covered, ever". I suspect the compiler handles this anyway and optimizes away, so there should be no performance gains (? not sure). The downside is just lines of code and source of obscure bugs in case our assumptions about opcodes somehow change (? unlikely?).

LMK WDYT