### PR TITLE
ci: specialize $OBJECTS for EEST coverage command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -227,13 +227,16 @@ commands:
       ignore_filename_regex:
         type: string
         default: ""
+      binaries:
+        type: string
+        default: evmone-unittests evmone-statetest evmone-blockchaintest evmone-t8n
     steps:
       - run:
           name: "Collect coverage data (clang)"
           working_directory: ~/build
           command: |
             IGNORE_FILENAME_REGEX='include/evmc<<#parameters.ignore_filename_regex>>|<<parameters.ignore_filename_regex>><</parameters.ignore_filename_regex>>'
-            OBJECTS="-object bin/evmone-unittests -object bin/evmone-statetest -object bin/evmone-blockchaintest -object bin/evmone-t8n"
+            OBJECTS=$(printf -- '-object bin/%s ' <<parameters.binaries>>)
             ARGS="lib/libevmone.so $OBJECTS -Xdemangler llvm-cxxfilt -instr-profile=evmone.profdata -ignore-filename-regex=$IGNORE_FILENAME_REGEX"
 
             rm -rf ~/coverage
@@ -409,6 +412,7 @@ jobs:
             bin/evmone-blockchaintest ~/spec-tests/fixtures/blockchain_tests
       - collect_coverage_clang:
           ignore_filename_regex: lib/evmone/(advanced|cpu_check|eof|lru_cache|tracing|vm)|test/(experimental|t8n|unittests|utils)
+          binaries: evmone-statetest evmone-blockchaintest
       - upload_coverage:
           flags: eest-develop
 


### PR DESCRIPTION
Follow-up to https://github.com/ipsilon/evmone/pull/1356#issuecomment-3469701436.

In order to not include unit test and t8n code (which brings in uncovered template specializations into consideration, unnecessarily), we do not include them in the `-object` arguments to `llvm-cov`

Opening as draft to work out and test the CI config