### PR TITLE
test: Disallow empty storage values in MTP hash

### DIFF
--- a/test/state/mpt_hash.cpp
+++ b/test/state/mpt_hash.cpp
@@ -18,8 +18,8 @@ hash256 mpt_hash(const std::map<bytes32, bytes32>& storage)
     MPT trie;
     for (const auto& [key, value] : storage)
     {
-        if (!is_zero(value))  // Skip "deleted" values.
-            trie.insert(keccak256(key), rlp::encode(rlp::trim(value)));
+        assert(!is_zero(value));  // Zero values should not be in the storage.
+        trie.insert(keccak256(key), rlp::encode(rlp::trim(value)));
     }
     return trie.hash();
 }

--- a/test/unittests/state_mpt_hash_test.cpp
+++ b/test/unittests/state_mpt_hash_test.cpp
@@ -51,17 +51,6 @@ TEST(state_mpt_hash, two_accounts)
         0xd3e845156fca75de99712281581304fbde104c0fc5a102b09288c07cdde0b666_bytes32);
 }
 
-TEST(state_mpt_hash, deleted_storage)
-{
-    TestAccount acc;
-    acc.storage[0x01_bytes32] = {};
-    acc.storage[0x02_bytes32] = {0xfd_bytes32};
-    acc.storage[0x03_bytes32] = {};
-    const TestState accounts{{0x07_address, acc}};
-    EXPECT_EQ(mpt_hash(accounts),
-        0x4e7338c16731491e0fb5d1623f5265c17699c970c816bab71d4d717f6071414d_bytes32);
-}
-
 TEST(state_mpt_hash, one_transactions)
 {
     // https://sepolia.etherscan.io/tx/0xd4070618ed3026722ae5dbacc95e70714327d65abce292bba9de38201895cdff


### PR DESCRIPTION
During normal execution empty storage values are filtered out and they should not appear during the final MPT hash of the storage. Convert the check into an assert.