### PR TITLE
Optimize BN254 ecmul with the field endomorphism

### DIFF
--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -31,6 +31,23 @@ struct Curve
 
     static constexpr auto A = 0;
     static constexpr auto B = ecc::FieldElement<Curve>(3);
+
+    /// Endomorphism parameters. See ecc::decompose().
+    /// @{
+    /// λ
+    static constexpr auto LAMBDA = 0xb3c4d79d41a917585bfc41088d8daaa78b17ea66b99c90dd_u256;
+    /// β
+    static constexpr ecc::FieldElement<Curve> BETA{
+        0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256};
+    /// x₁
+    static constexpr auto X1 = 0x6f4d8248eeb859fd95b806bca6f338ee_u256;
+    /// -y₁
+    static constexpr auto MINUS_Y1 = 0x6f4d8248eeb859fbf83e9682e87cfd45_u256;
+    /// x₂
+    static constexpr auto X2 = 0x6f4d8248eeb859fc8211bbeb7d4f1128_u256;
+    /// y₂
+    static constexpr auto Y2 = 0x6f4d8248eeb859fd0be4e1541221250b_u256;
+    /// @}
 };
 
 using AffinePoint = ecc::AffinePoint<Curve>;


### PR DESCRIPTION
- Add `ecc::decompose()` procedure to split ECC scalar into two smaller ones. 
- Use the decomposition to speed up BN254 scalar multiplication.
- Based on [Faster Point Multiplication on Elliptic Curves
with Efficient Endomorphisms](https://www.iacr.org/archive/crypto2001/21390189.pdf)
- v1 and v2 vectors taken from [cloudflare implementation](https://github.com/flashbots/builder/blob/main/crypto/bn256/cloudflare/lattice.go/)

Before:
```
(vvenv) rodia@MacBook-Pro-2 evmone % ./build/bin/evmone-precompiles-bench --benchmark_filter=ecmul
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2025-12-02T12:37:39+01:00
Running ./build/bin/evmone-precompiles-bench
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 1.82, 2.09, 1.99
------------------------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------
precompile<PrecompileId::ecmul, evmmax_cpp>      56080 ns        56081 ns        12380 gas_rate=106.989M/s gas_used=60k
```

After:
```
(vvenv) rodia@MacBook-Pro-2 evmone % ./build/bin/evmone-precompiles-bench --benchmark_filter=ecmul
Unable to determine clock rate from sysctl: hw.cpufrequency: No such file or directory
This does not affect benchmark measurements, only the metadata output.
***WARNING*** Failed to set thread affinity. Estimated CPU frequency may be incorrect.
2025-12-02T12:38:10+01:00
Running ./build/bin/evmone-precompiles-bench
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 1.75, 2.05, 1.97
------------------------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------
precompile<PrecompileId::ecmul, evmmax_cpp>      37996 ns        37987 ns        18480 gas_rate=157.947M/s gas_used=60k
```
