### PR TITLE
precompiles: Fix BN254 input point validation

### DIFF
--- a/test/state/precompiles.cpp
+++ b/test/state/precompiles.cpp
@@ -446,16 +446,15 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
     const auto q = AffinePoint::from_bytes(input_span.subspan<64, 64>());
-
-    if (validate(p) && validate(q))
-    {
-        const auto res = evmmax::ecc::add(p, q);
-        const std::span<uint8_t, 64> output_span{output, 64};
-        res.to_bytes(output_span);
-        return {EVMC_SUCCESS, output_span.size()};
-    }
-    else
+    if (!p.has_value() || !q.has_value()) [[unlikely]]
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (!validate(*p) || !validate(*q)) [[unlikely]]
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    const auto res = evmmax::ecc::add(*p, *q);
+    const std::span<uint8_t, 64> output_span{output, 64};
+    res.to_bytes(output_span);
+    return {EVMC_SUCCESS, output_span.size()};
 }
 
 ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* output,
@@ -472,17 +471,15 @@ ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* 
     using namespace evmmax::bn254;
 
     const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
-    const auto c = intx::be::unsafe::load<intx::uint256>(input_buffer + 64);
-
-    if (validate(p))
-    {
-        const auto res = evmmax::bn254::mul(p, c);
-        const std::span<uint8_t, 64> output_span{output, 64};
-        res.to_bytes(output_span);
-        return {EVMC_SUCCESS, output_span.size()};
-    }
-    else
+    if (!p.has_value() || !validate(*p)) [[unlikely]]
         return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    const auto c = intx::be::unsafe::load<uint256>(input_buffer + 64);
+
+    const auto res = evmmax::bn254::mul(*p, c);
+    const std::span<uint8_t, 64> output_span{output, 64};
+    res.to_bytes(output_span);
+    return {EVMC_SUCCESS, output_span.size()};
 }
 
 ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8_t* output,

--- a/test/unittests/evmmax_bn254_add_test.cpp
+++ b/test/unittests/evmmax_bn254_add_test.cpp
@@ -112,11 +112,14 @@ TEST(evmmax, bn254_add)
         const auto e =
             AffinePoint::from_bytes(std::span<const uint8_t, 64>{&expected_output[0], 64});
 
-        ASSERT_TRUE(validate(p));
-        ASSERT_TRUE(validate(q));
-        ASSERT_TRUE(validate(e));
+        ASSERT_TRUE(p.has_value());
+        ASSERT_TRUE(validate(*p));
+        ASSERT_TRUE(q.has_value());
+        ASSERT_TRUE(validate(*q));
+        ASSERT_TRUE(e.has_value());
+        ASSERT_TRUE(validate(*e));
 
-        const auto r = add(p, q);
+        const auto r = add(*p, *q);
         EXPECT_EQ(r, e);
     }
 }

--- a/test/unittests/evmmax_bn254_from_bytes.cpp
+++ b/test/unittests/evmmax_bn254_from_bytes.cpp
@@ -26,7 +26,8 @@ TEST(evmmax, bn254_point_from_bytes_valid)
 
         const auto p =
             AffinePoint::from_bytes(std::span<const uint8_t, SIZE>{input.begin(), input.end()});
-        EXPECT_TRUE(validate(p));
+        ASSERT_TRUE(p.has_value());
+        EXPECT_TRUE(validate(*p));
     }
 }
 
@@ -45,6 +46,32 @@ TEST(evmmax, bn254_point_from_bytes_not_on_curve)
 
         const auto p =
             AffinePoint::from_bytes(std::span<const uint8_t, SIZE>{input.begin(), input.end()});
-        EXPECT_FALSE(validate(p));
+        ASSERT_TRUE(p.has_value());
+        EXPECT_FALSE(validate(*p));
+    }
+}
+
+TEST(evmmax, bn254_point_from_bytes_fp_invalid)
+{
+    static constexpr std::string_view TEST_CASES[]{
+        "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+        "0000000000000000000000000000000000000000000000000000000000000000",
+        "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd48"
+        "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd49",
+        "0000000000000000000000000000000000000000000000000000000000000001"
+        "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd49",
+        "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd48"
+        "0000000000000000000000000000000000000000000000000000000000000002",
+    };
+
+    for (const auto& input_hex : TEST_CASES)
+    {
+        static constexpr auto SIZE = sizeof(AffinePoint);
+        auto input = from_hex(input_hex).value();
+        ASSERT_EQ(input.size(), SIZE);
+
+        const auto p =
+            AffinePoint::from_bytes(std::span<const uint8_t, SIZE>{input.begin(), input.end()});
+        EXPECT_FALSE(p.has_value());
     }
 }

--- a/test/unittests/evmmax_bn254_mul_test.cpp
+++ b/test/unittests/evmmax_bn254_mul_test.cpp
@@ -162,10 +162,12 @@ TEST(evmmax, bn254_mul)
         const auto e =
             AffinePoint::from_bytes(std::span<const uint8_t, 64>{&expected_output[0], 64});
 
-        ASSERT_TRUE(validate(p));
-        ASSERT_TRUE(validate(e));
+        ASSERT_TRUE(p.has_value());
+        ASSERT_TRUE(validate(*p));
+        ASSERT_TRUE(e.has_value());
+        ASSERT_TRUE(validate(*e));
 
-        const auto r = mul(p, k);
+        const auto r = mul(*p, k);
         EXPECT_EQ(r, e);
     }
 }


### PR DESCRIPTION
Add missing check for the prime field elements being out of range when loading from bytes an input point to any BN254 precompile.

This bug was hidden because the out-of-range values were accidentally reduced with "mod P". So to reveal the bug we needed a special input point such that (x mod P, y mod P) passed the curve equation.

The bug was introduced in the initial implementation of the BN254 precompiles:
https://github.com/ipsilon/evmone/pull/716