### PR TITLE
ci: Bump Xcode to 16.3.0 in macos-xcode-min

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -65,7 +65,7 @@ executors:
   macos-xcode-min:
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 16.2.0
+      xcode: 16.3.0
     environment:
       CMAKE_BUILD_PARALLEL_LEVEL: 6
 


### PR DESCRIPTION
The previous version 16.2.0 has been deprecated on Circle CI.