### PR TITLE
crypto: Rework prime/order specification for FieldElement

### DIFF
--- a/lib/evmone_precompiles/bn254.hpp
+++ b/lib/evmone_precompiles/bn254.hpp
@@ -18,27 +18,29 @@ struct Curve
     /// The field/scalar unsigned int type.
     using uint_type = uint256;
 
-    /// The field prime number (P).
-    static constexpr auto FIELD_PRIME =
-        0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
-
     /// The order of the curve (N).
     static constexpr auto ORDER =
         0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001_u256;
 
-    /// The modular arithmetic for the field.
-    static constexpr ModArith Fp{FIELD_PRIME};
+    struct FpSpec
+    {
+        /// The field prime number (P).
+        static constexpr auto ORDER =
+            0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_u256;
+    };
+    using Fp = ecc::FieldElement<FpSpec>;
+
+    static constexpr auto& FIELD_PRIME = Fp::ORDER;
 
     static constexpr auto A = 0;
-    static constexpr auto B = ecc::FieldElement<Curve>(3);
+    static constexpr auto B = Fp{3};
 
     /// Endomorphism parameters. See ecc::decompose().
     /// @{
     /// λ
     static constexpr auto LAMBDA = 0xb3c4d79d41a917585bfc41088d8daaa78b17ea66b99c90dd_u256;
     /// β
-    static constexpr ecc::FieldElement<Curve> BETA{
-        0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256};
+    static constexpr Fp BETA{0x59e26bcea0d48bacd4f263f1acdb5c4f5763473177fffffe_u256};
     /// x₁
     static constexpr auto X1 = 0x6f4d8248eeb859fd95b806bca6f338ee_u256;
     /// -y₁

--- a/lib/evmone_precompiles/pairing/bn254/fields.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/fields.hpp
@@ -15,7 +15,7 @@ using namespace intx;
 struct BaseFieldConfig
 {
     using ValueT = uint256;
-    static constexpr auto& MOD_ARITH = Curve::Fp;
+    static constexpr auto MOD_ARITH = ModArith{Curve::FIELD_PRIME};
     static constexpr auto ONE = MOD_ARITH.to_mont(1);
 };
 using Fq = ecc::BaseFieldElem<BaseFieldConfig>;

--- a/lib/evmone_precompiles/secp256k1.hpp
+++ b/lib/evmone_precompiles/secp256k1.hpp
@@ -16,15 +16,24 @@ struct Curve
 {
     using uint_type = uint256;
 
-    /// The field prime number (P).
-    static constexpr auto FIELD_PRIME =
-        0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f_u256;
+    struct FpSpec
+    {
+        /// The field prime number (P).
+        static constexpr auto ORDER =
+            0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f_u256;
+    };
+    using Fp = ecc::FieldElement<FpSpec>;
 
-    /// The secp256k1 curve group order (N).
-    static constexpr auto ORDER =
-        0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;
+    struct FrSpec
+    {
+        /// The secp256k1 curve group order (N).
+        static constexpr auto ORDER =
+            0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141_u256;
+    };
+    using Fr = ecc::FieldElement<FrSpec>;
 
-    static constexpr ModArith Fp{FIELD_PRIME};
+    static constexpr auto& FIELD_PRIME = Fp::ORDER;
+    static constexpr auto& ORDER = Fr::ORDER;
 
     static constexpr auto A = 0;
 };
@@ -37,11 +46,10 @@ using AffinePoint = ecc::AffinePoint<Curve>;
 /// where P is ::FieldPrime.
 ///
 /// @return Square root of x if it exists, std::nullopt otherwise.
-std::optional<ecc::FieldElement<Curve>> field_sqrt(const ecc::FieldElement<Curve>& x) noexcept;
+std::optional<Curve::Fp> field_sqrt(const Curve::Fp& x) noexcept;
 
 /// Calculate y coordinate of a point having x coordinate and y parity.
-std::optional<ecc::FieldElement<Curve>> calculate_y(
-    const ecc::FieldElement<Curve>& x, bool y_parity) noexcept;
+std::optional<Curve::Fp> calculate_y(const Curve::Fp& x, bool y_parity) noexcept;
 
 /// Convert the secp256k1 point (uncompressed public key) to Ethereum address.
 evmc::address to_address(const AffinePoint& pt) noexcept;

--- a/lib/evmone_precompiles/secp256r1.hpp
+++ b/lib/evmone_precompiles/secp256r1.hpp
@@ -14,17 +14,21 @@ struct Curve
 {
     using uint_type = uint256;
 
-    /// The field prime number (P).
-    static constexpr auto FIELD_PRIME =
-        0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff_u256;
-
     /// The secp256r1 curve group order (N).
     static constexpr auto ORDER =
         0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551_u256;
 
-    static constexpr ModArith Fp{FIELD_PRIME};
+    struct FpSpec
+    {
+        /// The field prime number (P).
+        static constexpr auto ORDER =
+            0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff_u256;
+    };
+    using Fp = ecc::FieldElement<FpSpec>;
 
-    static constexpr auto A = FIELD_PRIME - 3;
+    static constexpr auto& FIELD_PRIME = Fp::ORDER;
+
+    static constexpr auto A = Fp::ORDER - 3;
 
     static constexpr auto B =
         0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b_u256;

--- a/test/unittests/evmmax_secp256k1_test.cpp
+++ b/test/unittests/evmmax_secp256k1_test.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 #include <test/utils/utils.hpp>
 
-using namespace evmmax;
 using namespace evmmax::secp256k1;
 using namespace evmc::literals;
 using namespace evmone::test;
@@ -42,7 +41,7 @@ TEST(secp256k1, field_sqrt)
              Curve::FIELD_PRIME - 1,
          })
     {
-        const auto a = ecc::FieldElement<Curve>{t};
+        const auto a = Curve::Fp{t};
         const auto a2_sqrt = field_sqrt(a * a);
         ASSERT_TRUE(a2_sqrt.has_value()) << to_string(t);
         EXPECT_TRUE(a2_sqrt == a || a2_sqrt == -a) << to_string(t);
@@ -53,13 +52,13 @@ TEST(secp256k1, field_sqrt_invalid)
 {
     for (const auto& t : {3_u256, Curve::FIELD_PRIME - 1})
     {
-        EXPECT_FALSE(field_sqrt(ecc::FieldElement<Curve>{t}).has_value());
+        EXPECT_FALSE(field_sqrt(Curve::Fp{t}).has_value());
     }
 }
 
 TEST(secp256k1, scalar_inv)
 {
-    const ModArith n{Curve::ORDER};
+    const evmmax::ModArith n{Curve::ORDER};
 
     for (const auto& t : {
              1_u256,
@@ -104,7 +103,7 @@ TEST(secp256k1, calculate_y)
 
     for (const auto& t : test_cases)
     {
-        const auto x = ecc::FieldElement<Curve>{t.x};
+        const auto x = Curve::Fp{t.x};
 
         const auto y_even = calculate_y(x, false);
         ASSERT_TRUE(y_even.has_value());
@@ -123,7 +122,7 @@ TEST(secp256k1, calculate_y_invalid)
              Curve::FIELD_PRIME - 1,
          })
     {
-        const auto x = ecc::FieldElement<Curve>{t};
+        const auto x = Curve::Fp{t};
 
         const auto y_even = calculate_y(x, false);
         ASSERT_FALSE(y_even.has_value());


### PR DESCRIPTION
Decouple the `Curve::FIELD_PRIME` from the prime/order specification for the `FieldElement`. This allows at least multiple different FieldElements for the same curve.