### PR TITLE
Fix missing EIP-7702 y_parity validation

### DIFF
--- a/test/state/state.cpp
+++ b/test/state/state.cpp
@@ -105,6 +105,11 @@ int64_t process_authorization_list(
 
         // 3. Verify if the signer has been successfully recovered from the signature.
         //    authority = ecrecover(...)
+        // y_parity must be 0 or 1 for EIP-7702/2930 signatures.
+        if (auth.v > 1)
+            continue;
+        // TODO: We actually only do "partial" verification by assuming the signature is valid
+        //   when the test has the signer specified.
         if (!auth.signer.has_value())
             continue;
 
@@ -131,7 +136,7 @@ int64_t process_authorization_list(
 
         // 7. Add PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST gas to the global refund counter
         // if authority exists in the trie.
-        // Successful authorisation validation makes an account non-empty.
+        // Successful authorization validation makes an account non-empty.
         // We apply the refund only if the account has existed before.
         // We detect "exists in the trie" by inspecting _empty_ property (EIP-161) because _empty_
         // implies an account doesn't exist in the state (EIP-7523).

--- a/test/unittests/state_transition_eip7702_test.cpp
+++ b/test/unittests/state_transition_eip7702_test.cpp
@@ -59,6 +59,24 @@ TEST_F(state_transition, eip7702_set_code_transaction_authority_is_to)
     expect.post[To].code = bytes{0xef, 0x01, 0x00} + hex(delegate);
 }
 
+TEST_F(state_transition, eip7702_set_code_transaction_invalid_y_parity)
+{
+    rev = EVMC_PRAGUE;
+
+    constexpr auto authority = 0xca11ee_address;
+    constexpr auto delegate = 0xde1e_address;
+    pre[authority] = {.nonce = 1};
+    tx.to = To;
+    tx.type = Transaction::Type::set_code;
+    tx.authorization_list = {{.addr = delegate, .nonce = 1, .signer = authority, .v = 2}};
+    pre[To] = {.code = ret(0)};
+
+    expect.post[authority].nonce = 1;
+    expect.post[authority].code = bytes{};
+    expect.post[To].exists = true;
+    expect.post[delegate].exists = false;
+}
+
 TEST_F(state_transition, eip7702_extcodesize)
 {
     rev = EVMC_PRAGUE;


### PR DESCRIPTION
Fixes https://github.com/ipsilon/evmone/issues/1444.