### PR TITLE
crypto: Use exact size for x1 in modexp_even CRT

### DIFF
--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -13,25 +13,27 @@ using namespace intx;
 namespace
 {
 /// Adds y to x: x[] += y[]. The result is truncated to the size of x.
-/// The x and y must be of the same size.
 constexpr void add(std::span<uint64_t> x, std::span<const uint64_t> y) noexcept
 {
-    assert(x.size() == y.size());
+    assert(x.size() >= y.size());
 
     bool carry = false;
-    for (size_t i = 0; i < x.size(); ++i)
+    for (size_t i = 0; i < y.size(); ++i)
         std::tie(x[i], carry) = addc(x[i], y[i], carry);
+    for (size_t i = y.size(); carry && i < x.size(); ++i)
+        std::tie(x[i], carry) = addc(x[i], uint64_t{0}, carry);
 }
 
 /// Subtracts y from x: x[] -= y[]. The result is truncated to the size of x.
-/// The x and y must be of the same size.
 constexpr void sub(std::span<uint64_t> x, std::span<const uint64_t> y) noexcept
 {
-    assert(x.size() == y.size());
+    assert(x.size() >= y.size());
 
     bool borrow = false;
-    for (size_t i = 0; i < x.size(); ++i)
+    for (size_t i = 0; i < y.size(); ++i)
         std::tie(x[i], borrow) = subc(x[i], y[i], borrow);
+    for (size_t i = y.size(); borrow && i < x.size(); ++i)
+        std::tie(x[i], borrow) = subc(x[i], uint64_t{0}, borrow);
 }
 
 /// Multiplies each word of x by y and adds the matching word of p, propagating a carry to the next
@@ -517,22 +519,22 @@ void modexp_even(std::span<uint64_t> r, const std::span<const uint64_t> base, Ex
     assert(!base.empty() && base.back() != 0);        // base must be trimmed.
     assert(!mod_odd.empty() && mod_odd.back() != 0);  // mod_odd must be trimmed.
 
-    const size_t num_pow2_words = (k + 63) / 64;
-    assert(r.size() >= std::max(mod_odd.size(), num_pow2_words));
+    const auto odd_size = mod_odd.size();
+    const size_t pow2_size = (k + 63) / 64;
+    assert(r.size() >= std::max(odd_size, pow2_size));
 
-    const auto tmp_storage =
-        std::make_unique_for_overwrite<uint64_t[]>(r.size() + num_pow2_words * 2);
-    const auto x1 = std::span{tmp_storage.get(), r.size()};
-    const auto mod_odd_inv = std::span{tmp_storage.get() + r.size(), num_pow2_words};
-    const auto y = std::span{tmp_storage.get() + r.size() + num_pow2_words, num_pow2_words};
+    const auto tmp_storage = std::make_unique_for_overwrite<uint64_t[]>(odd_size + pow2_size * 2);
+    const auto x1 = std::span{tmp_storage.get(), odd_size};
+    const auto mod_odd_inv = std::span{tmp_storage.get() + odd_size, pow2_size};
+    const auto y = std::span{tmp_storage.get() + odd_size + pow2_size, pow2_size};
 
     modexp_odd(x1, base, exp, mod_odd);
 
-    const auto x2 = r.subspan(0, num_pow2_words);  // Reuse the result storage.
+    const auto x2 = r.first(pow2_size);  // Reuse the result storage.
     modexp_pow2(x2, base, exp, k);
 
     modinv_pow2(mod_odd_inv, mod_odd);
-    sub(x2, x1.subspan(0, num_pow2_words));
+    sub(x2, x1.first(std::min(odd_size, pow2_size)));
     mul(y, x2, mod_odd_inv);
     mask_pow2(y, k);
     mul(r, mod_odd, y);

--- a/test/unittests/precompiles_expmod_test.cpp
+++ b/test/unittests/precompiles_expmod_test.cpp
@@ -408,6 +408,14 @@ TEST(expmod, test_vectors)
         // 3^5 mod (5 * 2^128) = 243.
         {"03", "05", "000000000000000500000000000000000000000000000000",
             "0000000000000000000000000000000000000000000000f3"},
+        // Even modulus with 1-word odd part and multi-word pow2 factor.
+        // Exercises carry/borrow propagation in add/sub with shorter operand.
+        // 2^64 mod (3 * 2^128).
+        {"02", "40", "0300000000000000000000000000000000", "0000000000000000010000000000000000"},
+        // 2^128 mod (3 * 2^128): carry propagates through all high words in add.
+        {"02", "80", "0300000000000000000000000000000000", "0100000000000000000000000000000000"},
+        // 2^129 mod (7 * 2^128): carry propagates and is absorbed at nonzero word.
+        {"02", "0081", "0700000000000000000000000000000000", "0200000000000000000000000000000000"},
     };
 
     for (const auto& [base_hex, exp_hex, mod_hex, expected_result_hex] : test_cases)


### PR DESCRIPTION
Shrink the x1 (odd-part result) buffer from r.size() to mod_odd.size() words, reducing temporary storage. Relax add/sub to handle shorter y operand with carry/borrow propagation through remaining high words.