### PR TITLE
crypto: Document preconditions and edge cases in ECC/pairing code

### DIFF
--- a/include/evmmax/evmmax.hpp
+++ b/include/evmmax/evmmax.hpp
@@ -158,8 +158,8 @@ public:
         return (d.carry) ? s : d.value;
     }
 
-    /// Compute the modular inversion of the x in Montgomery form. The result is in Montgomery form.
-    /// If x is not invertible, the result is 0.
+    /// Computes modular inverse of x in Montgomery form. Result is in Montgomery form.
+    /// Returns 0 for non-invertible x (including x == 0).
     constexpr UintT inv(const UintT& x) const noexcept
     {
         assert((mod_ & 1) == 1);

--- a/lib/evmone_precompiles/bls.hpp
+++ b/lib/evmone_precompiles/bls.hpp
@@ -26,7 +26,7 @@ inline constexpr auto BLS_FIELD_MODULUS =
 /// Addition in BLS12-381 curve group over G2 extension field.
 ///
 /// Computes P ⊕ Q for two points in affine coordinates on the BLS12-381 curve over G2 extension
-/// field, performs subgroup checks for both points according to spec
+/// field. Checks that point coordinates are from the field and that points are on curve.
 /// https://eips.ethereum.org/EIPS/eip-2537#abi-for-g2-addition
 [[nodiscard]] bool g2_add(uint8_t _rx[128], uint8_t _ry[128], const uint8_t _x0[128],
     const uint8_t _y0[128], const uint8_t _x1[128], const uint8_t _y1[128]) noexcept;

--- a/lib/evmone_precompiles/ecc.hpp
+++ b/lib/evmone_precompiles/ecc.hpp
@@ -99,17 +99,20 @@ public:
         return wrap(Fp.sub(0, a.value_));
     }
 
+    /// Division returns 0 when the divisor is 0. See ModArith::inv().
     friend constexpr auto operator/(one_t, const FieldElement& a) noexcept
     {
         return wrap(Fp.inv(a.value_));
     }
 
+    /// Division returns 0 when the divisor is 0. See ModArith::inv().
     friend constexpr auto operator/(const FieldElement& a, const FieldElement& b) noexcept
     {
         return wrap(Fp.mul(a.value_, Fp.inv(b.value_)));
     }
 
     /// Named 1/x inversion method. Needed in the pairing templates.
+    /// Returns 0 when this element is 0. See ModArith::inv().
     constexpr auto inv() const noexcept { return wrap(Fp.inv(value_)); }
 
     /// Named one element. Needed in the pairing templates.
@@ -461,6 +464,9 @@ ProjPoint<Curve> dbl(const ProjPoint<Curve>& p) noexcept
     }
 }
 
+/// Computes scalar multiplication [c]P.
+/// Not constant-time: execution time depends on the scalar value.
+/// Safe for EVM precompiles (public calldata), not for secret key operations.
 template <typename Curve>
 ProjPoint<Curve> mul(const AffinePoint<Curve>& p, typename Curve::uint_type c) noexcept
 {
@@ -487,6 +493,7 @@ ProjPoint<Curve> mul(const AffinePoint<Curve>& p, typename Curve::uint_type c) n
 
 /// Computes multi-scalar multiplication of u×P ⊕ v×Q.
 ///
+/// Not constant-time. See mul() for details.
 /// The implementation uses the "Straus-Shamir trick": https://eprint.iacr.org/2003/257.pdf#page=7.
 template <typename Curve>
 ProjPoint<Curve> msm(const typename Curve::uint_type& u, const AffinePoint<Curve>& p,

--- a/lib/evmone_precompiles/pairing/bn254/utils.hpp
+++ b/lib/evmone_precompiles/pairing/bn254/utils.hpp
@@ -207,6 +207,7 @@ constexpr Fq12 endomorphism(const Fq12& f) noexcept
 
 
 /// Computes `P0 + P1` in Jacobian coordinates.
+/// P0 and P1 must not be the point at infinity, and must not be equal or negations of each other.
 constexpr ecc::JacPoint<Fq2> add(
     const ecc::JacPoint<Fq2>& P0, const ecc::JacPoint<Fq2>& P1) noexcept
 {


### PR DESCRIPTION
- ModArith::inv(): returns 0 for non-invertible input (including 0)
- FieldElement division/inv: returns 0 when divisor is 0
- mul(), msm(): not constant-time, safe for public EVM calldata only
- BN254 Jacobian add(): must not receive infinity, equal, or negated points
- BLS g2_add(): fix comment to match actual checks (field + on-curve, not subgroup)