### PR TITLE
test: Add push1_stack_overflow test

### DIFF
--- a/test/unittests/evm_test.cpp
+++ b/test/unittests/evm_test.cpp
@@ -91,6 +91,15 @@ TEST_P(evm, dup_stack_overflow)
     EXPECT_STATUS(EVMC_STACK_OVERFLOW);
 }
 
+TEST_P(evm, push1_stack_overflow)
+{
+    // PUSH1 has an immediate byte so it must not bypass the stack overflow check.
+    execute(1024 * push(1));
+    EXPECT_STATUS(EVMC_SUCCESS);
+    execute(1025 * push(1));
+    EXPECT_STATUS(EVMC_STACK_OVERFLOW);
+}
+
 TEST_P(evm, dup_stack_underflow)
 {
     for (int i = 0; i < 16; ++i)


### PR DESCRIPTION
Verify that 1024 PUSH1 instructions fill the stack successfully and 1025 PUSH1 instructions trigger EVMC_STACK_OVERFLOW. This is a regression test for a bug where instructions with immediates (like PUSH1) could bypass the stack overflow check.