### PR TITLE
Add missing inline keyword to always_inline functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,9 @@ if(CABLE_COMPILER_GNULIKE)
         $<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
         $<$<COMPILE_LANGUAGE:CXX>:-Wno-missing-field-initializers>
 
-        $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes>
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>>:-Wno-attributes=clang::>
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>>:-Wno-attributes=msvc::>
+        $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,12>>:-Wno-attributes>
         $<$<CXX_COMPILER_ID:GNU>:-Wduplicated-cond>
         $<$<CXX_COMPILER_ID:GNU>:-Wlogical-op>
 

--- a/lib/evmone_precompiles/blake2b.cpp
+++ b/lib/evmone_precompiles/blake2b.cpp
@@ -21,7 +21,8 @@ inline uint64_t rotr(uint64_t x, unsigned r) noexcept
 /// The G primitive function mixes two input words, "x" and "y", into
 /// four words indexed by "a", "b", "c", and "d" in the working vector v[0..15].
 [[gnu::always_inline, clang::no_sanitize("coverage"), clang::no_sanitize("undefined")]]
-void g(uint64_t v[16], size_t a, size_t b, size_t c, size_t d, uint64_t x, uint64_t y) noexcept
+inline void g(
+    uint64_t v[16], size_t a, size_t b, size_t c, size_t d, uint64_t x, uint64_t y) noexcept
 {
     v[a] = v[a] + v[b] + x;
     v[d] = rotr(v[d] ^ v[a], 32);

--- a/lib/evmone_precompiles/modexp.cpp
+++ b/lib/evmone_precompiles/modexp.cpp
@@ -361,8 +361,9 @@ void mul_amm(std::span<uint64_t, N> r, std::span<const uint64_t, N> x,
 /// Almost Montgomery Multiplication specialized for 4-word (256-bit) operands.
 /// Delegates to mul_amm_256 in mulmod.cpp.
 template <>
-[[gnu::always_inline]] void mul_amm<4>(std::span<uint64_t, 4> r, std::span<const uint64_t, 4> x,
-    std::span<const uint64_t, 4> y, std::span<const uint64_t, 4> mod, uint64_t mod_inv) noexcept
+[[gnu::always_inline]] inline void mul_amm<4>(std::span<uint64_t, 4> r,
+    std::span<const uint64_t, 4> x, std::span<const uint64_t, 4> y,
+    std::span<const uint64_t, 4> mod, uint64_t mod_inv) noexcept
 {
     mul_amm_256(r, x, y, mod, mod_inv);
 }

--- a/lib/evmone_precompiles/sha256.cpp
+++ b/lib/evmone_precompiles/sha256.cpp
@@ -135,7 +135,7 @@ static bool calc_chunk(uint8_t chunk[CHUNK_SIZE], struct BufferState* state)
     return true;
 }
 
-[[gnu::always_inline, msvc::forceinline]] static void sha_256_implementation(
+[[gnu::always_inline, msvc::forceinline]] static inline void sha_256_implementation(
     uint32_t h[8], const std::byte* input, size_t len)
 {
     /*
@@ -251,7 +251,7 @@ __attribute__((target("bmi,bmi2"))) static void sha_256_x86_bmi(
     sha_256_implementation(h, input, len);
 }
 
-[[gnu::always_inline]] static __m128i set(uint64_t a, uint64_t b) noexcept
+[[gnu::always_inline]] static inline __m128i set(uint64_t a, uint64_t b) noexcept
 {
     // NOLINTNEXTLINE(*-runtime-int)
     return _mm_set_epi64x(static_cast<long long>(a), static_cast<long long>(b));


### PR DESCRIPTION
GCC requires both [[gnu::always_inline]] and the inline keyword, otherwise it warns "function might not be inlinable". The functions were already being inlined.

This was silenced by the -Wno-attributes warning, now tuned to ignore only attributes with known vendor prefixes.